### PR TITLE
Fix: Landing page locale error

### DIFF
--- a/apps/web/src/pages/Landing/components/StatCard.tsx
+++ b/apps/web/src/pages/Landing/components/StatCard.tsx
@@ -165,7 +165,8 @@ function StringInterpolationWithMotion({ value, delay, inView, live }: Omit<Stat
   const locale = useCurrentLocale()
 
   // For Arabic locales, use simple Text component instead of animated sprites
-  const isArabic = locale.startsWith('ar')
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const isArabic = locale?.startsWith('ar') ?? false
   if (isArabic) {
     return (
       <Text variant="heading2" color={live ? theme.success : theme.neutral1} allowFontScaling={false}>


### PR DESCRIPTION
## 🐛 Problem
The landing page was crashing with a TypeError when trying to access `startsWith` on an undefined locale value.

## ✅ Solution
- Added optional chaining to safely handle undefined locale values
- Added fallback value for Arabic locale check
- Added ESLint disable comment for the necessary null check

## 🧪 Testing
- Landing page now loads without errors
- Arabic locale detection still works when locale is defined
- No TypeScript or linting errors

Fixes the error: `TypeError: Cannot read properties of undefined (reading 'startsWith')`