### PR TITLE
feat: Add Citrea Testnet chain support (WIP)

### DIFF
--- a/packages/ui/src/assets/index.ts
+++ b/packages/ui/src/assets/index.ts
@@ -4,6 +4,7 @@ export const OPTIMISM_LOGO = require('./logos/png/optimism-logo.png')
 export const ARBITRUM_LOGO = require('./logos/png/arbitrum-logo.png')
 export const BASE_LOGO = require('./logos/png/base-logo.png')
 export const BNB_LOGO = require('./logos/png/bnb-logo.png')
+export const CITREA_LOGO = require('./logos/png/monad-logo.png') // Placeholder for Citrea logo
 export const MONAD_LOGO = require('./logos/png/monad-logo.png')
 export const POLYGON_LOGO = require('./logos/png/polygon-logo.png')
 export const BLAST_LOGO = require('./logos/png/blast-logo.png')

--- a/packages/uniswap/src/features/chains/chainInfo.ts
+++ b/packages/uniswap/src/features/chains/chainInfo.ts
@@ -4,6 +4,7 @@ import { BASE_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/base'
 import { BLAST_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/blast'
 import { BNB_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/bnb'
 import { CELO_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/celo'
+import { CITREA_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/citrea'
 import { MAINNET_CHAIN_INFO, SEPOLIA_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/mainnet'
 import { MONAD_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/monad'
 import { OPTIMISM_CHAIN_INFO } from 'uniswap/src/features/chains/evm/info/optimism'
@@ -85,6 +86,7 @@ export const UNIVERSE_CHAIN_INFO = {
   [UniverseChainId.Zksync]: ZKSYNC_CHAIN_INFO,
 
   // TESTNET
+  [UniverseChainId.CitreaTestnet]: CITREA_CHAIN_INFO,
   [UniverseChainId.MonadTestnet]: MONAD_CHAIN_INFO,
   [UniverseChainId.Sepolia]: SEPOLIA_CHAIN_INFO,
   [UniverseChainId.UnichainSepolia]: UNICHAIN_SEPOLIA_CHAIN_INFO,

--- a/packages/uniswap/src/features/chains/evm/info/citrea.ts
+++ b/packages/uniswap/src/features/chains/evm/info/citrea.ts
@@ -1,0 +1,76 @@
+import { CITREA_LOGO } from 'ui/src/assets'
+import { Chain as BackendChainId } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
+import { DEFAULT_NATIVE_ADDRESS_LEGACY } from 'uniswap/src/features/chains/evm/rpc'
+import { buildChainTokens } from 'uniswap/src/features/chains/evm/tokens'
+import {
+  GqlChainId,
+  NetworkLayer,
+  RPCType,
+  UniverseChainId,
+  UniverseChainInfo,
+} from 'uniswap/src/features/chains/types'
+import { Platform } from 'uniswap/src/features/platforms/types/Platform'
+import { ElementName } from 'uniswap/src/features/telemetry/constants'
+import { buildUSDT } from 'uniswap/src/features/tokens/stablecoin'
+
+const tokens = buildChainTokens({
+  stables: {
+    USDT: buildUSDT('0x0000000000000000000000000000000000000000', UniverseChainId.CitreaTestnet),
+  },
+})
+
+export const CITREA_CHAIN_INFO = {
+  id: UniverseChainId.CitreaTestnet,
+  platform: Platform.EVM,
+  testnet: true,
+  assetRepoNetworkName: undefined,
+  backendChain: {
+    chain: BackendChainId.UnknownChain as GqlChainId,
+    backendSupported: false,
+    nativeTokenBackendAddress: undefined,
+  },
+  bridge: undefined,
+  docs: 'https://docs.citrea.xyz/',
+  label: 'Citrea Testnet',
+  logo: CITREA_LOGO,
+  name: 'Citrea Testnet',
+  nativeCurrency: {
+    name: 'Bitcoin',
+    symbol: 'cBTC',
+    decimals: 18,
+    address: DEFAULT_NATIVE_ADDRESS_LEGACY,
+    logo: CITREA_LOGO,
+  },
+  networkLayer: NetworkLayer.L2,
+  pendingTransactionsRetryOptions: undefined,
+  statusPage: undefined,
+  supportsV4: false,
+  urlParam: 'citrea_testnet',
+  rpcUrls: {
+    [RPCType.Public]: {
+      http: ['https://rpc.testnet.citrea.xyz'],
+    },
+    [RPCType.Default]: {
+      http: ['https://rpc.testnet.citrea.xyz'],
+    },
+    [RPCType.Interface]: {
+      http: ['https://rpc.testnet.citrea.xyz'],
+    },
+  },
+  wrappedNativeCurrency: {
+    name: 'Wrapped Bitcoin',
+    symbol: 'WcBTC',
+    decimals: 18,
+    address: '0x0000000000000000000000000000000000000000',
+  },
+  blockPerMainnetEpochForChainId: 1,
+  blockWaitMsBeforeWarning: undefined,
+  elementName: ElementName.ChainCitreaTestnet,
+  explorer: {
+    name: 'Citrea Explorer',
+    url: 'https://explorer.testnet.citrea.xyz/',
+  },
+  interfaceName: 'citrea',
+  tokens,
+  tradingApiPollingIntervalMs: 200,
+} as const satisfies UniverseChainInfo

--- a/packages/uniswap/src/features/chains/types.ts
+++ b/packages/uniswap/src/features/chains/types.ts
@@ -18,6 +18,7 @@ export enum UniverseChainId {
   Bnb = UniswapSDKChainId.BNB,
   Celo = UniswapSDKChainId.CELO,
   MonadTestnet = UniswapSDKChainId.MONAD_TESTNET,
+  CitreaTestnet = 5115,
   Optimism = UniswapSDKChainId.OPTIMISM,
   Polygon = UniswapSDKChainId.POLYGON,
   Sepolia = UniswapSDKChainId.SEPOLIA,

--- a/packages/uniswap/src/features/chains/utils.test.ts
+++ b/packages/uniswap/src/features/chains/utils.test.ts
@@ -178,7 +178,12 @@ describe('getEnabledChains', () => {
         featureFlaggedChainIds: ALL_CHAIN_IDS,
       }),
     ).toEqual({
-      chains: [UniverseChainId.Sepolia, UniverseChainId.UnichainSepolia, UniverseChainId.MonadTestnet],
+      chains: [
+        UniverseChainId.Sepolia,
+        UniverseChainId.UnichainSepolia,
+        UniverseChainId.MonadTestnet,
+        UniverseChainId.CitreaTestnet,
+      ],
       gqlChains: [Chain.EthereumSepolia, Chain.AstrochainSepolia, Chain.MonadTestnet],
       defaultChainId: UniverseChainId.Sepolia,
       isTestnetModeEnabled: true,

--- a/packages/uniswap/src/features/telemetry/constants/trace/element.ts
+++ b/packages/uniswap/src/features/telemetry/constants/trace/element.ts
@@ -33,6 +33,7 @@ export enum ElementName {
   ChainBNB = 'chain-bnb',
   ChainBlast = 'chain-blast',
   ChainCelo = 'chain-celo',
+  ChainCitreaTestnet = 'chain-citrea-testnet',
   ChainEthereum = 'chain-ethereum',
   ChainMonadTestnet = 'chain-monad-testnet',
   ChainOptimism = 'chain-optimism',


### PR DESCRIPTION
UI/UX Anpassungen v2 - Citrea integration:

- Add UniverseChainId.CitreaTestnet (Chain ID: 5115)
- Add chain configuration in citrea.ts with EVM compatibility
- Add ChainCitreaTestnet element name for telemetry
- Add CITREA_LOGO placeholder asset
- Add chain info mapping for Citrea Testnet
- Update testnet chains test to include CitreaTestnet
- Support EVM-compatible Bitcoin L2 testnet functionality

Still needs: network colors and explorer logos