### PR TITLE
Fix data validation for landing page stats

### DIFF
--- a/apps/web/src/pages/Landing/components/StatCard.tsx
+++ b/apps/web/src/pages/Landing/components/StatCard.tsx
@@ -159,7 +159,7 @@ export function StatCard(props: StatCardProps) {
   )
 }
 
-function StringInterpolationWithMotion({ value, delay, inView, live }: Omit<StatCardProps, 'title'>) {
+function StringInterpolationWithMotion({ value = '', delay, inView, live }: Omit<StatCardProps, 'title'>) {
   const chars = value.split('')
   const theme = useTheme()
   const locale = useCurrentLocale()

--- a/apps/web/src/pages/Landing/sections/Stats.tsx
+++ b/apps/web/src/pages/Landing/sections/Stats.tsx
@@ -168,11 +168,15 @@ const RightBottom = styled(Flex, {
 function Cards({ inView }: { inView: boolean }) {
   const { t } = useTranslation()
   const { convertFiatAmountFormatted, formatNumberOrString } = useLocalizationContext()
-  const { totalVolume } = use24hProtocolVolume()
-  const { totalTVL } = useDailyTVLWithChange()
+  const { totalVolume, isLoading: volumeLoading } = use24hProtocolVolume()
+  const { totalTVL, isLoading: tvlLoading } = useDailyTVLWithChange()
   // Currently hardcoded, BE task [DAT-1435] to make this data available
   const allTimeVolume = 3.3 * 10 ** 12
   const allTimeSwappers = 119 * 10 ** 6
+
+  // Validate data before passing to StatCard
+  const validTotalVolume = !volumeLoading && totalVolume && !isNaN(totalVolume) ? totalVolume : undefined
+  const validTotalTVL = !tvlLoading && totalTVL && !isNaN(totalTVL) ? totalTVL : undefined
 
   return (
     <GridArea>
@@ -187,7 +191,7 @@ function Cards({ inView }: { inView: boolean }) {
       <RightTop>
         <StatCard
           title={t('stats.tvl')}
-          value={convertFiatAmountFormatted(totalTVL, NumberType.FiatTokenStats)}
+          value={convertFiatAmountFormatted(validTotalTVL, NumberType.FiatTokenStats)}
           delay={0.2}
           inView={inView}
         />
@@ -206,7 +210,7 @@ function Cards({ inView }: { inView: boolean }) {
       <RightBottom>
         <StatCard
           title={t('stats.24swapVolume')}
-          value={convertFiatAmountFormatted(totalVolume, NumberType.FiatTokenStats)}
+          value={convertFiatAmountFormatted(validTotalVolume, NumberType.FiatTokenStats)}
           live
           delay={0.6}
           inView={inView}


### PR DESCRIPTION
## Summary
- Added data validation for protocol volume and TVL data in Stats component
- Prevents NaN and undefined errors during initial loading states

## Changes
- Validate `totalVolume` and `totalTVL` from API hooks before passing to StatCard
- Check for loading state, existence, and NaN values
- Pass `undefined` for invalid data, which displays `-` placeholder

## Test plan
- [x] Verified landing page loads without errors
- [x] Stats display `-` during loading, then show actual values
- [x] No console errors on initial page load
- [x] Linting and type checking pass