### PR TITLE
Fix undefined locale runtime error

### DIFF
--- a/apps/web/src/pages/Landing/components/StatCard.tsx
+++ b/apps/web/src/pages/Landing/components/StatCard.tsx
@@ -165,7 +165,7 @@ function StringInterpolationWithMotion({ value, delay, inView, live }: Omit<Stat
   const locale = useCurrentLocale()
 
   // For Arabic locales, use simple Text component instead of animated sprites
-  const isArabic = locale.startsWith('ar')
+  const isArabic = locale?.startsWith('ar') ?? false
   if (isArabic) {
     return (
       <Text variant="heading2" color={live ? theme.success : theme.neutral1} allowFontScaling={false}>

--- a/packages/uniswap/src/features/language/utils.ts
+++ b/packages/uniswap/src/features/language/utils.ts
@@ -4,5 +4,8 @@ import { navigatorLocale } from 'uniswap/src/features/language/hooks'
 // Determines the current language based on the user's locale settings, falling back to English if no mapping exists.
 export function getCurrentLanguageFromNavigator(): Language {
   const locale = navigatorLocale()
-  return locale ? mapLocaleToLanguage[locale] : Language.English
+  if (!locale || !(locale in mapLocaleToLanguage)) {
+    return Language.English
+  }
+  return mapLocaleToLanguage[locale]
 }


### PR DESCRIPTION
## Summary
- Fixed runtime error when browser locale is not mapped to a supported language
- Added defensive checks to prevent TypeError when accessing undefined locale properties

## Problem
The application was throwing a `TypeError: Cannot read properties of undefined (reading 'startsWith')` error when the browser's locale was not in the list of supported languages (e.g., de-CH for Swiss German).

## Solution
- Modified `getCurrentLanguageFromNavigator()` to check if the locale exists in the mapping before accessing it
- Added optional chaining in `StatCard.tsx` as an additional safety measure
- Falls back to English when locale is not supported

## Test plan
- [x] Clear localStorage to reset persisted state
- [x] Test with unsupported browser locale (e.g., German)
- [x] Verify the app loads without errors
- [x] Confirm fallback to English language works correctly