### PR TITLE
Update social media icon hover colors to Citrea yellow

### DIFF
--- a/apps/web/src/pages/Landing/sections/Footer.tsx
+++ b/apps/web/src/pages/Landing/sections/Footer.tsx
@@ -27,17 +27,17 @@ const PolicyLink = styled(Text, {
 export function Socials({ iconSize }: { iconSize?: string }) {
   return (
     <Flex row gap="$spacing24" maxHeight={iconSize} alignItems="flex-start">
-      <SocialIcon iconColor="#00C32B">
+      <SocialIcon iconColor="#F7911A">
         <Anchor href={uniswapUrls.social.github} target="_blank">
           <Github size={iconSize} fill="inherit" />
         </Anchor>
       </SocialIcon>
-      <SocialIcon iconColor="#20BAFF">
+      <SocialIcon iconColor="#F7911A">
         <Anchor href={uniswapUrls.social.x} target="_blank">
           <Twitter size={iconSize} fill="inherit" />
         </Anchor>
       </SocialIcon>
-      <SocialIcon iconColor="#2AABEE">
+      <SocialIcon iconColor="#F7911A">
         <Anchor href={uniswapUrls.social.telegram} target="_blank">
           <Telegram size={iconSize} fill="inherit" />
         </Anchor>


### PR DESCRIPTION
## Summary
Updates the social media icon hover colors in the footer to use unified Citrea yellow color.

## Changes
- Changed GitHub icon hover color from green (#00C32B) to Citrea yellow (#F7911A)
- Changed X/Twitter icon hover color from light blue (#20BAFF) to Citrea yellow (#F7911A)  
- Changed Telegram icon hover color from blue (#2AABEE) to Citrea yellow (#F7911A)
- Aligns with button styling and brand accent color

## Test plan
- [ ] Hover over social media icons in footer
- [ ] Verify all three icons show Citrea yellow color on hover
- [ ] Verify hover animation still works correctly