### PR TITLE
Add Brand Assets link to footer

### DIFF
--- a/apps/web/src/components/swap/SwapLineItem.tsx
+++ b/apps/web/src/components/swap/SwapLineItem.tsx
@@ -48,11 +48,7 @@ export function FOTTooltipContent() {
 
 function SwapFeeTooltipContent({ hasFee }: { hasFee: boolean }) {
   const message = hasFee ? <Trans i18nKey="swap.fees.experience" /> : <Trans i18nKey="swap.fees.noFee" />
-  return (
-    <BaseTooltipContent url={`${uniswapUrls.helpUrl}/articles/20131678274957`}>
-      {message}
-    </BaseTooltipContent>
-  )
+  return <BaseTooltipContent url={`${uniswapUrls.helpUrl}/articles/20131678274957`}>{message}</BaseTooltipContent>
 }
 
 export function SlippageTooltipContent() {

--- a/apps/web/src/pages/Landing/components/StatCard.tsx
+++ b/apps/web/src/pages/Landing/components/StatCard.tsx
@@ -165,6 +165,7 @@ function StringInterpolationWithMotion({ value, delay, inView, live }: Omit<Stat
   const locale = useCurrentLocale()
 
   // For Arabic locales, use simple Text component instead of animated sprites
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const isArabic = locale?.startsWith('ar') ?? false
   if (isArabic) {
     return (

--- a/apps/web/src/pages/Landing/sections/Footer.tsx
+++ b/apps/web/src/pages/Landing/sections/Footer.tsx
@@ -116,9 +116,9 @@ export function Footer() {
         <Text variant="body3">© {currentYear} - JuiceSwap Labs</Text>
         <Flex row alignItems="center" gap="$spacing16">
           <PolicyLink onPress={togglePrivacyPolicy}>{t('common.privacyPolicy')}</PolicyLink>
-          {/* <Anchor textDecorationLine="none" href="https://uniswap.org/trademark" target="_blank">
-            <PolicyLink>{t('common.trademarkPolicy')}</PolicyLink>
-          </Anchor> */}
+          <Anchor textDecorationLine="none" href="https://github.com/JuiceSwapxyz/documentation/tree/main/media_kit" target="_blank">
+            <PolicyLink>{t('common.brandAssets')}</PolicyLink>
+          </Anchor>
         </Flex>
       </Flex>
     </Flex>

--- a/apps/web/src/pages/Landing/sections/Footer.tsx
+++ b/apps/web/src/pages/Landing/sections/Footer.tsx
@@ -116,7 +116,11 @@ export function Footer() {
         <Text variant="body3">© {currentYear} - JuiceSwap Labs</Text>
         <Flex row alignItems="center" gap="$spacing16">
           <PolicyLink onPress={togglePrivacyPolicy}>{t('common.privacyPolicy')}</PolicyLink>
-          <Anchor textDecorationLine="none" href="https://github.com/JuiceSwapxyz/documentation/tree/main/media_kit" target="_blank">
+          <Anchor
+            textDecorationLine="none"
+            href="https://github.com/JuiceSwapxyz/documentation/tree/main/media_kit"
+            target="_blank"
+          >
             <PolicyLink>{t('common.brandAssets')}</PolicyLink>
           </Anchor>
         </Flex>

--- a/apps/web/src/pages/NavBar.e2e.test.ts
+++ b/apps/web/src/pages/NavBar.e2e.test.ts
@@ -151,9 +151,7 @@ test.describe('Navigation', () => {
     await expect(page.getByTestId(TestID.HelpModal).getByText('Docs')).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).getByText('Contact us')).toBeVisible()
 
-    await expect(
-      page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`),
-    ).toBeVisible()
+    await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`)).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.docsUrl}"]`)).toBeVisible()
     await expect(
       page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}/requests/new"]`),
@@ -224,9 +222,7 @@ test.describe('Mobile navigation', () => {
     await expect(page.getByTestId(TestID.HelpModal).getByText('Docs')).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).getByText('Contact us')).toBeVisible()
 
-    await expect(
-      page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`),
-    ).toBeVisible()
+    await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`)).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.docsUrl}"]`)).toBeVisible()
     await expect(
       page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}/requests/new"]`),


### PR DESCRIPTION
## Summary
Adds a Brand Assets link to the footer next to the Privacy Policy link.

## Changes
- Added Brand Assets link in footer that points to JuiceSwap's media kit on GitHub
- Link URL: https://github.com/JuiceSwapxyz/documentation/tree/main/media_kit
- Uses existing translation key `common.brandAssets` for the link text
- Maintains consistent styling with Privacy Policy link

## Test plan
- [ ] Verify Brand Assets link appears next to Privacy Policy in footer
- [ ] Verify link opens correct GitHub page in new tab
- [ ] Verify link styling matches Privacy Policy link
- [ ] Test on mobile responsive view