### PR TITLE
Remove footer navigation sections

### DIFF
--- a/apps/web/src/components/swap/SwapLineItem.tsx
+++ b/apps/web/src/components/swap/SwapLineItem.tsx
@@ -48,11 +48,7 @@ export function FOTTooltipContent() {
 
 function SwapFeeTooltipContent({ hasFee }: { hasFee: boolean }) {
   const message = hasFee ? <Trans i18nKey="swap.fees.experience" /> : <Trans i18nKey="swap.fees.noFee" />
-  return (
-    <BaseTooltipContent url={`${uniswapUrls.helpUrl}/articles/20131678274957`}>
-      {message}
-    </BaseTooltipContent>
-  )
+  return <BaseTooltipContent url={`${uniswapUrls.helpUrl}/articles/20131678274957`}>{message}</BaseTooltipContent>
 }
 
 export function SlippageTooltipContent() {

--- a/apps/web/src/pages/Landing/components/StatCard.tsx
+++ b/apps/web/src/pages/Landing/components/StatCard.tsx
@@ -165,6 +165,7 @@ function StringInterpolationWithMotion({ value, delay, inView, live }: Omit<Stat
   const locale = useCurrentLocale()
 
   // For Arabic locales, use simple Text component instead of animated sprites
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const isArabic = locale?.startsWith('ar') ?? false
   if (isArabic) {
     return (

--- a/apps/web/src/pages/Landing/sections/Footer.tsx
+++ b/apps/web/src/pages/Landing/sections/Footer.tsx
@@ -1,5 +1,3 @@
-import { MenuItem, MenuSectionTitle, useMenuContent } from 'components/NavBar/CompanyMenu/Content'
-import { MenuLink } from 'components/NavBar/CompanyMenu/MenuDropdown'
 import { Wiggle } from 'components/animations/Wiggle'
 import { useModalState } from 'hooks/useModalState'
 import { Github, Telegram, Twitter } from 'pages/Landing/components/Icons'
@@ -46,63 +44,18 @@ export function Socials({ iconSize }: { iconSize?: string }) {
   )
 }
 
-function FooterSection({ title, items }: { title: string; items: MenuItem[] }) {
-  return (
-    <Flex width={130} $md={{ width: '100%' }} flexGrow={0} flexShrink={1} flexBasis="auto" gap={8}>
-      <Text variant="subheading2">{title}</Text>
-      <Flex gap={5}>
-        {items.map((item, index) => (
-          <MenuLink
-            key={`footer_${title}_${index}}`}
-            label={item.label}
-            href={item.href}
-            internal={item.internal}
-            overflow={item.overflow}
-            textVariant="subheading2"
-          />
-        ))}
-      </Flex>
-    </Flex>
-  )
-}
-
 export function Footer() {
   const { t } = useTranslation()
   const { toggleModal: togglePrivacyPolicy } = useModalState(ModalName.PrivacyPolicy)
-  const sectionContent = useMenuContent()
-  const productsSection = sectionContent[MenuSectionTitle.Products]
-  const protocolSection = sectionContent[MenuSectionTitle.Protocol]
-  const companySection = sectionContent[MenuSectionTitle.Company]
-  const needHelpSection = sectionContent[MenuSectionTitle.NeedHelp]
-  const brandAssets = {
-    label: t('common.brandAssets'),
-    href: 'https://github.com/JuiceSwapxyz/documentation/tree/main/media_kit',
-    internal: false,
-  }
   const currentYear = new Date().getFullYear()
 
   return (
     <Flex maxWidth="100vw" width="100%" gap="$spacing24" pt="$none" px="$spacing48" pb={40} $lg={{ px: '$spacing40' }}>
       <Flex row $md={{ flexDirection: 'column' }} justifyContent="space-between" gap="$spacing32">
         <Flex height="100%" gap="$spacing60">
-          <Flex $md={{ display: 'none' }}>
+          <Flex>
             <Socials iconSize={SOCIAL_ICONS_SIZE} />
           </Flex>
-        </Flex>
-        <Flex row $md={{ flexDirection: 'column' }} height="100%" gap="$spacing16">
-          <Flex row gap="$spacing16" justifyContent="space-between" $md={{ width: 'auto' }}>
-            {productsSection && <FooterSection title={productsSection.title} items={productsSection.items} />}
-            {protocolSection && <FooterSection title={protocolSection.title} items={protocolSection.items} />}
-          </Flex>
-          <Flex row gap="$spacing16" $md={{ width: 'auto' }}>
-            {companySection && (
-              <FooterSection title={companySection.title} items={[...companySection.items, brandAssets]} />
-            )}
-            {needHelpSection && <FooterSection title={needHelpSection.title} items={needHelpSection.items} />}
-          </Flex>
-        </Flex>
-        <Flex $md={{ display: 'flex' }} display="none">
-          <Socials iconSize={SOCIAL_ICONS_SIZE} />
         </Flex>
       </Flex>
       <Separator />

--- a/apps/web/src/pages/NavBar.e2e.test.ts
+++ b/apps/web/src/pages/NavBar.e2e.test.ts
@@ -151,9 +151,7 @@ test.describe('Navigation', () => {
     await expect(page.getByTestId(TestID.HelpModal).getByText('Docs')).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).getByText('Contact us')).toBeVisible()
 
-    await expect(
-      page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`),
-    ).toBeVisible()
+    await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`)).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.docsUrl}"]`)).toBeVisible()
     await expect(
       page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}/requests/new"]`),
@@ -224,9 +222,7 @@ test.describe('Mobile navigation', () => {
     await expect(page.getByTestId(TestID.HelpModal).getByText('Docs')).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).getByText('Contact us')).toBeVisible()
 
-    await expect(
-      page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`),
-    ).toBeVisible()
+    await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}"]`)).toBeVisible()
     await expect(page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.docsUrl}"]`)).toBeVisible()
     await expect(
       page.getByTestId(TestID.HelpModal).locator(`a[href="${uniswapUrls.helpUrl}/requests/new"]`),


### PR DESCRIPTION
## Summary
Removes all footer navigation sections to simplify the footer design.

## Changes
- Removed Products section (Wallet, API links)
- Removed Protocol section (Vote, Governance, Developers links)
- Removed Company section (About, Careers, Brand assets links)
- Removed Need Help section
- Kept social media icons, copyright notice, and privacy policy link
- Simplified footer layout structure

## Visual Changes
- Footer now only shows:
  - Social media icons (GitHub, X, Telegram) on the left
  - Copyright notice and Privacy Policy at the bottom

## Test plan
- [ ] Verify footer displays correctly without navigation sections
- [ ] Verify social media icons remain functional
- [ ] Verify Privacy Policy link still works
- [ ] Test responsive layout on mobile