### PR TITLE
[BUGFIX]: Fix settings menu crash

### DIFF
--- a/apps/web/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/apps/web/src/components/AccountDrawer/SettingsMenu.tsx
@@ -86,7 +86,7 @@ export default function SettingsMenu({
           />
           <SettingsButton
             title={t('common.language')}
-            currentState={languageInfo.displayName}
+            currentState={languageInfo?.displayName}
             onClick={openLanguageSettings}
             testId={TestID.LanguageSettingsButton}
           />


### PR DESCRIPTION
## Summary
Fixes critical crash when opening the settings menu.

## Problem
- Settings menu crashed with: `TypeError: Cannot read properties of undefined (reading 'displayName')`
- `languageInfo` was undefined when accessing `displayName` property

## Solution
- Added optional chaining (`?`) to safely access `languageInfo?.displayName`
- Menu now handles undefined language info gracefully

## Test plan
- [ ] Open settings menu by clicking gear icon
- [ ] Verify menu opens without crashing
- [ ] Check that language option still displays correctly when language info is available