### PR TITLE
Fix missing social media preview images

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -14,6 +14,27 @@
     <meta name="theme-color" content="#fff" />
     <meta name="format-detection" content="telephone=no">
 
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://bapp.juiceswap.xyz/">
+    <meta property="og:title" content="JuiceSwap Interface">
+    <meta property="og:description" content="Swap crypto on Ethereum, Base, Arbitrum, Polygon, Unichain and more. The DeFi platform trusted by millions.">
+    <meta property="og:image" content="https://bapp.juiceswap.xyz/images/1200x630_JuiceSwap_Preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="JuiceSwap Interface">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://bapp.juiceswap.xyz/">
+    <meta property="twitter:title" content="JuiceSwap Interface">
+    <meta property="twitter:description" content="Swap crypto on Ethereum, Base, Arbitrum, Polygon, Unichain and more. The DeFi platform trusted by millions.">
+    <meta property="twitter:image" content="https://bapp.juiceswap.xyz/images/1200x630_JuiceSwap_Preview.png">
+    <meta property="twitter:image:alt" content="JuiceSwap Interface">
+
+    <!-- Standard Meta -->
+    <meta name="description" content="Swap crypto on Ethereum, Base, Arbitrum, Polygon, Unichain and more. The DeFi platform trusted by millions.">
+
     <!-- CSP will be injected here -->
 
     <link rel="preconnect" href="https://interface.gateway.uniswap.org/" crossorigin/>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -25,12 +25,12 @@
     <meta property="og:image:alt" content="JuiceSwap Interface">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://bapp.juiceswap.xyz/">
-    <meta property="twitter:title" content="JuiceSwap Interface">
-    <meta property="twitter:description" content="Swap crypto on Ethereum, Base, Arbitrum, Polygon, Unichain and more. The DeFi platform trusted by millions.">
-    <meta property="twitter:image" content="https://bapp.juiceswap.xyz/images/1200x630_JuiceSwap_Preview.png">
-    <meta property="twitter:image:alt" content="JuiceSwap Interface">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" content="https://bapp.juiceswap.xyz/">
+    <meta name="twitter:title" content="JuiceSwap Interface">
+    <meta name="twitter:description" content="Swap crypto on Ethereum, Base, Arbitrum, Polygon, Unichain and more. The DeFi platform trusted by millions.">
+    <meta name="twitter:image" content="https://bapp.juiceswap.xyz/images/1200x630_JuiceSwap_Preview.png">
+    <meta name="twitter:image:alt" content="JuiceSwap Interface">
 
     <!-- Standard Meta -->
     <meta name="description" content="Swap crypto on Ethereum, Base, Arbitrum, Polygon, Unichain and more. The DeFi platform trusted by millions.">


### PR DESCRIPTION
## Summary
- Added Open Graph and Twitter Card meta tags directly to index.html
- Fixes missing preview thumbnails when sharing links on social media
- Uses JuiceSwap branded preview image

## Problem
The website was missing social media preview images (Open Graph tags) when sharing links on platforms like Twitter, Facebook, LinkedIn, etc. The Cloudflare Functions that were supposed to inject these tags were not working properly in production.

## Solution
Added the meta tags directly to the index.html file including:
- Open Graph tags (og:image, og:title, og:description)
- Twitter Card tags
- Standard meta description
- Points to the JuiceSwap preview image at `/images/1200x630_JuiceSwap_Preview.png`

## Test Plan
- [ ] Deploy to staging/preview environment
- [ ] Test sharing the URL on Twitter/Facebook/LinkedIn
- [ ] Verify the JuiceSwap preview image appears correctly
- [ ] Check that title and description are displayed properly