### PR TITLE
feat: Add testnet mode toggle to settings

### DIFF
--- a/apps/web/src/components/AccountDrawer/SettingsMenu.tsx
+++ b/apps/web/src/components/AccountDrawer/SettingsMenu.tsx
@@ -1,6 +1,7 @@
 import { AnalyticsToggle } from 'components/AccountDrawer/AnalyticsToggle'
 import { AppVersionRow } from 'components/AccountDrawer/AppVersionRow'
 import { SlideOutMenu } from 'components/AccountDrawer/SlideOutMenu'
+import { TestnetModeToggle } from 'components/AccountDrawer/TestnetModeToggle'
 import Column from 'components/deprecated/Column'
 import Row from 'components/deprecated/Row'
 import { useAccount } from 'hooks/useAccount'
@@ -98,6 +99,7 @@ export default function SettingsMenu({
           />
           {connectedWithEmbeddedWallet && <SettingsButton title={t('common.passkeys')} onClick={openPasskeySettings} />}
         </Flex>
+        <TestnetModeToggle />
         <AnalyticsToggle />
       </Container>
     </SlideOutMenu>

--- a/apps/web/src/components/AccountDrawer/TestnetModeToggle.tsx
+++ b/apps/web/src/components/AccountDrawer/TestnetModeToggle.tsx
@@ -1,0 +1,16 @@
+import { SettingsToggle } from 'components/AccountDrawer/SettingsToggle'
+import { useCallback } from 'react'
+
+export function TestnetModeToggle() {
+  const handleToggle = useCallback(() => {
+    // Toggle does nothing - always stays on
+  }, [])
+
+  return (
+    <SettingsToggle
+      title="Testnet mode"
+      isActive={true}
+      toggle={handleToggle}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- Added a visual testnet mode toggle to the settings menu
- Toggle displays as always-on and has no functional impact
- Positioned between portfolio balance and analytics settings

## Implementation
- Created new `TestnetModeToggle` component
- Integrated into existing `SettingsMenu` component
- Toggle state is fixed to always show as enabled

## Test plan
- [x] Visual inspection of the toggle in settings menu
- [x] Verify toggle appears between portfolio balance and analytics
- [x] Confirm toggle remains always on when clicked