### PR TITLE
feat: Add minimal build check CI

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,27 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  build:
+    name: Can Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.1'
+          cache: 'yarn'
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn web build:production
+        env:
+          NODE_ENV: production


### PR DESCRIPTION
## Summary
Adds a minimal CI check that ONLY verifies the code builds successfully. 

## Why this approach?
- PR #83 tried to add comprehensive CI but it failed too often
- Too many linting/test errors blocked development
- This solution is minimal and guaranteed to work

## What does it check?
✅ **ONLY ONE THING:** Can the code build?
- No linting errors
- No test failures  
- No coverage requirements
- Just: `yarn web build:production`

## Benefits
- Won't block PRs for minor issues
- Fast feedback (10 minute timeout)
- Can be expanded later when codebase is ready

## Test
This workflow will run automatically on this PR to prove it works.