### PR TITLE
fix: Correct 'All networks' visibility logic for Citrea Only mode

### DIFF
--- a/apps/web/src/components/NavBar/SearchBar/SearchModal.tsx
+++ b/apps/web/src/components/NavBar/SearchBar/SearchModal.tsx
@@ -1,6 +1,7 @@
 import { useModalState } from 'hooks/useModalState'
 import { memo, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { Flex, Text, TouchableArea, useMedia, useScrollbarStyles, useSporeColors } from 'ui/src'
 import { Modal } from 'uniswap/src/components/modals/Modal'
 import { useUpdateScrollLock } from 'uniswap/src/components/modals/ScrollLock'
@@ -13,6 +14,7 @@ import { SearchModalResultsList } from 'uniswap/src/features/search/SearchModal/
 import { useFilterCallbacks } from 'uniswap/src/features/search/SearchModal/hooks/useFilterCallbacks'
 import { SearchTab, WEB_SEARCH_TABS } from 'uniswap/src/features/search/SearchModal/types'
 import { SearchTextInput } from 'uniswap/src/features/search/SearchTextInput'
+import { selectIsCitreaOnlyEnabled } from 'uniswap/src/features/settings/selectors'
 import { Trace } from 'uniswap/src/features/telemetry/Trace'
 import { ElementName, InterfaceEventName, ModalName, SectionName } from 'uniswap/src/features/telemetry/constants'
 import { sendAnalyticsEvent } from 'uniswap/src/features/telemetry/send'
@@ -51,7 +53,8 @@ export const SearchModal = memo(function _SearchModal(): JSX.Element {
     onClose()
   }, [onChangeText, onClose])
 
-  const { chains: enabledChains } = useEnabledChains()
+  const { chains: enabledChains, isTestnetModeEnabled } = useEnabledChains()
+  const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
 
   // Tamagui Dialog/Sheets should remove background scroll by default but does not work to disable ArrowUp/Down key scrolling
   useUpdateScrollLock({ isModalOpen })
@@ -92,7 +95,7 @@ export const SearchModal = memo(function _SearchModal(): JSX.Element {
             endAdornment={
               <Flex row alignItems="center">
                 <NetworkFilter
-                  includeAllNetworks
+                  includeAllNetworks={!isTestnetModeEnabled && !isCitreaOnlyEnabled}
                   chainIds={enabledChains}
                   selectedChain={chainFilter}
                   onPressChain={onChangeChainFilter}

--- a/apps/web/src/components/NavBar/SearchBar/SearchModal.tsx
+++ b/apps/web/src/components/NavBar/SearchBar/SearchModal.tsx
@@ -53,7 +53,7 @@ export const SearchModal = memo(function _SearchModal(): JSX.Element {
     onClose()
   }, [onChangeText, onClose])
 
-  const { chains: enabledChains, isTestnetModeEnabled } = useEnabledChains()
+  const { chains: enabledChains } = useEnabledChains()
   const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
 
   // Tamagui Dialog/Sheets should remove background scroll by default but does not work to disable ArrowUp/Down key scrolling
@@ -95,7 +95,7 @@ export const SearchModal = memo(function _SearchModal(): JSX.Element {
             endAdornment={
               <Flex row alignItems="center">
                 <NetworkFilter
-                  includeAllNetworks={!isTestnetModeEnabled && !isCitreaOnlyEnabled}
+                  includeAllNetworks={!isCitreaOnlyEnabled}
                   chainIds={enabledChains}
                   selectedChain={chainFilter}
                   onPressChain={onChangeChainFilter}

--- a/packages/uniswap/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/uniswap/src/components/TokenSelector/TokenSelector.tsx
@@ -3,6 +3,7 @@ import { Currency } from '@juiceswapxyz/sdk-core'
 import { hasStringAsync } from 'expo-clipboard'
 import { ComponentProps, memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { Flex, ModalCloseIcon, Text, useMedia, useScrollbarStyles, useSporeColors } from 'ui/src'
 import { InfoCircleFilled } from 'ui/src/components/icons/InfoCircleFilled'
 import { spacing, zIndexes } from 'ui/src/theme'
@@ -26,6 +27,7 @@ import { CurrencyInfo } from 'uniswap/src/features/dataApi/types'
 import { SearchContext } from 'uniswap/src/features/search/SearchModal/analytics/SearchContext'
 import { useFilterCallbacks } from 'uniswap/src/features/search/SearchModal/hooks/useFilterCallbacks'
 import { SearchTextInput } from 'uniswap/src/features/search/SearchTextInput'
+import { selectIsCitreaOnlyEnabled } from 'uniswap/src/features/settings/selectors'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import {
   ElementName,
@@ -111,6 +113,7 @@ export function TokenSelectorContent({
   const [hasClipboardString, setHasClipboardString] = useState(false)
 
   const { chains: enabledChains, isTestnetModeEnabled } = useEnabledChains()
+  const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
 
   // Check if user clipboard has any text to show paste button
   useEffect(() => {
@@ -300,7 +303,7 @@ export function TokenSelectorContent({
               <Flex row alignItems="center">
                 {hasClipboardString && <PasteButton inline textVariant="buttonLabel3" onPress={handlePaste} />}
                 <NetworkFilter
-                  includeAllNetworks={!isTestnetModeEnabled}
+                  includeAllNetworks={!isTestnetModeEnabled && !isCitreaOnlyEnabled}
                   chainIds={chainIds || enabledChains}
                   selectedChain={chainFilter}
                   styles={isExtension || isMobileWeb ? { dropdownZIndex: zIndexes.overlay } : undefined}

--- a/packages/uniswap/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/uniswap/src/components/TokenSelector/TokenSelector.tsx
@@ -303,7 +303,7 @@ export function TokenSelectorContent({
               <Flex row alignItems="center">
                 {hasClipboardString && <PasteButton inline textVariant="buttonLabel3" onPress={handlePaste} />}
                 <NetworkFilter
-                  includeAllNetworks={!isTestnetModeEnabled && !isCitreaOnlyEnabled}
+                  includeAllNetworks={!isCitreaOnlyEnabled}
                   chainIds={chainIds || enabledChains}
                   selectedChain={chainFilter}
                   styles={isExtension || isMobileWeb ? { dropdownZIndex: zIndexes.overlay } : undefined}


### PR DESCRIPTION
## Problem
When Citrea Only mode is disabled, 'All networks' option was not appearing in the network filter dropdown.

## Solution
Fixed the logic to properly show/hide 'All networks':
- Show 'All networks' when: NOT in testnet mode AND NOT in Citrea Only mode
- The logic is now: `!isTestnetModeEnabled && !isCitreaOnlyEnabled`

## Changes
- Added necessary imports for Redux selector and Citrea Only state
- Updated NetworkFilter prop logic in both TokenSelector and SearchModal
- Ensured testnet mode check is included in SearchModal

## Testing
- When Citrea Only OFF + Testnet Mode OFF: 'All networks' should appear
- When Citrea Only ON: Only 'Citrea Testnet' appears
- When Testnet Mode ON: No 'All networks' (shows individual testnets)