### PR TITLE
feat: Add TaprootFreakCoin (TFC) token to Citrea Testnet

### DIFF
--- a/packages/uniswap/src/components/TokenSelector/hooks/useCommonTokensOptionsWithFallback.ts
+++ b/packages/uniswap/src/components/TokenSelector/hooks/useCommonTokensOptionsWithFallback.ts
@@ -87,6 +87,17 @@ const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
     currencyId: `${UniverseChainId.CitreaTestnet}-0x9B28B690550522608890C3C7e63c0b4A7eBab9AA`,
     logoUrl: '',
   },
+  {
+    currency: buildCurrency({
+      chainId: UniverseChainId.CitreaTestnet,
+      address: '0x14ADf6B87096Ef750a956756BA191fc6BE94e473',
+      decimals: 18,
+      symbol: 'TFC',
+      name: 'TaprootFreakCoin',
+    }) as Currency,
+    currencyId: `${UniverseChainId.CitreaTestnet}-0x14ADf6B87096Ef750a956756BA191fc6BE94e473`,
+    logoUrl: '',
+  },
 ]
 
 export function useCommonTokensOptionsWithFallback(


### PR DESCRIPTION
## Summary
This PR adds the TaprootFreakCoin (TFC) token to the list of available tokens on Citrea Testnet.

## Changes
- Added TFC token configuration to the hardcoded common base currencies list
- Token details:
  - **Address:** 0x14ADf6B87096Ef750a956756BA191fc6BE94e473
  - **Symbol:** TFC
  - **Name:** TaprootFreakCoin
  - **Decimals:** 18
  - **Chain:** Citrea Testnet

## Impact
Users can now see and select the TFC token in the token selector when using Citrea Testnet.

## Testing
- Token appears in the token selector on Citrea Testnet
- Token information displays correctly
- No impact on other chains or tokens