### PR TITLE
fix: disable LP incentive announcement banner

### DIFF
--- a/apps/web/src/components/Liquidity/LPIncentives/LPIncentiveAnnouncementBanner.tsx
+++ b/apps/web/src/components/Liquidity/LPIncentives/LPIncentiveAnnouncementBanner.tsx
@@ -125,8 +125,8 @@ export function LPIncentiveAnnouncementBanner() {
   const [hidden, setHidden] = useState(true)
 
   useEffect(() => {
-    const hasSeenBanner = localStorage.getItem(LP_INCENTIVE_BANNER_STORAGE_KEY) !== null
-    setHidden(hasSeenBanner)
+    // Always hide the banner
+    setHidden(true)
   }, [])
 
   const handleClose = () => {


### PR DESCRIPTION
## Summary
- Permanently disabled the LP incentive announcement banner that appears in the bottom-left corner
- The banner previously advertised 'UNI rewards are here' to promote liquidity provision

## Changes
- Modified  to always hide the banner regardless of localStorage or feature flag status

## Testing
- Verified the banner no longer appears on the web interface
- No functional impact on other features