### PR TITLE
fix: disable promotional banners

### DIFF
--- a/apps/web/src/components/TopLevelBanners/MobileAppPromoBanner.tsx
+++ b/apps/web/src/components/TopLevelBanners/MobileAppPromoBanner.tsx
@@ -1,12 +1,10 @@
 import { ReactComponent as UniswapLogo } from 'assets/svg/uniswap_app_logo.svg'
 import { useEthersWeb3Provider } from 'hooks/useEthersProvider'
 import { useAtom } from 'jotai'
-import { useAtomValue } from 'jotai/utils'
 import { X } from 'react-feather'
 import { useTranslation } from 'react-i18next'
-import { hideMobileAppPromoBannerAtom, persistHideMobileAppPromoBannerAtom } from 'state/application/atoms'
+import { hideMobileAppPromoBannerAtom } from 'state/application/atoms'
 import { Anchor, Flex, Text, styled, useSporeColors } from 'ui/src'
-import { isWebAndroid, isWebIOS } from 'utilities/src/platform'
 import { getWalletMeta } from 'utils/walletMeta'
 
 const Wrapper = styled(Flex, {
@@ -43,9 +41,8 @@ const StyledButton = styled(Anchor, {
  * - The user has not clicked the JuiceSwap wallet or Get JuiceSwap Wallet buttons in wallet options
  */
 export function useMobileAppPromoBannerEligible(): boolean {
-  const hideMobileAppPromoBanner = useAtomValue(hideMobileAppPromoBannerAtom)
-  const persistHideMobileAppPromoBanner = useAtomValue(persistHideMobileAppPromoBannerAtom)
-  return (isWebIOS || isWebAndroid) && !hideMobileAppPromoBanner && !persistHideMobileAppPromoBanner
+  // Always return false to disable the mobile app promo banner
+  return false
 }
 
 const UNIVERSAL_DOWNLOAD_LINK = 'https://uniswapwallet.onelink.me/8q3y/39b0eeui'


### PR DESCRIPTION
## Summary
- Permanently disabled the mobile app promo banner that appears on mobile browsers
- The banner was showing 'Get the JuiceSwap Wallet app' on both iOS and Android devices

## Changes
- Modified `MobileAppPromoBanner.tsx` to always return false in the eligibility check function
- Removed unused imports and variables to satisfy linting requirements

## Testing
- Verified the banner no longer appears on mobile browsers (Safari, Chrome, etc.)
- No functional impact on other features