### PR TITLE
fix: implement fallback logic for quote output amounts

### DIFF
--- a/packages/uniswap/src/features/transactions/swap/types/trade.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/trade.ts
@@ -44,7 +44,7 @@ function getQuoteOutputAmount<T extends QuoteResponseWithAggregatedOutputs>(quot
     return CurrencyAmount.fromRawAmount(outputCurrency, '0')
   }
 
-  return quote.quote.aggregatedOutputs?.reduce((acc, output) => acc.add(CurrencyAmount.fromRawAmount(outputCurrency, output.amount ?? '0')), CurrencyAmount.fromRawAmount(outputCurrency, '0')) ?? CurrencyAmount.fromRawAmount(outputCurrency, '0')
+  return quote.quote.aggregatedOutputs?.reduce((acc, output) => acc.add(CurrencyAmount.fromRawAmount(outputCurrency, output.amount ?? '0')), CurrencyAmount.fromRawAmount(outputCurrency, '0')) ?? CurrencyAmount.fromRawAmount(outputCurrency, 'output' in quote.quote ? quote.quote.output?.amount ?? '0' : '0')
 }
 
 /**


### PR DESCRIPTION
## Problem

Swap quotes were displaying 0 values on localhost while showing correct values on the dev website. This was caused by the quote processing logic only looking for `aggregatedOutputs` field in API responses, but some quote types (specifically ClassicQuote) return the amount in a different field structure.

## Root Cause Analysis

The `getQuoteOutputAmount` function in `trade.ts` was only checking for `quote.aggregatedOutputs` and returning 0 when this field was missing. However, the API was returning valid quote data in `quote.output.amount` for Classic routing quotes.

Console debugging revealed:
- `hasAggregatedOutputs: false` 
- `resultAmount: '0'` (what was being displayed)
- `rawQuoteAmount: '81222979073583'` (the actual quote value)

## Solution

Implemented a robust fallback mechanism using the nullish coalescing operator (`??`) that:

1. **Primary logic**: First attempts to use `aggregatedOutputs` as before (maintains backward compatibility)
2. **Type-safe fallback**: If `aggregatedOutputs` is missing, checks if the quote has an `output` property using `'output' in quote.quote`
3. **Fallback value**: Uses `quote.output.amount` for ClassicQuote types when `aggregatedOutputs` is undefined
4. **Safety net**: Falls back to '0' if neither field is available

## Technical Implementation

**Before:**
```typescript
return quote.quote.aggregatedOutputs?.reduce(...)
```

**After:**
```typescript
return quote.quote.aggregatedOutputs?.reduce(...) ?? 
  CurrencyAmount.fromRawAmount(outputCurrency, 'output' in quote.quote ? quote.quote.output?.amount ?? '0' : '0')
```

## Benefits

- ✅ **Fixes localhost quote display** - No more 0 values shown to users
- ✅ **Maintains compatibility** - Existing `aggregatedOutputs` logic unchanged
- ✅ **Type safety** - Properly handles different quote types (ClassicQuote, DutchQuoteV2, etc.)
- ✅ **Minimal change** - Single line modification reduces risk
- ✅ **Performance** - Nullish coalescing is efficient
- ✅ **Robustness** - Multiple fallback levels prevent runtime errors

## Testing

- ✅ TypeScript compilation passes
- ✅ No runtime errors in dev server
- ✅ Hot module reloading works correctly
- ✅ Handles all quote types without breaking

## Alternative Approaches Considered

1. **API-level fix**: Would require backend changes and potentially break other consumers
2. **Type checking**: More complex but this minimal approach achieves the same result
3. **Separate handlers**: Would require refactoring multiple files vs this single line change

This solution provides the most value with the least risk and complexity.