### PR TITLE
feat: Default to V3 for liquidity positions and remove protocol selection

### DIFF
--- a/apps/web/src/components/Liquidity/PositionsHeader.tsx
+++ b/apps/web/src/components/Liquidity/PositionsHeader.tsx
@@ -6,9 +6,8 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { ClickableTamaguiStyle } from 'theme/components/styles'
-import { Flex, LabeledCheckbox, Text, useMedia } from 'ui/src'
+import { Flex, LabeledCheckbox, Text } from 'ui/src'
 import { Plus } from 'ui/src/components/icons/Plus'
-import { RotatableChevron } from 'ui/src/components/icons/RotatableChevron'
 import { StatusIndicatorCircle } from 'ui/src/components/icons/StatusIndicatorCircle'
 import { NetworkFilter } from 'uniswap/src/components/network/NetworkFilter'
 import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
@@ -50,7 +49,6 @@ export function PositionsHeader({
   const { t } = useTranslation()
   const { chains } = useEnabledChains()
   const navigate = useNavigate()
-  const media = useMedia()
 
   const statusFilterOptions = useMemo(() => {
     return [PositionStatus.IN_RANGE, PositionStatus.OUT_OF_RANGE, PositionStatus.CLOSED].map((status) => {
@@ -99,27 +97,6 @@ export function PositionsHeader({
     ))
   }, [selectedVersions, onVersionChange])
 
-  const createOptions = useMemo(
-    () =>
-      PROTOCOL_VERSIONS.map((version) => {
-        const protocolVersionLabel = getProtocolVersionLabel(version)
-        return (
-          <Flex
-            key={`PositionsHeader-create-${protocolVersionLabel}`}
-            p="$spacing8"
-            {...ClickableTamaguiStyle}
-            onPress={() => {
-              navigate(`/positions/create/${protocolVersionLabel}`)
-            }}
-          >
-            <Text variant="body2">{t('position.new.protocol', { protocol: protocolVersionLabel })}</Text>
-          </Flex>
-        )
-      }),
-    [navigate, t],
-  )
-
-  const [createDropdownOpen, setCreateDropdownOpen] = useState(false)
   const [protocolDropdownOpen, setProtocolDropdownOpen] = useState(false)
   const [statusDropdownOpen, setStatusDropdownOpen] = useState(false)
 
@@ -129,57 +106,24 @@ export function PositionsHeader({
       <Flex gap="$gap8" row $sm={{ flexDirection: 'column' }}>
         {showFilters && (
           <>
-            <Flex gap="$spacing1" row $sm={{ width: '100%' }}>
-              <Flex
-                row
-                gap="$gap8"
-                px="$padding16"
-                backgroundColor="$neutral1"
-                borderTopLeftRadius="$rounded16"
-                borderBottomLeftRadius="$rounded16"
-                alignItems="center"
-                $sm={{ justifyContent: 'center' }}
-                justifyContent="flex-start"
-                flexGrow={1}
-                {...ClickableTamaguiStyle}
-                onPress={() => {
-                  navigate('/positions/create/v4')
-                }}
-              >
-                <Plus size={20} color="$surface1" />
-                <Text color="$surface1" variant="buttonLabel3">
-                  {t('common.new')}
-                </Text>
-              </Flex>
-              <DropdownSelector
-                containerStyle={{ width: 'auto' }}
-                menuLabel={
-                  <Flex
-                    borderTopRightRadius="$rounded16"
-                    borderBottomRightRadius="$rounded16"
-                    backgroundColor="$neutral1"
-                    justifyContent="center"
-                    alignItems="center"
-                    p="$padding8"
-                    {...ClickableTamaguiStyle}
-                  >
-                    <RotatableChevron direction="down" height={20} width={20} color="$surface1" />
-                  </Flex>
-                }
-                buttonStyle={{
-                  borderWidth: 0,
-                  p: 0,
-                }}
-                dropdownStyle={{ width: 160 }}
-                hideChevron={true}
-                isOpen={createDropdownOpen}
-                toggleOpen={() => {
-                  setCreateDropdownOpen((prev) => !prev)
-                }}
-                alignRight={media.sm}
-              >
-                {createOptions}
-              </DropdownSelector>
+            <Flex
+              row
+              gap="$gap8"
+              px="$padding16"
+              backgroundColor="$neutral1"
+              borderRadius="$rounded16"
+              alignItems="center"
+              $sm={{ justifyContent: 'center' }}
+              justifyContent="flex-start"
+              {...ClickableTamaguiStyle}
+              onPress={() => {
+                navigate('/positions/create/v3')
+              }}
+            >
+              <Plus size={20} color="$surface1" />
+              <Text color="$surface1" variant="buttonLabel3">
+                {t('common.new')}
+              </Text>
             </Flex>
             <Flex row alignItems="center" shrink height="100%" gap="$gap4">
               <DropdownSelector

--- a/apps/web/src/pages/CreatePosition/CreateLiquidityContextProvider.tsx
+++ b/apps/web/src/pages/CreatePosition/CreateLiquidityContextProvider.tsx
@@ -41,7 +41,7 @@ const DEFAULT_POSITION_STATE: PositionState = {
   fee: DEFAULT_FEE_DATA,
   hook: undefined,
   userApprovedHook: undefined,
-  protocolVersion: ProtocolVersion.V4,
+  protocolVersion: ProtocolVersion.V3,
 }
 
 // Combined state interface

--- a/apps/web/src/pages/CreatePosition/CreatePosition.tsx
+++ b/apps/web/src/pages/CreatePosition/CreatePosition.tsx
@@ -1,7 +1,6 @@
 import type { Currency } from '@juiceswapxyz/sdk-core'
 import { ProtocolVersion } from '@uniswap/client-pools/dist/pools/v1/types_pb'
 import { BreadcrumbNavContainer, BreadcrumbNavLink } from 'components/BreadcrumbNav'
-import { DropdownSelector } from 'components/DropdownSelector'
 import { LPSettings } from 'components/LPSettings'
 import { Container } from 'components/Liquidity/Create/Container'
 import { DynamicFeeTierSpeedbump } from 'components/Liquidity/Create/DynamicFeeTierSpeedbump'
@@ -14,7 +13,6 @@ import { useLiquidityUrlState } from 'components/Liquidity/Create/hooks/useLiqui
 import { DEFAULT_POSITION_STATE, PositionFlowStep } from 'components/Liquidity/Create/types'
 import { DepositStep } from 'components/Liquidity/Deposit'
 import { FeeTierSearchModal } from 'components/Liquidity/FeeTierSearchModal'
-import { getProtocolVersionLabel } from 'components/Liquidity/utils/protocolVersion'
 import { PoolProgressIndicator } from 'components/PoolProgressIndicator/PoolProgressIndicator'
 import {
   CreateLiquidityContextProvider,
@@ -26,10 +24,10 @@ import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ChevronRight } from 'react-feather'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, useParams } from 'react-router'
+import { useParams } from 'react-router'
 import { MultichainContextProvider } from 'state/multichain/MultichainContext'
 import { useMultichainContext } from 'state/multichain/useMultichainContext'
-import { Button, Flex, Text, TouchableArea, styled, useMedia } from 'ui/src'
+import { Button, Flex, Text, styled, useMedia } from 'ui/src'
 import { RotateLeft } from 'ui/src/components/icons/RotateLeft'
 import { INTERFACE_NAV_HEIGHT } from 'ui/src/theme'
 import { parseRestProtocolVersion } from 'uniswap/src/data/rest/utils'
@@ -248,23 +246,17 @@ const ToolbarContainer = styled(Flex, {
 })
 
 const Toolbar = () => {
-  const navigate = useNavigate()
   const { t } = useTranslation()
   const {
     areTokensUnchanged,
     positionState,
-    setPositionState,
-    setStep,
     reset: resetCreatePositionState,
-    setPriceRangeState,
     priceRangeState,
     resetPriceRange: resetPriceRangeState,
     depositState,
     resetDeposit: resetDepositState,
   } = useCreateLiquidityContext()
-  const { protocolVersion } = positionState
   const customSlippageTolerance = useTransactionSettingsStore((s) => s.customSlippageTolerance)
-  const [versionDropdownOpen, setVersionDropdownOpen] = useState(false)
 
   const [showResetModal, setShowResetModal] = useState(false)
 
@@ -297,38 +289,6 @@ const Toolbar = () => {
     }
   }, [handleReset, isTestnetModeEnabled, prevIsTestnetModeEnabled])
 
-  const handleVersionChange = useCallback(
-    (version: ProtocolVersion) => {
-      const versionUrl = getProtocolVersionLabel(version)
-      if (versionUrl) {
-        navigate(`/positions/create/${versionUrl}`)
-      }
-
-      setPositionState({
-        ...DEFAULT_POSITION_STATE,
-        protocolVersion: version,
-      })
-      setPriceRangeState(DEFAULT_PRICE_RANGE_STATE)
-      setStep(PositionFlowStep.SELECT_TOKENS_AND_FEE_TIER)
-      setVersionDropdownOpen(false)
-    },
-    [setPositionState, setPriceRangeState, setStep, navigate, setVersionDropdownOpen],
-  )
-
-  const versionOptions = useMemo(
-    () =>
-      [ProtocolVersion.V4, ProtocolVersion.V3, ProtocolVersion.V2]
-        .filter((version) => version != protocolVersion)
-        .map((version) => (
-          <TouchableArea key={`version-${version}`} onPress={() => handleVersionChange(version)}>
-            <Flex p="$spacing8" borderRadius="$rounded8" hoverStyle={{ backgroundColor: '$surface2' }}>
-              <Text variant="body2">{t('position.new.protocol', { protocol: getProtocolVersionLabel(version) })}</Text>
-            </Flex>
-          </TouchableArea>
-        )),
-    [handleVersionChange, protocolVersion, t],
-  )
-
   return (
     <Flex>
       <ResetCreatePositionFormModal
@@ -339,21 +299,18 @@ const Toolbar = () => {
 
       <ToolbarContainer>
         <ResetButton onClickReset={() => setShowResetModal(true)} isDisabled={isFormUnchanged} />
-        <DropdownSelector
-          containerStyle={{ width: 'auto' }}
-          buttonStyle={{ py: '$spacing8', px: '$spacing12' }}
-          dropdownStyle={{ width: 200, borderRadius: '$rounded16' }}
-          menuLabel={
-            <Text variant="buttonLabel3" lineHeight="16px">
-              {t('position.protocol', { protocol: getProtocolVersionLabel(protocolVersion) })}
-            </Text>
-          }
-          isOpen={versionDropdownOpen}
-          toggleOpen={() => setVersionDropdownOpen(!versionDropdownOpen)}
-          alignRight
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          py="$spacing8"
+          px="$spacing12"
+          backgroundColor="$surface3"
+          borderRadius="$rounded12"
         >
-          {versionOptions}
-        </DropdownSelector>
+          <Text variant="buttonLabel3" lineHeight="16px">
+            {t('position.protocol', { protocol: 'v3' })}
+          </Text>
+        </Flex>
         <Flex
           borderRadius="$rounded12"
           borderWidth={!customSlippageTolerance ? '$spacing1' : '$none'}
@@ -395,7 +352,7 @@ function CreatePositionContent({
   paramsProtocolVersion: ProtocolVersion | undefined
   autoSlippageTolerance: number
 }) {
-  const initialProtocolVersion = paramsProtocolVersion ?? ProtocolVersion.V4
+  const initialProtocolVersion = paramsProtocolVersion ?? ProtocolVersion.V3
 
   const [currencyInputs, setCurrencyInputs] = useState<{ tokenA: Maybe<Currency>; tokenB: Maybe<Currency> }>({
     tokenA: initialInputs.tokenA,

--- a/apps/web/src/pages/Positions/index.tsx
+++ b/apps/web/src/pages/Positions/index.tsx
@@ -69,7 +69,7 @@ function DisconnectedWalletView() {
           {t('positions.welcome.connect.description')}
         </Text>
         <Flex row gap="$gap8">
-          <Button variant="default" size="small" emphasis="secondary" onPress={() => navigate('/positions/create/v4')}>
+          <Button variant="default" size="small" emphasis="secondary" onPress={() => navigate('/positions/create/v3')}>
             {t('position.new')}
           </Button>
           <Button variant="default" size="small" width={160} onPress={accountDrawer.open}>
@@ -125,7 +125,7 @@ function EmptyPositionsView() {
           <Button variant="default" size="small" emphasis="secondary" onPress={() => navigate('/explore/pools')}>
             {t('pools.explore')}
           </Button>
-          <Button variant="default" size="small" width={160} onPress={() => navigate('/positions/create/v4')}>
+          <Button variant="default" size="small" width={160} onPress={() => navigate('/positions/create/v3')}>
             {t('position.new')}
           </Button>
         </Flex>


### PR DESCRIPTION
## Summary
- Changed default protocol version from V4 to V3 across the application
- Removed protocol version dropdown selectors for simplified UI
- Fixed all position creation flows to use V3 by default

## Changes
- Updated default protocol version in `CreatePosition.tsx` and `CreateLiquidityContextProvider.tsx` from V4 to V3
- Removed protocol version dropdown from positions header page
- Removed protocol version selector from create position page
- Fixed navigation links to point to V3 instead of V4
- Removed unused imports and variables

## Why
The application will only offer V3 liquidity pools, so the protocol selection dropdowns were unnecessary complexity for users.

## Testing
- [x] Verified "New Position" buttons navigate to V3
- [x] Confirmed protocol dropdown removed from positions page
- [x] Confirmed protocol selector removed from create position page
- [x] Tested that V3 is the default protocol version