### PR TITLE
fix: Enable Citrea only mode by default for new browser sessions

### DIFF
--- a/packages/uniswap/src/features/settings/selectors.ts
+++ b/packages/uniswap/src/features/settings/selectors.ts
@@ -12,4 +12,4 @@ export const selectIsTestnetModeEnabled = (state: UniswapState): boolean =>
   state.userSettings.isTestnetModeEnabled ?? true // TODO: remove this once we have a way to toggle testnet mode
 
 export const selectIsCitreaOnlyEnabled = (state: UniswapState): boolean =>
-  state.userSettings.isCitreaOnlyEnabled ?? false
+  state.userSettings.isCitreaOnlyEnabled ?? true


### PR DESCRIPTION
## Summary
Fixed the issue where Citrea only mode was disabled by default when opening the site in a new browser.

## Problem
- Despite the initial state setting `isCitreaOnlyEnabled: true`, new browser sessions showed the toggle as disabled
- The selector was defaulting to `false` when the persisted state was undefined

## Solution
- Changed the selector default value from `false` to `true` in `selectIsCitreaOnlyEnabled`
- Now aligns with the initial state configuration

## Testing
- [x] Verified Citrea only mode is enabled when opening site in new incognito window
- [x] Verified toggle still works correctly to enable/disable the mode
- [x] Verified setting persists across sessions