### PR TITLE
feat: Set cBTC/cUSD as default swap tokens for Citrea Testnet

### DIFF
--- a/apps/web/src/pages/Landing/sections/Hero.tsx
+++ b/apps/web/src/pages/Landing/sections/Hero.tsx
@@ -24,19 +24,16 @@ export function Hero({ scrollToRef, transition }: HeroProps) {
   const media = useMedia()
   const { height: scrollPosition } = useScroll({ enabled: !media.sm })
   const { defaultChainId } = useEnabledChains()
-  // Use WETH on Sepolia as default input currency
+  // Use native token (cBTC on Citrea) as default input currency
   const initialInputCurrency = useCurrency({
-    address:
-      defaultChainId === UniverseChainId.Sepolia
-        ? '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14' // WETH on Sepolia
-        : 'ETH',
+    address: 'ETH', // This will get the native token for any chain
     chainId: defaultChainId,
   })
-  // Use USDC on Sepolia as default output currency
+  // Use cUSD as default output currency for Citrea and Sepolia
   const initialOutputCurrency = useCurrency({
     address:
-      defaultChainId === UniverseChainId.Sepolia
-        ? '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238' // USDC on Sepolia
+      defaultChainId === UniverseChainId.CitreaTestnet || defaultChainId === UniverseChainId.Sepolia
+        ? '0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0' // cUSD
         : undefined,
     chainId: defaultChainId,
   })

--- a/apps/web/src/state/swap/hooks.tsx
+++ b/apps/web/src/state/swap/hooks.tsx
@@ -277,14 +277,32 @@ export function useInitialCurrencyState(): {
 
   const outputChainIsSupported = useSupportedChainId(parsedCurrencyState.outputChainId)
 
-  const initialOutputCurrencyAddress = useMemo(
-    () =>
+  const initialOutputCurrencyAddress = useMemo(() => {
+    // If there are parsed output currency params, use them
+    if (parsedCurrencyState.outputCurrencyAddress) {
       // clear output if identical unless there's a supported outputChainId which means we're bridging
-      initialInputCurrencyAddress === parsedCurrencyState.outputCurrencyAddress && !outputChainIsSupported
-        ? undefined
-        : parsedCurrencyState.outputCurrencyAddress,
-    [initialInputCurrencyAddress, parsedCurrencyState.outputCurrencyAddress, outputChainIsSupported],
-  )
+      if (initialInputCurrencyAddress === parsedCurrencyState.outputCurrencyAddress && !outputChainIsSupported) {
+        return undefined
+      }
+      return parsedCurrencyState.outputCurrencyAddress
+    }
+
+    // Default to cUSD when no output currency is specified
+    if (!hasCurrencyQueryParams) {
+      // For Citrea Testnet, default to cUSD
+      if (initialChainId === UniverseChainId.CitreaTestnet || initialChainId === UniverseChainId.Sepolia) {
+        return '0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0' // cUSD
+      }
+    }
+
+    return undefined
+  }, [
+    initialInputCurrencyAddress,
+    parsedCurrencyState.outputCurrencyAddress,
+    outputChainIsSupported,
+    hasCurrencyQueryParams,
+    initialChainId,
+  ])
 
   const initialInputCurrency = useCurrency({ address: initialInputCurrencyAddress, chainId: initialChainId })
   const initialOutputCurrency = useCurrency({

--- a/packages/uniswap/src/features/tokens/stablecoin.ts
+++ b/packages/uniswap/src/features/tokens/stablecoin.ts
@@ -31,5 +31,5 @@ export const buildUSDT = createTokenFactory({
 export const buildCUSD = createTokenFactory({
   decimals: 18,
   name: 'Citrus Dollar',
-  symbol: 'CUSD',
+  symbol: 'cUSD',
 })

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useDefaultSwapFormState.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useDefaultSwapFormState.ts
@@ -4,7 +4,7 @@ import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledCh
 import { getNativeAddress } from 'uniswap/src/constants/addresses'
 import type { TradeableAsset } from 'uniswap/src/entities/assets'
 import { AssetType } from 'uniswap/src/entities/assets'
-import type { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import type { SwapFormState } from 'uniswap/src/features/transactions/swap/stores/swapFormStore/types'
 import { CurrencyField } from 'uniswap/src/types/currency'
 
@@ -14,6 +14,26 @@ const getDefaultInputCurrency = (chainId: UniverseChainId): TradeableAsset => ({
   type: AssetType.Currency,
 })
 
+const getDefaultOutputCurrency = (chainId: UniverseChainId): TradeableAsset | undefined => {
+  // For Citrea Testnet, default output to cUSD
+  if (chainId === UniverseChainId.CitreaTestnet) {
+    return {
+      address: '0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0', // cUSD on Citrea Testnet
+      chainId,
+      type: AssetType.Currency,
+    }
+  }
+  // For Sepolia, default output to cUSD
+  if (chainId === UniverseChainId.Sepolia) {
+    return {
+      address: '0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0', // cUSD on Sepolia
+      chainId,
+      type: AssetType.Currency,
+    }
+  }
+  return undefined
+}
+
 export const getDefaultState = (defaultChainId: UniverseChainId): Readonly<Omit<SwapFormState, 'account'>> => ({
   exactAmountFiat: undefined,
   exactAmountToken: '',
@@ -21,7 +41,7 @@ export const getDefaultState = (defaultChainId: UniverseChainId): Readonly<Omit<
   focusOnCurrencyField: CurrencyField.INPUT,
   filteredChainIds: {},
   input: getDefaultInputCurrency(defaultChainId),
-  output: undefined,
+  output: getDefaultOutputCurrency(defaultChainId),
   isFiatMode: false,
   isMax: false,
   isSubmitting: false,


### PR DESCRIPTION
## Summary
- Changes default swap input token from WETH to native token (cBTC on Citrea)
- Changes default output token from USDC to cUSD for Citrea Testnet and Sepolia
- Fixes cUSD symbol display from CUSD to cUSD

## Changes
- Updated landing page default tokens
- Updated swap page default tokens
- Fixed token symbol in stablecoin definitions
- Added default output currency logic for Citrea Testnet

## Test Plan
- [x] Test on http://localhost:3001/ - cBTC/cUSD should be selected by default
- [x] Test on http://localhost:3001/?intro=true - cBTC/cUSD should be selected by default
- [x] Test on http://localhost:3001/swap - cBTC/cUSD should be selected by default
- [x] Verify cUSD symbol displays correctly (not CUSD)