### PR TITLE
fix: Remove 'Migrate to v4' button from position cards

### DIFF
--- a/apps/web/src/pages/Positions/index.tsx
+++ b/apps/web/src/pages/Positions/index.tsx
@@ -211,7 +211,7 @@ function VirtualizedPositionsList({
                 style={{ textDecoration: 'none' }}
                 to={getPositionUrl(position)}
               >
-                <LiquidityPositionCard showVisibilityOption liquidityPosition={position} showMigrateButton />
+                <LiquidityPositionCard showVisibilityOption liquidityPosition={position} />
               </Link>
             </Flex>
           )


### PR DESCRIPTION
## Summary
Removes the 'Migrate to v4' button from liquidity position cards on the positions page.

## Changes
- Removed `showMigrateButton` prop from `LiquidityPositionCard` component in positions page

## Motivation
The migrate button is not needed for the current implementation and should not be displayed on position cards.

## Test Plan
1. Navigate to /positions page
2. Connect wallet with existing positions
3. Verify that no 'Migrate to v4' button appears on position cards
4. Verify position cards display correctly without the button