### PR TITLE
fix: Hide 'All networks' option when Citrea Only mode is enabled

### DIFF
--- a/apps/web/src/components/Liquidity/PositionsHeader.tsx
+++ b/apps/web/src/components/Liquidity/PositionsHeader.tsx
@@ -4,6 +4,7 @@ import { lpStatusConfig } from 'components/Liquidity/constants'
 import { getProtocolStatusLabel, getProtocolVersionLabel } from 'components/Liquidity/utils/protocolVersion'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router'
 import { ClickableTamaguiStyle } from 'theme/components/styles'
 import { Flex, LabeledCheckbox, Text } from 'ui/src'
@@ -12,6 +13,7 @@ import { StatusIndicatorCircle } from 'ui/src/components/icons/StatusIndicatorCi
 import { NetworkFilter } from 'uniswap/src/components/network/NetworkFilter'
 import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { selectIsCitreaOnlyEnabled } from 'uniswap/src/features/settings/selectors'
 
 const StyledDropdownButton = {
   borderRadius: '$rounded16',
@@ -49,6 +51,7 @@ export function PositionsHeader({
   const { t } = useTranslation()
   const { chains } = useEnabledChains()
   const navigate = useNavigate()
+  const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
 
   const statusFilterOptions = useMemo(() => {
     return [PositionStatus.IN_RANGE, PositionStatus.OUT_OF_RANGE, PositionStatus.CLOSED].map((status) => {
@@ -157,7 +160,7 @@ export function PositionsHeader({
                 {...ClickableTamaguiStyle}
               >
                 <NetworkFilter
-                  includeAllNetworks
+                  includeAllNetworks={!isCitreaOnlyEnabled}
                   selectedChain={selectedChain}
                   onPressChain={onChainChange}
                   chainIds={chains}

--- a/apps/web/src/pages/Explore/index.tsx
+++ b/apps/web/src/pages/Explore/index.tsx
@@ -18,7 +18,7 @@ import { useExploreParams } from 'pages/Explore/redirects'
 import RecentTransactions from 'pages/Explore/tables/RecentTransactions'
 import { NamedExoticComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate, useSearchParams } from 'react-router'
 import { setOpenModal } from 'state/application/reducer'
 import { ExploreContextProvider } from 'state/explore'
@@ -28,6 +28,7 @@ import { Plus } from 'ui/src/components/icons/Plus'
 import { getChainInfo } from 'uniswap/src/features/chains/chainInfo'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { isBackendSupportedChain, toGraphQLChain } from 'uniswap/src/features/chains/utils'
+import { selectIsCitreaOnlyEnabled } from 'uniswap/src/features/settings/selectors'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import { ElementName, InterfacePageName, ModalName } from 'uniswap/src/features/telemetry/constants'
 import { getChainUrlParam, useChainIdFromUrlParam } from 'utils/chainParams'
@@ -101,6 +102,7 @@ const Explore = ({ initialTab }: { initialTab?: ExploreTab }) => {
   const tabNavRef = useRef<HTMLDivElement>(null)
   const resetManualOutage = useResetAtom(manualChainOutageAtom)
   const Pages = usePages()
+  const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
   const [params] = useSearchParams()
   const dispatch = useDispatch()
   const navigate = useNavigate()
@@ -231,7 +233,9 @@ const Explore = ({ initialTab }: { initialTab?: ExploreTab }) => {
                   </Button>
                 </Flex>
               )}
-              <TableNetworkFilter showMultichainOption={currentKey !== ExploreTab.Transactions} />
+              <TableNetworkFilter
+                showMultichainOption={currentKey !== ExploreTab.Transactions && !isCitreaOnlyEnabled}
+              />
               {currentKey === ExploreTab.Tokens && <VolumeTimeFrameSelector />}
               {currentKey === ExploreTab.Pools && <ProtocolFilter />}
               <SearchBar tab={currentKey} />


### PR DESCRIPTION
## Summary
- Hide the 'All networks' filter option when Citrea Only mode is enabled
- Applied to both Positions page and Explore page for consistency

## Changes
- Updated PositionsHeader component to use Redux selector for Citrea Only setting
- Modified network filter to conditionally show 'All networks' based on the setting
- Applied same logic to Explore page's TableNetworkFilter component

## Testing
- Enable Citrea Only mode in settings
- Navigate to /positions - 'All networks' option should be hidden
- Navigate to /explore - 'All networks' option should be hidden
- Disable Citrea Only mode - 'All networks' option should reappear on both pages