### PR TITLE
fix: Show Citrea Testnet in explore page network filter

### DIFF
--- a/apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx
+++ b/apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx
@@ -109,10 +109,16 @@ export default function TableNetworkFilter({ showMultichainOption = true }: { sh
                   .filter((c) => c !== UniverseChainId.MonadTestnet)
                   .map(tableNetworkItemRenderer)
               : null}
-            {/* Unsupported non-testnet backend supported chains */}
+            {/* Unsupported non-testnet chains */}
             {enabledChainIds
               .filter((c) => !isBackendSupportedChainId(c) && !isTestnetChain(c))
               .map(tableNetworkItemRenderer)}
+            {/* Unsupported testnet chains (when testnet mode is enabled) */}
+            {isTestnetModeEnabled
+              ? enabledChainIds
+                  .filter((c) => !isBackendSupportedChainId(c) && isTestnetChain(c))
+                  .map(tableNetworkItemRenderer)
+              : null}
           </ScrollView>
         </DropdownSelector>
       </Trace>


### PR DESCRIPTION
## Summary

This PR fixes the issue where Citrea Testnet was not visible in the explore page network filter dropdown.

## Problem

Citrea Testnet was not appearing in the explore page network selector because:
1. It's marked as `backendSupported: false` (since it's not in the GraphQL backend yet)
2. The network filter only showed unsupported non-testnet chains, but not unsupported testnets

## Solution

Modified the network filter to also display unsupported testnet chains when testnet mode is enabled.

## Changes

- Updated `apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx`
- Added a new section to render unsupported testnet chains when testnet mode is active

## Result

- Citrea Testnet now appears in the explore page network dropdown when testnet mode is enabled
- It displays with a "Beta" badge to indicate it's not fully backend-supported
- Users can select it to filter/explore Citrea Testnet data

## Testing

- [x] Verified Citrea Testnet appears in network dropdown with testnet mode enabled
- [x] Verified it shows with Beta badge
- [x] No regression in other network selections