### PR TITLE
feat: Clean up positions page by removing educational tiles

### DIFF
--- a/apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx
+++ b/apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx
@@ -7,6 +7,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import { memo, useCallback, useState } from 'react'
 import { Check } from 'react-feather'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router'
 import { EllipsisTamaguiStyle } from 'theme/components/styles'
 import type { FlexProps } from 'ui/src'
@@ -21,7 +22,6 @@ import { useIsSupportedChainIdCallback } from 'uniswap/src/features/chains/hooks
 import type { UniverseChainInfo } from 'uniswap/src/features/chains/types'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { isBackendSupportedChainId, isTestnetChain, toGraphQLChain } from 'uniswap/src/features/chains/utils'
-import { useSelector } from 'react-redux'
 import { selectIsCitreaOnlyEnabled } from 'uniswap/src/features/settings/selectors'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import { InterfacePageName, ModalName } from 'uniswap/src/features/telemetry/constants'
@@ -84,7 +84,9 @@ export default function TableNetworkFilter({ showMultichainOption = true }: { sh
                 <NetworkLogo chainId={null} />
               ) : (
                 <ChainLogo
-                  chainId={isCitreaOnlyEnabled ? UniverseChainId.CitreaTestnet : (currentChainId ?? UniverseChainId.Mainnet)}
+                  chainId={
+                    isCitreaOnlyEnabled ? UniverseChainId.CitreaTestnet : currentChainId ?? UniverseChainId.Mainnet
+                  }
                   size={20}
                   testId={TestID.TokensNetworkFilterSelected}
                 />

--- a/apps/web/src/constants/hardcodedPositions.ts
+++ b/apps/web/src/constants/hardcodedPositions.ts
@@ -2,8 +2,8 @@ import { CurrencyAmount } from '@juiceswapxyz/sdk-core'
 import { PositionStatus, ProtocolVersion } from '@uniswap/client-pools/dist/pools/v1/types_pb'
 import { FeeData } from 'components/Liquidity/Create/types'
 import { V3PositionInfo } from 'components/Liquidity/types'
-import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { NUSD, TFC, USDC, WCBTC, cUSD } from 'constants/hardcodedPools'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 
 const feeTierData: FeeData = {
   isDynamic: false,

--- a/apps/web/src/pages/Positions/index.tsx
+++ b/apps/web/src/pages/Positions/index.tsx
@@ -1,6 +1,4 @@
 import { PositionStatus, ProtocolVersion } from '@uniswap/client-pools/dist/pools/v1/types_pb'
-import PROVIDE_LIQUIDITY from 'assets/images/provideLiquidity.png'
-import V4_HOOK from 'assets/images/v4Hooks.png'
 import { ExpandoRow } from 'components/AccountDrawer/MiniPortfolio/ExpandoRow'
 import { useAccountDrawer } from 'components/AccountDrawer/MiniPortfolio/hooks'
 import { ExternalArrowLink } from 'components/Liquidity/ExternalArrowLink'
@@ -71,22 +69,6 @@ function DisconnectedWalletView() {
           </Button>
         </Flex>
       </Flex>
-      <Flex gap="$gap20" mb="$spacing24">
-        <Flex row gap="$gap12" $sm={{ flexDirection: 'column' }}>
-          <LearnMoreTile
-            width="100%"
-            img={PROVIDE_LIQUIDITY}
-            text={t('liquidity.provideOnProtocols')}
-            link={uniswapUrls.helpArticleUrls.providingLiquidityInfo}
-          />
-          <LearnMoreTile
-            width="100%"
-            img={V4_HOOK}
-            text={t('liquidity.hooks')}
-            link={uniswapUrls.helpArticleUrls.v4HooksInfo}
-          />
-        </Flex>
-      </Flex>
     </Flex>
   )
 }
@@ -125,44 +107,6 @@ function EmptyPositionsView() {
         </Flex>
       </Flex>
     </Flex>
-  )
-}
-
-function LearnMoreTile({
-  img,
-  text,
-  link,
-  width = 344,
-}: {
-  img: string
-  text: string
-  link?: string
-  width?: number | string
-}) {
-  return (
-    <Anchor
-      href={link}
-      textDecorationLine="none"
-      target="_blank"
-      rel="noopener noreferrer"
-      width={width}
-      {...ClickableTamaguiStyle}
-      hoverStyle={{ backgroundColor: '$surface1Hovered', borderColor: '$surface3Hovered' }}
-    >
-      <Flex
-        row
-        borderRadius="$rounded20"
-        borderColor="$surface3"
-        borderWidth="$spacing1"
-        borderStyle="solid"
-        alignItems="center"
-        gap="$gap16"
-        overflow="hidden"
-      >
-        <img src={img} style={{ objectFit: 'cover', width: '72px', height: '72px' }} />
-        <Text variant="subheading2">{text}</Text>
-      </Flex>
-    </Anchor>
   )
 }
 
@@ -451,18 +395,6 @@ export default function Pool() {
           {isConnected && (
             <Flex gap="$gap20" mb="$spacing24">
               <Text variant="subheading1">{t('liquidity.learnMoreLabel')}</Text>
-              <Flex gap="$gap12">
-                <LearnMoreTile
-                  img={PROVIDE_LIQUIDITY}
-                  text={t('liquidity.provideOnProtocols')}
-                  link={uniswapUrls.helpArticleUrls.providingLiquidityInfo}
-                />
-                <LearnMoreTile
-                  img={V4_HOOK}
-                  text={t('liquidity.hooks')}
-                  link={uniswapUrls.helpArticleUrls.v4HooksInfo}
-                />
-              </Flex>
               <ExternalArrowLink href={uniswapUrls.helpArticleUrls.positionsLearnMore}>
                 {t('common.button.learn')}
               </ExternalArrowLink>


### PR DESCRIPTION
## Summary
- Removed 'Providing liquidity on different protocols' tile from positions page
- Removed 'Hooks on v4' tile from positions page
- Cleaned up unused LearnMoreTile component and related imports
- Simplified the Learn More section on the positions page

## Changes
- Removed two educational tiles that were displayed both when wallet is disconnected and when connected
- Removed unused image imports (PROVIDE_LIQUIDITY and V4_HOOK)
- Deleted the LearnMoreTile component as it's no longer used
- Kept the basic Learn More link but removed the tile-based layout

## Test plan
- [x] Visit /positions page when wallet is disconnected - tiles should not appear
- [x] Visit /positions page when wallet is connected - tiles should not appear at bottom
- [x] Verify Learn More section still shows with link to help article