### PR TITLE
fix: Remove V2 positions import message from positions page

### DIFF
--- a/apps/web/src/pages/Positions/index.tsx
+++ b/apps/web/src/pages/Positions/index.tsx
@@ -433,18 +433,6 @@ export default function Pool() {
               <CloseIconWithHover onClose={() => setClosedCTADismissed(true)} size="$icon.20" />
             </Flex>
           )}
-          {isConnected && (
-            <Flex row centered $sm={{ flexDirection: 'column', alignItems: 'flex-start' }} mb="$spacing24" gap="$gap4">
-              <Text variant="body3" color="$neutral2">
-                {t('pool.import.link.description')}
-              </Text>
-              <Anchor href="/pools/v2/find" textDecorationLine="none">
-                <Text variant="body3" color="$neutral1" {...ClickableTamaguiStyle}>
-                  {t('pool.import.positions.v2')}
-                </Text>
-              </Anchor>
-            </Flex>
-          )}
         </Flex>
         <Flex gap="$gap32">
           <TopPools chainId={chainFilter} />


### PR DESCRIPTION
## Summary
Removes the V2 positions import message that was displayed on the positions page.

## Changes
- Removed the text 'Some v2 positions aren't displayed automatically'
- Removed the 'Import V2 positions' link pointing to /pools/v2/find
- Cleaned up the section that was displaying this message

## Test plan
- [x] Navigate to /positions page
- [x] Verify the V2 import message is no longer displayed
- [x] Verify page layout still looks correct