### PR TITLE
fix: Remove 'Pools with rewards' section from positions page

### DIFF
--- a/apps/web/src/pages/Positions/TopPools.tsx
+++ b/apps/web/src/pages/Positions/TopPools.tsx
@@ -2,7 +2,6 @@ import { ExploreStatsResponse } from '@uniswap/client-explore/dist/uniswap/explo
 import { PoolSortFields } from 'appGraphql/data/pools/useTopPools'
 import { OrderDirection } from 'appGraphql/data/util'
 import { ExternalArrowLink } from 'components/Liquidity/ExternalArrowLink'
-import { useAccount } from 'hooks/useAccount'
 import { TopPoolsSection } from 'pages/Positions/TopPoolsSection'
 import { useTranslation } from 'react-i18next'
 import { useTopPools } from 'state/explore/topPools'
@@ -10,15 +9,9 @@ import { Flex, useMedia } from 'ui/src'
 import { ALL_NETWORKS_ARG } from 'uniswap/src/data/rest/base'
 import { useExploreStatsQuery } from 'uniswap/src/data/rest/exploreStats'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
-import { FeatureFlags } from 'uniswap/src/features/gating/flags'
-import { useFeatureFlag } from 'uniswap/src/features/gating/hooks'
-
-const MAX_BOOSTED_POOLS = 3
 
 export function TopPools({ chainId }: { chainId: UniverseChainId | null }) {
-  const account = useAccount()
   const { t } = useTranslation()
-  const isLPIncentivesEnabled = useFeatureFlag(FeatureFlags.LpIncentives)
   const media = useMedia()
   const isBelowXlScreen = !media.xl
 
@@ -30,13 +23,11 @@ export function TopPools({ chainId }: { chainId: UniverseChainId | null }) {
     input: { chainId: chainId ? chainId.toString() : ALL_NETWORKS_ARG },
   })
 
-  const { topPools, topBoostedPools } = useTopPools({
+  const { topPools } = useTopPools({
     topPoolData: { data: exploreStatsData, isLoading: exploreStatsLoading, isError: !!exploreStatsError },
     sortState: { sortDirection: OrderDirection.Desc, sortBy: PoolSortFields.TVL },
   })
 
-  const displayBoostedPools =
-    topBoostedPools && topBoostedPools.length > 0 && Boolean(account.address) && isLPIncentivesEnabled
   const displayTopPools = topPools && topPools.length > 0
 
   if (!isBelowXlScreen) {
@@ -45,18 +36,6 @@ export function TopPools({ chainId }: { chainId: UniverseChainId | null }) {
 
   return (
     <Flex gap={48}>
-      {displayBoostedPools && (
-        <Flex gap="$gap20">
-          <TopPoolsSection
-            title={t('pool.top.rewards')}
-            pools={topBoostedPools.slice(0, MAX_BOOSTED_POOLS)}
-            isLoading={exploreStatsLoading}
-          />
-          <ExternalArrowLink href="/explore/pools" openInNewTab={false}>
-            {t('explore.more.unichain')}
-          </ExternalArrowLink>
-        </Flex>
-      )}
       {displayTopPools && (
         <Flex gap="$gap20">
           <TopPoolsSection title={t('pool.top.tvl')} pools={topPools} isLoading={exploreStatsLoading} />


### PR DESCRIPTION
## Summary
Removes the 'Pools with rewards' section from the positions page, keeping only the 'Top pools by TVL' section.

## Changes
- Removed the entire boosted pools display section
- Removed displayBoostedPools logic and related variables
- Removed unused imports (useAccount, FeatureFlags, useFeatureFlag)
- Removed unused variables (account, isLPIncentivesEnabled)
- Removed MAX_BOOSTED_POOLS constant
- Simplified the TopPools component

## Test plan
- [x] Navigate to /positions page
- [x] Verify only 'Top pools by TVL' section is displayed
- [x] Verify 'Pools with rewards' section is no longer shown
- [x] Verify page layout still looks correct