### PR TITLE
fix: Remove visual elements from landing page for consistent dark theme

### DIFF
--- a/apps/web/src/pages/Landing/LandingV2.tsx
+++ b/apps/web/src/pages/Landing/LandingV2.tsx
@@ -1,19 +1,11 @@
 import { Hero } from 'pages/Landing/sections/Hero'
 import { Suspense, lazy, memo, useRef } from 'react'
-import { Flex, styled } from 'ui/src'
+import { Flex } from 'ui/src'
 import { INTERFACE_NAV_HEIGHT } from 'ui/src/theme'
 
 // The Fold is always loaded, but is lazy-loaded because it is not seen without user interaction.
 // Annotating it with webpackPreload allows it to be ready when requested.
 const Fold = lazy(() => import(/* webpackPreload: true */ './Fold'))
-
-const Grain = styled(Flex, {
-  position: 'absolute',
-  inset: 0,
-  background: 'url(/images/noise-color.png)',
-  opacity: 0.018,
-  zIndex: 0,
-})
 
 function LandingV2({ transition }: { transition?: boolean }) {
   const scrollAnchor = useRef<HTMLDivElement | null>(null)
@@ -34,7 +26,6 @@ function LandingV2({ transition }: { transition?: boolean }) {
       minWidth="100vw"
       data-testid="landing-page"
     >
-      <Grain />
       <Hero scrollToRef={scrollToRef} transition={transition} />
       <Suspense>
         <Fold ref={scrollAnchor} />

--- a/apps/web/src/pages/Landing/sections/Hero.tsx
+++ b/apps/web/src/pages/Landing/sections/Hero.tsx
@@ -1,7 +1,6 @@
 import { ColumnCenter } from 'components/deprecated/Column'
 import { useCurrency } from 'hooks/Tokens'
 import { useScroll } from 'hooks/useScroll'
-import { TokenCloud } from 'pages/Landing/components/TokenCloud'
 import { Hover, RiseIn, RiseInText } from 'pages/Landing/components/animations'
 import { Swap } from 'pages/Swap'
 import { Fragment, useCallback, useMemo } from 'react'
@@ -91,7 +90,6 @@ export function Hero({ scrollToRef, transition }: HeroProps) {
       pt={INTERFACE_NAV_HEIGHT}
       pointerEvents="none"
     >
-      {!media.sm && <TokenCloud />}
 
       <Flex
         alignSelf="center"


### PR DESCRIPTION
## Summary
This PR removes visual elements from the landing page to create a consistent dark theme across the application, matching the clean appearance of the swap page.

## Changes
- 🎨 Removed TokenCloud component with floating token icons
- 🧹 Removed grain/noise texture overlay 
- 📦 Cleaned up unused imports and components
- ✨ Unified background appearance between landing and swap pages

## Visual Impact
### Before
- Landing page had floating token icons in the background
- Subtle noise texture overlay on the background
- Different visual style compared to swap page

### After
- Clean, dark background matching the swap page
- Consistent visual experience across the application
- Improved focus on main content without distracting elements

## Testing
- Verified landing page renders correctly without visual artifacts
- Confirmed swap page appearance remains unchanged
- Tested responsive behavior on different screen sizes
- No functionality changes, purely visual adjustments