### PR TITLE
fix: Remove visual elements from landing page for consistent dark the…

### DIFF
--- a/apps/web/src/pages/Landing/LandingV2.tsx
+++ b/apps/web/src/pages/Landing/LandingV2.tsx
@@ -1,19 +1,11 @@
 import { Hero } from 'pages/Landing/sections/Hero'
 import { Suspense, lazy, memo, useRef } from 'react'
-import { Flex, styled } from 'ui/src'
+import { Flex } from 'ui/src'
 import { INTERFACE_NAV_HEIGHT } from 'ui/src/theme'
 
 // The Fold is always loaded, but is lazy-loaded because it is not seen without user interaction.
 // Annotating it with webpackPreload allows it to be ready when requested.
 const Fold = lazy(() => import(/* webpackPreload: true */ './Fold'))
-
-const Grain = styled(Flex, {
-  position: 'absolute',
-  inset: 0,
-  background: 'url(/images/noise-color.png)',
-  opacity: 0.018,
-  zIndex: 0,
-})
 
 function LandingV2({ transition }: { transition?: boolean }) {
   const scrollAnchor = useRef<HTMLDivElement | null>(null)
@@ -34,7 +26,6 @@ function LandingV2({ transition }: { transition?: boolean }) {
       minWidth="100vw"
       data-testid="landing-page"
     >
-      <Grain />
       <Hero scrollToRef={scrollToRef} transition={transition} />
       <Suspense>
         <Fold ref={scrollAnchor} />

--- a/apps/web/src/pages/Landing/sections/Hero.tsx
+++ b/apps/web/src/pages/Landing/sections/Hero.tsx
@@ -1,7 +1,6 @@
 import { ColumnCenter } from 'components/deprecated/Column'
 import { useCurrency } from 'hooks/Tokens'
 import { useScroll } from 'hooks/useScroll'
-import { TokenCloud } from 'pages/Landing/components/TokenCloud'
 import { Hover, RiseIn, RiseInText } from 'pages/Landing/components/animations'
 import { Swap } from 'pages/Swap'
 import { Fragment, useCallback, useMemo } from 'react'
@@ -91,7 +90,6 @@ export function Hero({ scrollToRef, transition }: HeroProps) {
       pt={INTERFACE_NAV_HEIGHT}
       pointerEvents="none"
     >
-      {!media.sm && <TokenCloud />}
 
       <Flex
         alignSelf="center"


### PR DESCRIPTION
…me (#125)

- Remove TokenCloud component with floating icons
- Remove grain/noise texture overlay
- Clean up unused imports
- Align landing page background with swap page design