### PR TITLE
fix: Resolve ESLint errors in TopPools and bappsCampaign hooks

### DIFF
--- a/apps/web/src/components/Tokens/TokenTable/index.tsx
+++ b/apps/web/src/components/Tokens/TokenTable/index.tsx
@@ -90,7 +90,7 @@ export const TopTokensTable = memo(function TopTokensTable() {
   // Show hardcoded tokens for Citrea testnet or when Citrea Only toggle is enabled
   if (chainId === UniverseChainId.CitreaTestnet || isCitreaOnlyEnabled) {
     // Convert hardcoded tokens to TokenStat format
-    const citreaTokens = HARDCODED_CITREA_TOKENS.map((token, index) => ({
+    const citreaTokens = HARDCODED_CITREA_TOKENS.map((token) => ({
       ...token,
       chain: toGraphQLChain(UniverseChainId.CitreaTestnet),
       market: {

--- a/apps/web/src/constants/hardcodedTokens.ts
+++ b/apps/web/src/constants/hardcodedTokens.ts
@@ -1,6 +1,6 @@
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 // Import tokens from hardcodedPools to avoid duplication
-import { NUSD, TFC, USDC, WCBTC, cUSD } from './hardcodedPools'
+import { NUSD, TFC, USDC, WCBTC, cUSD } from 'constants/hardcodedPools'
 
 // Hardcoded Citrea tokens for the explore page with market data
 export const HARDCODED_CITREA_TOKENS = [

--- a/apps/web/src/services/bappsCampaign/hooks.ts
+++ b/apps/web/src/services/bappsCampaign/hooks.ts
@@ -61,7 +61,7 @@ export function useBAppsCampaignProgress() {
 
       return success
     },
-    [account.address, defaultChainId, fetchProgress],
+    [account.address, defaultChainId],
   )
 
   // Check if a swap completed a task with enhanced status handling
@@ -106,7 +106,7 @@ export function useBAppsCampaignProgress() {
 
       return null
     },
-    [account.address, defaultChainId, fetchProgress],
+    [account.address, defaultChainId],
   )
 
   // Fetch progress on mount and when dependencies change


### PR DESCRIPTION
## Summary
- Fixed React hooks violations by moving hooks before conditional returns in TopPools.tsx
- Removed unused MAX_BOOSTED_POOLS variable
- Fixed unnecessary dependencies in useCallback hooks in bappsCampaign/hooks.ts
- Updated import path in hardcodedTokens.ts

## Changes Made
- **TopPools.tsx**: Moved `useExploreStatsQuery` and `useTopPools` hooks to the top of the component, before any conditional returns
- **TopPools.tsx**: Removed unused `MAX_BOOSTED_POOLS` constant
- **bappsCampaign/hooks.ts**: Removed unnecessary `fetchProgress` dependency from useCallback hooks
- **hardcodedTokens.ts**: Fixed import path to use absolute path

## Test Plan
- [x] ESLint passes without errors (`yarn lint`)
- [x] TypeScript compilation succeeds (`yarn typecheck`)
- [x] Pre-commit hooks pass