### PR TITLE
fix: Prioritize trusted token check before safety info validation

### DIFF
--- a/packages/uniswap/src/features/tokens/safetyUtils.ts
+++ b/packages/uniswap/src/features/tokens/safetyUtils.ts
@@ -85,20 +85,27 @@ export function getTokenProtectionFeeOnTransfer(currencyInfo: Maybe<CurrencyInfo
 
 // eslint-disable-next-line complexity
 export function getTokenProtectionWarning(currencyInfo?: Maybe<CurrencyInfo>): TokenProtectionWarning {
-  if (!currencyInfo?.currency || !currencyInfo.safetyInfo) {
+  if (!currencyInfo?.currency) {
     return TokenProtectionWarning.NonDefault
   }
-  const { currency, safetyInfo } = currencyInfo
 
-  const { protectionResult, attackType } = safetyInfo
+  const { currency } = currencyInfo
+
   if (currency instanceof NativeCurrency) {
     return TokenProtectionWarning.None
   }
 
-  // Skip warnings for hardcoded trusted tokens
+  // Skip warnings for hardcoded trusted tokens (check this before safetyInfo check)
   if (isHardcodedTrustedToken(currency)) {
     return TokenProtectionWarning.None
   }
+
+  if (!currencyInfo.safetyInfo) {
+    return TokenProtectionWarning.NonDefault
+  }
+
+  const { safetyInfo } = currencyInfo
+  const { protectionResult, attackType } = safetyInfo
 
   const { maxFeePercent: feeOnTransfer } = getTokenProtectionFeeOnTransfer(currencyInfo)
 


### PR DESCRIPTION
## Summary
Fixed token safety warnings incorrectly showing for trusted tokens like USDC on Citrea testnet.

## Problem
Trusted tokens were showing "Always do your research" warnings even though they were in the hardcoded trusted tokens list. This happened because the safety info check occurred before the trusted token check.

## Solution
Reordered the validation logic in `getTokenProtectionWarning()`:
1. Check if currency exists
2. Check if it's a native currency → no warning
3. **Check if it's a trusted token → no warning** (moved this before safety info check)
4. Only then check if safety info is missing → show warning

## Changes
- Modified `packages/uniswap/src/features/tokens/safetyUtils.ts`
- Moved `isHardcodedTrustedToken()` check before `safetyInfo` validation
- This prevents false warnings for trusted tokens without safety data

## Test Plan
- [x] Tested USDC swap on Citrea testnet - no warning appears
- [x] Verified other trusted tokens (cUSD, NUSD, WcBTC, TFC) don't show warnings
- [x] Confirmed non-trusted tokens still show appropriate warnings
- [x] ESLint and TypeScript checks pass