### PR TITLE
fix: Remove intro parameter from logo navigation

### DIFF
--- a/apps/web/src/components/NavBar/CompanyMenu/index.tsx
+++ b/apps/web/src/components/NavBar/CompanyMenu/index.tsx
@@ -27,7 +27,7 @@ export function CompanyMenu() {
           group
           $platform-web={{ containerType: 'normal' }}
         >
-          <Link to="/?intro=true" style={{ textDecoration: 'none' }}>
+          <Link to="/" style={{ textDecoration: 'none' }}>
             <Flex row alignItems="center" gap="$gap4" data-testid={TestID.NavUniswapLogo}>
               <NavIcon />
               {isLargeScreen && (

--- a/apps/web/src/pages/Landing/index.tsx
+++ b/apps/web/src/pages/Landing/index.tsx
@@ -1,4 +1,3 @@
-import { useWeb3React } from '@web3-react/core'
 import { useAccountDrawer } from 'components/AccountDrawer/MiniPortfolio/hooks'
 import { PRIVACY_SHARING_OPT_OUT_STORAGE_KEY } from 'components/PrivacyChoices/constants'
 import { useAccount } from 'hooks/useAccount'
@@ -6,9 +5,8 @@ import usePrevious from 'hooks/usePrevious'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import LandingV2 from 'pages/Landing/LandingV2'
-import { parse } from 'qs'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useLocation, useNavigate } from 'react-router'
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router'
 import { ExploreContextProvider } from 'state/explore'
 import { TRANSITION_DURATIONS } from 'theme/styles'
 import { useConversionTracking } from 'uniswap/src/data/rest/conversionTracking/useConversionTracking'
@@ -19,15 +17,8 @@ const privacySharingOptOutAtom = atomWithStorage<boolean>(PRIVACY_SHARING_OPT_OU
 
 export default function Landing() {
   const account = useAccount()
-  const { connector } = useWeb3React()
-  const disconnect = useCallback(() => {
-    connector.deactivate?.()
-    connector.resetState()
-  }, [connector])
 
   const [transition, setTransition] = useState(false)
-  const location = useLocation()
-  const queryParams = useMemo(() => parse(location.search, { ignoreQueryPrefix: true }), [location])
   const navigate = useNavigate()
   const accountDrawer = useAccountDrawer()
   const prevAccount = usePrevious(account.address)
@@ -64,12 +55,10 @@ export default function Landing() {
     const timeoutId = setTimeout(() => {
       if (redirectOnConnect.current) {
         navigate('/swap')
-      } else if (account.address && queryParams.intro) {
-        disconnect()
       }
     }, TRANSITION_DURATIONS.fast)
     return () => clearTimeout(timeoutId)
-  }, [account.address, prevAccount, accountDrawer, navigate, queryParams.intro, connector, disconnect])
+  }, [account.address, prevAccount, accountDrawer, navigate])
 
   return (
     <Trace logImpression page={InterfacePageName.LandingPage}>


### PR DESCRIPTION
## Summary
- Remove `?intro=true` parameter from JuiceSwap logo link in navbar
- Clean up unused disconnect logic and imports in Landing component
- Simplify navigation behavior to maintain wallet connection state

## Changes
- **NavBar**: Updated logo link from `/?intro=true` to `/`
- **Landing component**: 
  - Removed unused `disconnect()` function and related logic
  - Cleaned up unused imports (`useWeb3React`, `parse`, `useCallback`, `useMemo`, `useLocation`)
  - Simplified useEffect dependency array
  - Removed conditional disconnect behavior based on intro parameter

## Motivation
The `?intro=true` parameter was intended to disconnect wallets when clicking the logo, but was not working consistently in practice. Removing this simplifies the navigation behavior and ensures users remain connected when navigating to the landing page.

## Test plan
- [x] Logo navigation works correctly
- [x] Wallet connection state is preserved when clicking logo
- [x] Landing page functions normally without intro parameter logic