### PR TITLE
fix: Add logo URLs for Citrea testnet tokens

### DIFF
--- a/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
+++ b/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
@@ -37,10 +37,18 @@ export const TokenLogo = memo(function _TokenLogo({
 }: TokenLogoProps): JSX.Element {
   const isTestnetToken = !!chainId && isTestnetChain(chainId)
 
-  // Override logo URL for cBTC and WcBTC tokens on Citrea Testnet
+  // Override logo URLs for Citrea Testnet tokens
   let logoUrl = url
-  if ((symbol === 'WcBTC' || symbol === 'cBTC') && chainId === UniverseChainId.CitreaTestnet) {
-    logoUrl = 'https://docs.juiceswap.xyz/media/icons/cbtc.png'
+  if (chainId === UniverseChainId.CitreaTestnet) {
+    const tokenLogoOverrides: Record<string, string> = {
+      WcBTC: 'https://docs.juiceswap.xyz/media/icons/cbtc.png',
+      cBTC: 'https://docs.juiceswap.xyz/media/icons/cbtc.png',
+      cUSD: 'https://docs.juiceswap.xyz/media/icons/cusd.png',
+      NUSD: 'https://docs.juiceswap.xyz/media/icons/nusd.png',
+    }
+    if (symbol && tokenLogoOverrides[symbol]) {
+      logoUrl = tokenLogoOverrides[symbol]
+    }
   }
 
   // We want to avoid the extra render on mobile when updating the state, so we set this to `true` from the start.

--- a/packages/uniswap/src/features/tokens/hardcodedTokens.ts
+++ b/packages/uniswap/src/features/tokens/hardcodedTokens.ts
@@ -46,7 +46,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
       name: 'Citrus Dollar',
     }) as Currency,
     currencyId: `${UniverseChainId.CitreaTestnet}-0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0`,
-    logoUrl: '',
+    logoUrl: 'https://docs.juiceswap.xyz/media/icons/cusd.png',
   },
   {
     currency: buildCurrency({
@@ -79,7 +79,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
       name: 'Nectra USD',
     }) as Currency,
     currencyId: `${UniverseChainId.CitreaTestnet}-0x9B28B690550522608890C3C7e63c0b4A7eBab9AA`,
-    logoUrl: '',
+    logoUrl: 'https://docs.juiceswap.xyz/media/icons/nusd.png',
   },
   {
     currency: buildCurrency({


### PR DESCRIPTION
## Summary
- Added logo URLs for cUSD and NUSD tokens on Citrea testnet
- Refactored TokenLogo component to use a cleaner override pattern for token logos
- Ensures consistent token branding across all interfaces

## Changes
- Set `logoUrl` for cUSD token to `https://docs.juiceswap.xyz/media/icons/cusd.png`
- Set `logoUrl` for NUSD token to `https://docs.juiceswap.xyz/media/icons/nusd.png`
- Refactored TokenLogo.tsx to use a Record-based lookup for logo overrides (reduces complexity)

## Test Plan
- [ ] Token logos display correctly in the swap interface
- [ ] Token logos display correctly in the explore page
- [ ] Token logos display correctly in token selector