### PR TITLE
fix: Correct Explore Token button link on landing page

### DIFF
--- a/apps/web/src/pages/Landing/components/cards/WebappCard.tsx
+++ b/apps/web/src/pages/Landing/components/cards/WebappCard.tsx
@@ -198,7 +198,7 @@ export function WebappCard() {
   const { t } = useTranslation()
   return (
     <ValuePropCard
-      to="/tokens/ethereum"
+      to="/explore/tokens/"
       minHeight={500}
       color={primary}
       $theme-dark={{


### PR DESCRIPTION
## Summary
- Update WebappCard to link to `/explore/tokens/` instead of `/tokens/ethereum`
- Ensures consistent navigation to the token exploration page

## Issue
The "Explore Token" button on the landing page was linking to `/tokens/ethereum` which is incorrect. It should link to `/explore/tokens/` to properly navigate users to the token exploration interface.

## Changes
✅ Fixed WebappCard component to use correct explore tokens route
✅ Maintains consistent navigation patterns across the app

## Test plan
- [x] Landing page "Explore Token" button now links to `/explore/tokens/`
- [x] Navigation works correctly on localhost:3001