### PR TITLE
fix: Complete token logo implementation for TFC and USDC

### DIFF
--- a/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
+++ b/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
@@ -45,6 +45,8 @@ export const TokenLogo = memo(function _TokenLogo({
       cBTC: 'https://docs.juiceswap.xyz/media/icons/cbtc.png',
       cUSD: 'https://docs.juiceswap.xyz/media/icons/cusd.png',
       NUSD: 'https://docs.juiceswap.xyz/media/icons/nusd.png',
+      TFC: 'https://docs.juiceswap.xyz/media/icons/tfc.png',
+      USDC: 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png',
     }
     if (symbol && tokenLogoOverrides[symbol]) {
       logoUrl = tokenLogoOverrides[symbol]

--- a/packages/uniswap/src/features/tokens/hardcodedTokens.ts
+++ b/packages/uniswap/src/features/tokens/hardcodedTokens.ts
@@ -35,7 +35,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
       name: 'TaprootFreakCoin',
     }) as Currency,
     currencyId: `${UniverseChainId.Sepolia}-0x14ADf6B87096Ef750a956756BA191fc6BE94e473`,
-    logoUrl: '',
+    logoUrl: 'https://docs.juiceswap.xyz/media/icons/tfc.png',
   },
   {
     currency: buildCurrency({
@@ -68,7 +68,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
       name: 'USDC (Satsuma)',
     }) as Currency,
     currencyId: `${UniverseChainId.CitreaTestnet}-0x36c16eaC6B0Ba6c50f494914ff015fCa95B7835F`,
-    logoUrl: '',
+    logoUrl: 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png',
   },
   {
     currency: buildCurrency({
@@ -90,7 +90,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
       name: 'TaprootFreakCoin',
     }) as Currency,
     currencyId: `${UniverseChainId.CitreaTestnet}-0x14ADf6B87096Ef750a956756BA191fc6BE94e473`,
-    logoUrl: '',
+    logoUrl: 'https://docs.juiceswap.xyz/media/icons/tfc.png',
   },
 ]
 


### PR DESCRIPTION
## Summary
- Add logo URLs for TFC tokens on both Sepolia and Citrea Testnet
- Add logo URL for USDC token on Citrea Testnet
- Update TokenLogo component to include TFC and USDC in logo overrides
- Ensures consistent logo display across all Citrea tokens

## Changes
✅ **hardcodedTokens.ts** - Added logo URLs:
  - TFC (Sepolia): `https://docs.juiceswap.xyz/media/icons/tfc.png`
  - TFC (CitreaTestnet): `https://docs.juiceswap.xyz/media/icons/tfc.png`
  - USDC (CitreaTestnet): `https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png`

✅ **TokenLogo.tsx** - Added override rules:
  - TFC: `https://docs.juiceswap.xyz/media/icons/tfc.png`
  - USDC: `https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png`

## Test plan
- [x] TFC tokens display correct logo on both Sepolia and Citrea
- [x] USDC token displays correct logo on Citrea Testnet
- [x] All tokens (cUSD, NUSD, cBTC, TFC, USDC) have consistent logo implementation
- [x] Logo overrides work correctly in TokenLogo component