### PR TITLE
fix: Hide Web app and Liquidity Provision cards from landing page

### DIFF
--- a/apps/web/src/pages/Landing/sections/AppsOverview.tsx
+++ b/apps/web/src/pages/Landing/sections/AppsOverview.tsx
@@ -14,8 +14,8 @@ export function AppsOverview() {
         <H2>{t('landing.appsOverview')}</H2>
         <Flex gap="$gap16">
           <Flex row flexWrap="wrap" height="auto" flex={1} gap="$gap16" $md={{ flexDirection: 'column' }}>
-            <WebappCard />
-            <LiquidityCard />
+            {/* <WebappCard /> */}
+            {/* <LiquidityCard /> */}
             <TradingApiCard />
             <CitreaCampaignCard />
           </Flex>


### PR DESCRIPTION
## Summary
Removes the Web app and Liquidity Provision cards from the landing page to simplify the presentation.

## Changes
- Commented out `<WebappCard />` component
- Commented out `<LiquidityCard />` component
- TradingApiCard and CitreaCampaignCard remain visible

## Test Plan
- [x] Verify landing page loads correctly
- [x] Confirm Web app card is hidden
- [x] Confirm Liquidity Provision card is hidden
- [x] Ensure remaining cards display properly