### PR TITLE
fix: Update Trading API documentation URL

### DIFF
--- a/packages/uniswap/src/constants/urls.ts
+++ b/packages/uniswap/src/constants/urls.ts
@@ -96,7 +96,7 @@ export const uniswapUrls = {
     wethExplainer: createHelpArticleUrl('16015852009997-Why-do-ETH-swaps-involve-converting-to-WETH'),
   },
   downloadWalletUrl: 'https://wallet.juiceswap.xyz/',
-  tradingApiDocsUrl: 'https://hub.juiceswap.xyz/',
+  tradingApiDocsUrl: 'https://api.juiceswap.xyz/',
   unichainUrl: 'https://www.unichain.org/',
   uniswapXUrl: 'https://x.juiceswap.xyz/',
   helpCenterUrl: 'https://help.juiceswap.xyz/',


### PR DESCRIPTION
## Summary
Updates the Trading API documentation URL from hub.juiceswap.xyz to api.juiceswap.xyz

## Changes
- Modified `tradingApiDocsUrl` in `/packages/uniswap/src/constants/urls.ts`
- Changed from `https://hub.juiceswap.xyz/` to `https://api.juiceswap.xyz/`

## Impact
- Trading API card on landing page now links to api.juiceswap.xyz
- Navigation menu API link updated
- All references to `uniswapUrls.tradingApiDocsUrl` now use the new URL

## Test Plan
- [x] Verify Trading API card button redirects to new URL
- [x] Check navigation menu API link works correctly
- [x] Ensure no broken links