### PR TITLE
fix: Remove Privacy Policy link from footer

### DIFF
--- a/apps/web/src/pages/Landing/sections/Footer.tsx
+++ b/apps/web/src/pages/Landing/sections/Footer.tsx
@@ -68,7 +68,7 @@ export function Footer() {
       >
         <Text variant="body3">© {currentYear} - JuiceSwap Labs</Text>
         <Flex row alignItems="center" gap="$spacing16">
-          <PolicyLink onPress={togglePrivacyPolicy}>{t('common.privacyPolicy')}</PolicyLink>
+          {/* <PolicyLink onPress={togglePrivacyPolicy}>{t('common.privacyPolicy')}</PolicyLink> */}
           <Anchor
             textDecorationLine="none"
             href="https://github.com/JuiceSwapxyz/documentation/tree/main/media_kit"


### PR DESCRIPTION
## Summary
Removes the Privacy Policy link from the landing page footer to simplify navigation.

## Changes
- Commented out Privacy Policy link in Footer component
- Brand Assets link remains unchanged and functional

## Impact
- Footer now only displays Brand Assets link
- Privacy Policy modal remains in codebase but is no longer accessible from footer

## Test Plan
- [x] Verify footer loads correctly without Privacy Policy link
- [x] Confirm Brand Assets link still works
- [x] Check footer layout remains properly aligned