### PR TITLE
feat: Remove all Get Help buttons and support links

### DIFF
--- a/apps/web/src/components/Dialog/Dialog.tsx
+++ b/apps/web/src/components/Dialog/Dialog.tsx
@@ -1,4 +1,3 @@
-import { GetHelpHeader } from 'components/Modal/GetHelpHeader'
 import React from 'react'
 import { Button, ButtonEmphasis, ButtonVariant, Flex, FlexProps, Text, TextProps } from 'ui/src'
 import { Modal } from 'uniswap/src/components/modals/Modal'
@@ -61,7 +60,6 @@ export function Dialog({
 }: DialogProps): JSX.Element {
   return (
     <Modal alignment={alignment} isModalOpen={isOpen} name={modalName} onClose={onClose}>
-      {displayHelpCTA && <GetHelpHeader closeModal={onClose} />}
       <Flex
         flexDirection="column"
         alignItems={textAlign === 'center' ? 'center' : 'flex-start'}

--- a/apps/web/src/components/HelpModal/HelpContent.tsx
+++ b/apps/web/src/components/HelpModal/HelpContent.tsx
@@ -2,8 +2,6 @@ import { useTranslation } from 'react-i18next'
 import { Anchor, Flex, Text, TouchableArea } from 'ui/src'
 import { BookOpen } from 'ui/src/components/icons/BookOpen'
 import { ExternalLink } from 'ui/src/components/icons/ExternalLink'
-import { GraduationCap } from 'ui/src/components/icons/GraduationCap'
-import { SpeechBubbles } from 'ui/src/components/icons/SpeechBubbles'
 import { X } from 'ui/src/components/icons/X'
 import { uniswapUrls } from 'uniswap/src/constants/urls'
 import { TestID } from 'uniswap/src/test/fixtures/testIDs'
@@ -53,19 +51,9 @@ export function HelpContent({ onClose }: HelpContentProps) {
         </TouchableArea>
       </Flex>
       <HelpItem
-        icon={<GraduationCap size="$icon.20" color="$neutral2" />}
-        title={t('settings.action.help')}
-        href={uniswapUrls.helpUrl}
-      />
-      <HelpItem
         icon={<BookOpen size="$icon.20" color="$neutral2" />}
         title={t('common.docs')}
         href={uniswapUrls.docsUrl}
-      />
-      <HelpItem
-        icon={<SpeechBubbles size="$icon.20" color="$neutral2" />}
-        title={t('common.contactUs.button')}
-        href={uniswapUrls.helpRequestUrl}
       />
     </Flex>
   )

--- a/apps/web/src/components/Modal/GetHelpHeader.tsx
+++ b/apps/web/src/components/Modal/GetHelpHeader.tsx
@@ -1,37 +1,7 @@
-import { EnvelopeHeartIcon } from 'components/Icons/EnvelopeHeart'
 import { ReactNode } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router'
-import { Flex, ModalCloseIcon, TouchableArea, useSporeColors } from 'ui/src'
+import { Flex, ModalCloseIcon, TouchableArea } from 'ui/src'
 import { BackArrow } from 'ui/src/components/icons/BackArrow'
 import { Text } from 'ui/src/components/text/Text'
-import { uniswapUrls } from 'uniswap/src/constants/urls'
-
-function GetHelpButton({ url }: { url?: string }) {
-  const { t } = useTranslation()
-  const colors = useSporeColors()
-
-  return (
-    <Link to={url ?? uniswapUrls.helpUrl} style={{ textDecoration: 'none' }} target="_blank">
-      <Flex
-        row
-        width="fit-content"
-        borderRadius="$rounded16"
-        px="$spacing8"
-        py="$spacing4"
-        backgroundColor="$surface2"
-        gap="4px"
-        alignItems="center"
-        hoverStyle={{ backgroundColor: '$surface2Hovered' }}
-      >
-        <EnvelopeHeartIcon fill={colors.neutral2.val} />
-        <Text variant="body2" color="$neutral2">
-          {t('common.getHelp.button')}
-        </Text>
-      </Flex>
-    </Link>
-  )
-}
 
 interface GetHelpHeaderProps {
   closeModal: () => void
@@ -42,7 +12,7 @@ interface GetHelpHeaderProps {
   className?: string
 }
 
-export function GetHelpHeader({ title, goBack, link, closeModal, closeDataTestId, className }: GetHelpHeaderProps) {
+export function GetHelpHeader({ title, goBack, closeModal, closeDataTestId, className }: GetHelpHeaderProps) {
   return (
     <Flex row justifyContent="space-between" alignItems="center" gap="$spacing4" width="100%" className={className}>
       {goBack && (
@@ -55,8 +25,7 @@ export function GetHelpHeader({ title, goBack, link, closeModal, closeDataTestId
           <Text variant="body2">{title}</Text>
         </Flex>
       )}
-      <Flex row fill justifyContent="flex-end" alignItems="center" gap="10px">
-        <GetHelpButton url={link} />
+      <Flex row fill justifyContent="flex-end" alignItems="center">
         <ModalCloseIcon testId={closeDataTestId} onClose={closeModal} />
       </Flex>
     </Flex>

--- a/apps/web/src/components/swap/CitreaCampaignProgress.tsx
+++ b/apps/web/src/components/swap/CitreaCampaignProgress.tsx
@@ -151,48 +151,48 @@ export function CitreaCampaignProgress() {
       )}
       <ProgressContainer>
         <Flex row justifyContent="space-between" alignItems="center" width="100%">
-        <Flex gap="$spacing4">
-          <Flex row gap="$spacing8" alignItems="center">
-            <img src={CitreaLogo} alt="Citrea" width={20} height={20} />
-            <Text variant="body2" fontWeight="$semibold">
-              ₿apps Campaign Progress
+          <Flex gap="$spacing4">
+            <Flex row gap="$spacing8" alignItems="center">
+              <img src={CitreaLogo} alt="Citrea" width={20} height={20} />
+              <Text variant="body2" fontWeight="$semibold">
+                ₿apps Campaign Progress
+              </Text>
+            </Flex>
+            <Text variant="body4" color="$neutral2">
+              Complete 3 swaps to earn rewards
             </Text>
           </Flex>
-          <Text variant="body4" color="$neutral2">
-            Complete 3 swaps to earn rewards
+
+          <Text variant="body3" color="$neutral2">
+            {completedTasks.length}/3 completed
           </Text>
         </Flex>
 
-        <Text variant="body3" color="$neutral2">
-          {completedTasks.length}/3 completed
-        </Text>
-      </Flex>
+        <ProgressBar>
+          <ProgressFill width={`${progress}%`} />
+        </ProgressBar>
 
-      <ProgressBar>
-        <ProgressFill width={`${progress}%`} />
-      </ProgressBar>
-
-      <Flex row gap="$spacing8" width="100%" justifyContent="space-between">
-        {CAMPAIGN_TASKS.map((task) => {
-          const isCompleted = completedTasks.includes(task.id)
-          return (
-            <TaskButton
-              key={task.id}
-              size="small"
-              emphasis={isCompleted ? 'tertiary' : 'secondary'}
-              onPress={() => !isCompleted && handleTaskClick(task.url)}
-              disabled={isCompleted}
-              flex={1}
-            >
-              <Flex row gap="$spacing4" alignItems="center">
-                {isCompleted && <Text variant="body4">✓</Text>}
-                <Text variant="buttonLabel4">{task.name}</Text>
-              </Flex>
-            </TaskButton>
-          )
-        })}
-      </Flex>
-    </ProgressContainer>
+        <Flex row gap="$spacing8" width="100%" justifyContent="space-between">
+          {CAMPAIGN_TASKS.map((task) => {
+            const isCompleted = completedTasks.includes(task.id)
+            return (
+              <TaskButton
+                key={task.id}
+                size="small"
+                emphasis={isCompleted ? 'tertiary' : 'secondary'}
+                onPress={() => !isCompleted && handleTaskClick(task.url)}
+                disabled={isCompleted}
+                flex={1}
+              >
+                <Flex row gap="$spacing4" alignItems="center">
+                  {isCompleted && <Text variant="body4">✓</Text>}
+                  <Text variant="buttonLabel4">{task.name}</Text>
+                </Flex>
+              </TaskButton>
+            )
+          })}
+        </Flex>
+      </ProgressContainer>
     </>
   )
 }


### PR DESCRIPTION
## Summary
Removed all "Get Help" buttons and support.juiceswap.xyz links from the application as requested.

## Changes Made

### 1. GetHelpHeader Component
- Removed the GetHelpButton component entirely
- Removed imports for EnvelopeHeartIcon, Link, useTranslation, uniswapUrls
- Modal headers now only show title (if provided) and close button
- The `link` prop is now unused but kept for backward compatibility

### 2. HelpContent Dropdown
- Removed "Help Center" link (was linking to helpUrl)
- Removed "Contact Us" link (was linking to helpRequestUrl)
- Kept only the "Docs" link as it points to documentation
- Removed unused imports for GraduationCap and SpeechBubbles icons

### 3. Dialog Component
- Removed GetHelpHeader import
- Removed the conditional rendering of GetHelpHeader when `displayHelpCTA=true`
- The `displayHelpCTA` prop is now unused but kept for backward compatibility

## Impact
- All 12+ modals using GetHelpHeader no longer show help buttons
- Help dropdown menu simplified to only show Docs link
- All references to support.juiceswap.xyz have been removed from UI components
- Note: The support URLs still exist in constants/urls.ts but are no longer used in the UI

## Testing
- Type checking passes
- Application builds successfully
- Modal headers display correctly without help buttons