### PR TITLE
fix: Disable MiniWalletIcon to prevent missing wallet icon errors

### DIFF
--- a/apps/web/src/components/Identicon/StatusIcon.tsx
+++ b/apps/web/src/components/Identicon/StatusIcon.tsx
@@ -87,7 +87,8 @@ export default function StatusIcon({
   return (
     <IconWrapper size={size} data-testid="StatusIconRoot">
       <Identicon account={address ?? account?.address} size={size} />
-      {showMiniIcons && <MiniWalletIcon />}
+      {/* Disabled to prevent missing wallet icon errors */}
+      {/* {showMiniIcons && <MiniWalletIcon />} */}
       {hasSocks && showMiniIcons && <Socks />}
     </IconWrapper>
   )


### PR DESCRIPTION
## Summary
- Disable MiniWalletIcon rendering in StatusIcon component to prevent broken image elements
- Fixes missing wallet icons for unsupported wallet types (e.g., Rabby Wallet)
- Maintains clean Identicon appearance without failed image loads

## Changes
- Comment out MiniWalletIcon in StatusIcon component
- Prevents `<img>` elements with broken src attributes

## Test plan
- [x] Connect with various wallet types
- [x] Verify no broken image elements in browser dev tools
- [x] Confirm Identicons display cleanly without mini badges