### PR TITLE
fix: Remove Send and Receive buttons from portfolio interface

### DIFF
--- a/apps/web/src/components/AccountDrawer/AuthenticatedHeader.tsx
+++ b/apps/web/src/components/AccountDrawer/AuthenticatedHeader.tsx
@@ -1,7 +1,6 @@
 import { NetworkStatus } from '@apollo/client'
 import { CurrencyAmount, Token } from '@juiceswapxyz/sdk-core'
 import { MultiBlockchainAddressDisplay } from 'components/AccountDetails/MultiBlockchainAddressDisplay'
-import { ActionTile } from 'components/AccountDrawer/ActionTile'
 import { DownloadGraduatedWalletCard } from 'components/AccountDrawer/DownloadGraduatedWalletCard'
 import IconButton, { IconWithConfirmTextButton } from 'components/AccountDrawer/IconButton'
 import { EmptyWallet } from 'components/AccountDrawer/MiniPortfolio/EmptyWallet'
@@ -13,23 +12,18 @@ import { Power } from 'components/Icons/Power'
 import { Settings } from 'components/Icons/Settings'
 import StatusIcon from 'components/Identicon/StatusIcon'
 
-import { ReceiveModalState, receiveCryptoModalStateAtom } from 'components/ReceiveCryptoModal/state'
 import DelegationMismatchModal from 'components/delegation/DelegationMismatchModal'
 import { useAccount } from 'hooks/useAccount'
 import { useDisconnect } from 'hooks/useDisconnect'
 import { useIsUniExtensionConnected } from 'hooks/useIsUniExtensionConnected'
 import { useModalState } from 'hooks/useModalState'
 import { useSignOutWithPasskey } from 'hooks/useSignOutWithPasskey'
-import { useAtom } from 'jotai'
-import { SendFormModal } from 'pages/Swap/Send/SendFormModal'
 import { useCallback, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { useUserHasAvailableClaim, useUserUnclaimedAmount } from 'state/claim/hooks'
 import { CopyHelper } from 'theme/components/CopyHelper'
 import { Button, Flex, Text } from 'ui/src'
-import { ArrowDownCircleFilled } from 'ui/src/components/icons/ArrowDownCircleFilled'
-import { SendAction } from 'ui/src/components/icons/SendAction'
 import { Shine } from 'ui/src/loading/Shine'
 import AnimatedNumber, {
   BALANCE_CHANGE_INDICATION_DURATION,
@@ -54,7 +48,6 @@ import i18next from 'uniswap/src/i18n'
 import { TestID } from 'uniswap/src/test/fixtures/testIDs'
 import { shortenAddress } from 'utilities/src/addresses'
 import { NumberType } from 'utilities/src/format/types'
-import { useEvent } from 'utilities/src/react/hooks'
 
 export default function AuthenticatedHeader({ account, openSettings }: { account: string; openSettings: () => void }) {
   const disconnect = useDisconnect()
@@ -62,8 +55,6 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
   const { t } = useTranslation()
   const navigate = useNavigate()
   const wallet = useWallet()
-
-  const [, setReceiveModalState] = useAtom(receiveCryptoModalStateAtom)
 
   const isUniExtensionConnected = useIsUniExtensionConnected()
   const isExtensionDeeplinkingDisabled = useFeatureFlag(FeatureFlags.DisableExtensionDeeplinks)
@@ -96,15 +87,6 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
     accountDrawer.close()
     navigate(`/buy`, { replace: true })
   }, [accountDrawer, navigate])
-
-  const openAddressQRModal = useEvent(() => setReceiveModalState(ReceiveModalState.QR_CODE))
-  const openCEXTransferModal = useEvent(() => setReceiveModalState(ReceiveModalState.CEX_TRANSFER))
-  const openReceiveCryptoModal = useEvent(() => setReceiveModalState(ReceiveModalState.DEFAULT))
-  const {
-    isOpen: isSendFormModalOpen,
-    openModal: openSendFormModal,
-    closeModal: closeSendFormModal,
-  } = useModalState(ModalName.Send)
 
   const { data, networkStatus, loading } = usePortfolioTotalValue({
     address: account,
@@ -212,27 +194,9 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
           ) : (
             <>
               {isPortfolioZero ? (
-                <EmptyWallet
-                  handleBuyCryptoClick={handleBuyCryptoClick}
-                  handleReceiveCryptoClick={openAddressQRModal}
-                  handleCEXTransferClick={openCEXTransferModal}
-                />
+                <EmptyWallet handleBuyCryptoClick={handleBuyCryptoClick} />
               ) : (
                 <>
-                  <Flex row gap="$gap8">
-                    <ActionTile
-                      dataTestId={TestID.Send}
-                      Icon={<SendAction size={24} color="$accent1" />}
-                      name={t('common.send.button')}
-                      onClick={openSendFormModal}
-                    />
-                    <ActionTile
-                      dataTestId={TestID.WalletReceiveCrypto}
-                      Icon={<ArrowDownCircleFilled size={24} color="$accent1" />}
-                      name={t('common.receive')}
-                      onClick={openReceiveCryptoModal}
-                    />
-                  </Flex>
                   <DownloadGraduatedWalletCard />
                   <MiniPortfolio account={account} />
                 </>
@@ -251,7 +215,6 @@ export default function AuthenticatedHeader({ account, openSettings }: { account
           )}
         </Flex>
       </Flex>
-      {isSendFormModalOpen && <SendFormModal isModalOpen={isSendFormModalOpen} onClose={closeSendFormModal} />}
       {displayDelegationMismatchModal && (
         <DelegationMismatchModal onClose={() => setDisplayDelegationMismatchModal(false)} />
       )}

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/EmptyWallet.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/EmptyWallet.tsx
@@ -1,66 +1,15 @@
 import { useCallback, useMemo } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { Flex, Separator, Text, useIsDarkMode, useSporeColors } from 'ui/src'
+import { Flex, Separator, Text, useIsDarkMode } from 'ui/src'
 import { CRYPTO_PURCHASE_BACKGROUND_DARK, CRYPTO_PURCHASE_BACKGROUND_LIGHT } from 'ui/src/assets'
-import { ArrowDownCircle } from 'ui/src/components/icons/ArrowDownCircle'
 import { Buy as BuyIcon } from 'ui/src/components/icons/Buy'
 import type { ActionCardItem } from 'uniswap/src/components/misc/ActionCard'
 import { ActionCard } from 'uniswap/src/components/misc/ActionCard'
-import type { FORServiceProvider } from 'uniswap/src/features/fiatOnRamp/types'
-import { useCexTransferProviders } from 'uniswap/src/features/fiatOnRamp/useCexTransferProviders'
-import { getServiceProviderLogo } from 'uniswap/src/features/fiatOnRamp/utils'
 import { ElementName } from 'uniswap/src/features/telemetry/constants'
 
-const ICON_SIZE = 28
-const ICON_SHIFT = 18
-
-function CEXTransferLogo({ providers }: { providers: FORServiceProvider[] }) {
-  const colors = useSporeColors()
-  const isDarkMode = useIsDarkMode()
-  const displayProviders = providers.slice(0, 3)
-  const totalLogos = displayProviders.length
-
-  return (
-    <Flex height={ICON_SIZE} width={totalLogos === 1 ? ICON_SIZE : ICON_SIZE + (totalLogos - 1) * ICON_SHIFT}>
-      {displayProviders.map((provider, index) => (
-        <Flex
-          key={provider.serviceProvider}
-          position="absolute"
-          left={totalLogos === 1 ? 0 : index * ICON_SHIFT}
-          borderRadius="$rounded8"
-          zIndex={-index}
-        >
-          <img
-            key={provider.serviceProvider}
-            width={ICON_SIZE}
-            height={ICON_SIZE}
-            src={getServiceProviderLogo(provider.logos, isDarkMode)}
-            alt={provider.name}
-            style={{
-              borderRadius: 8,
-              borderWidth: 2,
-              borderStyle: 'solid',
-              borderColor: colors.surface1.val,
-            }}
-          />
-        </Flex>
-      ))}
-    </Flex>
-  )
-}
-
-export const EmptyWallet = ({
-  handleBuyCryptoClick,
-  handleReceiveCryptoClick,
-  handleCEXTransferClick,
-}: {
-  handleBuyCryptoClick: () => void
-  handleReceiveCryptoClick: () => void
-  handleCEXTransferClick: () => void
-}) => {
+export const EmptyWallet = ({ handleBuyCryptoClick }: { handleBuyCryptoClick: () => void }) => {
   const { t } = useTranslation()
   const isDarkMode = useIsDarkMode()
-  const providers = useCexTransferProviders()
 
   const BackgroundImageWrapperCallback = useCallback(
     ({ children }: { children: React.ReactNode }) => {
@@ -83,33 +32,8 @@ export const EmptyWallet = ({
         onPress: handleBuyCryptoClick,
         BackgroundImageWrapperCallback,
       },
-      {
-        title: t('home.empty.transfer'),
-        blurb: t('home.empty.transfer.description'),
-        elementName: ElementName.EmptyStateReceive,
-        icon: <ArrowDownCircle color="$accent1" size="$icon.28" />,
-        onPress: handleReceiveCryptoClick,
-      },
-      ...(providers.length > 0
-        ? [
-            {
-              title: t('home.empty.cexTransfer'),
-              blurb: t('home.empty.cexTransfer.description'),
-              elementName: ElementName.EmptyStateCEXTransfer,
-              icon: <CEXTransferLogo providers={providers} />,
-              onPress: handleCEXTransferClick,
-            },
-          ]
-        : []),
     ],
-    [
-      providers,
-      BackgroundImageWrapperCallback,
-      handleBuyCryptoClick,
-      handleReceiveCryptoClick,
-      handleCEXTransferClick,
-      t,
-    ],
+    [BackgroundImageWrapperCallback, handleBuyCryptoClick, t],
   )
 
   return (

--- a/apps/web/src/components/swap/CitreaCampaignProgress.tsx
+++ b/apps/web/src/components/swap/CitreaCampaignProgress.tsx
@@ -151,48 +151,48 @@ export function CitreaCampaignProgress() {
       )}
       <ProgressContainer>
         <Flex row justifyContent="space-between" alignItems="center" width="100%">
-        <Flex gap="$spacing4">
-          <Flex row gap="$spacing8" alignItems="center">
-            <img src={CitreaLogo} alt="Citrea" width={20} height={20} />
-            <Text variant="body2" fontWeight="$semibold">
-              ₿apps Campaign Progress
+          <Flex gap="$spacing4">
+            <Flex row gap="$spacing8" alignItems="center">
+              <img src={CitreaLogo} alt="Citrea" width={20} height={20} />
+              <Text variant="body2" fontWeight="$semibold">
+                ₿apps Campaign Progress
+              </Text>
+            </Flex>
+            <Text variant="body4" color="$neutral2">
+              Complete 3 swaps to earn rewards
             </Text>
           </Flex>
-          <Text variant="body4" color="$neutral2">
-            Complete 3 swaps to earn rewards
+
+          <Text variant="body3" color="$neutral2">
+            {completedTasks.length}/3 completed
           </Text>
         </Flex>
 
-        <Text variant="body3" color="$neutral2">
-          {completedTasks.length}/3 completed
-        </Text>
-      </Flex>
+        <ProgressBar>
+          <ProgressFill width={`${progress}%`} />
+        </ProgressBar>
 
-      <ProgressBar>
-        <ProgressFill width={`${progress}%`} />
-      </ProgressBar>
-
-      <Flex row gap="$spacing8" width="100%" justifyContent="space-between">
-        {CAMPAIGN_TASKS.map((task) => {
-          const isCompleted = completedTasks.includes(task.id)
-          return (
-            <TaskButton
-              key={task.id}
-              size="small"
-              emphasis={isCompleted ? 'tertiary' : 'secondary'}
-              onPress={() => !isCompleted && handleTaskClick(task.url)}
-              disabled={isCompleted}
-              flex={1}
-            >
-              <Flex row gap="$spacing4" alignItems="center">
-                {isCompleted && <Text variant="body4">✓</Text>}
-                <Text variant="buttonLabel4">{task.name}</Text>
-              </Flex>
-            </TaskButton>
-          )
-        })}
-      </Flex>
-    </ProgressContainer>
+        <Flex row gap="$spacing8" width="100%" justifyContent="space-between">
+          {CAMPAIGN_TASKS.map((task) => {
+            const isCompleted = completedTasks.includes(task.id)
+            return (
+              <TaskButton
+                key={task.id}
+                size="small"
+                emphasis={isCompleted ? 'tertiary' : 'secondary'}
+                onPress={() => !isCompleted && handleTaskClick(task.url)}
+                disabled={isCompleted}
+                flex={1}
+              >
+                <Flex row gap="$spacing4" alignItems="center">
+                  {isCompleted && <Text variant="body4">✓</Text>}
+                  <Text variant="buttonLabel4">{task.name}</Text>
+                </Flex>
+              </TaskButton>
+            )
+          })}
+        </Flex>
+      </ProgressContainer>
     </>
   )
 }


### PR DESCRIPTION
## Summary
Removes Send and Receive functionality from the portfolio interface as requested.

## Changes Made
- ✅ Remove Send/Receive ActionTiles from AuthenticatedHeader when portfolio has balance
- ✅ Simplify EmptyWallet to show only "Buy crypto" option  
- ✅ Remove Transfer and CEX Transfer options from empty wallet state
- ✅ Clean up unused imports and handler functions

## Files Modified
- `apps/web/src/components/AccountDrawer/AuthenticatedHeader.tsx`
- `apps/web/src/components/AccountDrawer/MiniPortfolio/EmptyWallet.tsx`

## Quality Assurance
- ✅ TypeScript compilation passes
- ✅ ESLint passes without warnings
- ✅ Production build successful
- ✅ Code properly formatted with Prettier

## Test Plan
- [ ] Verify Send/Receive buttons are no longer visible in portfolio area
- [ ] Confirm empty wallet only shows "Buy crypto" option
- [ ] Test that existing functionality (buy, portfolio display) still works
- [ ] Verify no console errors or runtime issues

🤖 Generated with [Claude Code](https://claude.ai/code)