### PR TITLE
feat: Enable token search by contract address in navbar

### DIFF
--- a/packages/uniswap/src/features/search/SearchModal/SearchModalList.tsx
+++ b/packages/uniswap/src/features/search/SearchModal/SearchModalList.tsx
@@ -59,8 +59,13 @@ export const SearchModalList = memo(function _SearchModalList({
   onSelect,
   searchFilters,
 }: SearchModalListProps): JSX.Element {
-  const { navigateToTokenDetails, navigateToExternalProfile, navigateToNftCollection, navigateToPoolDetails } =
-    useUniswapContext()
+  const {
+    navigateToTokenDetails,
+    navigateToExternalProfile,
+    navigateToNftCollection,
+    navigateToPoolDetails,
+    navigateToSwapFlow,
+  } = useUniswapContext()
   const { registerSearchItem } = useAddToSearchHistory()
 
   const { value: isContextMenuOpen, setFalse: closeContextMenu, toggle: toggleContextMenu } = useBooleanState(false)
@@ -181,7 +186,13 @@ export const SearchModalList = memo(function _SearchModalList({
             onPress={() => {
               registerSearchItem(item)
 
-              navigateToTokenDetails(item.currencyInfo.currencyId)
+              if (isWeb) {
+                // On web, navigate to swap with token as output (buy) token
+                navigateToSwapFlow({ outputCurrencyId: item.currencyInfo.currencyId })
+              } else {
+                // On mobile, navigate to token details as before
+                navigateToTokenDetails(item.currencyInfo.currencyId)
+              }
 
               sendSearchOptionItemClickedAnalytics({
                 item,

--- a/packages/uniswap/src/features/search/SearchModal/SearchModalResultsList.tsx
+++ b/packages/uniswap/src/features/search/SearchModal/SearchModalResultsList.tsx
@@ -12,9 +12,9 @@ import { useCollectionSearchQuery } from 'uniswap/src/data/graphql/uniswap-data-
 import { fetchTokenDataDirectly, searchTokenToCurrencyInfo } from 'uniswap/src/data/rest/searchTokensAndPools'
 import { GqlResult } from 'uniswap/src/data/types'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
-import { CurrencyInfo } from 'uniswap/src/features/dataApi/types'
 import { useSearchPools } from 'uniswap/src/features/dataApi/searchPools'
 import { useSearchTokens } from 'uniswap/src/features/dataApi/searchTokens'
+import { CurrencyInfo } from 'uniswap/src/features/dataApi/types'
 import { Platform } from 'uniswap/src/features/platforms/types/Platform'
 import { SearchModalList, SearchModalListProps } from 'uniswap/src/features/search/SearchModal/SearchModalList'
 import { NUMBER_OF_RESULTS_SHORT } from 'uniswap/src/features/search/SearchModal/constants'
@@ -121,10 +121,8 @@ function useSectionsForSearchResults({
   )
 
   // Convert search results to token options
-  const regularTokenResults = useMemo(
-    () => useCurrencyInfosToTokenOptions({ currencyInfos: searchResultCurrencies }) || [],
-    [searchResultCurrencies],
-  )
+  const convertedTokenResults = useCurrencyInfosToTokenOptions({ currencyInfos: searchResultCurrencies })
+  const regularTokenResults = useMemo(() => convertedTokenResults || [], [convertedTokenResults])
 
   // Combine regular search results with direct token search
   const combinedTokenResults = useMemo(() => {

--- a/packages/uniswap/src/features/search/SearchModal/SearchModalResultsList.tsx
+++ b/packages/uniswap/src/features/search/SearchModal/SearchModalResultsList.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCurrencyInfosToTokenOptions } from 'uniswap/src/components/TokenSelector/hooks/useCurrencyInfosToTokenOptions'
@@ -8,8 +9,10 @@ import { usePoolSearchResultsToPoolOptions } from 'uniswap/src/components/lists/
 import { OnchainItemListOptionType, SearchModalOption, WalletOption } from 'uniswap/src/components/lists/items/types'
 import { useOnchainItemListSection } from 'uniswap/src/components/lists/utils'
 import { useCollectionSearchQuery } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
+import { fetchTokenDataDirectly, searchTokenToCurrencyInfo } from 'uniswap/src/data/rest/searchTokensAndPools'
 import { GqlResult } from 'uniswap/src/data/types'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { CurrencyInfo } from 'uniswap/src/features/dataApi/types'
 import { useSearchPools } from 'uniswap/src/features/dataApi/searchPools'
 import { useSearchTokens } from 'uniswap/src/features/dataApi/searchTokens'
 import { Platform } from 'uniswap/src/features/platforms/types/Platform'
@@ -22,16 +25,67 @@ import { getValidAddress } from 'uniswap/src/utils/addresses'
 import { isWeb } from 'utilities/src/platform'
 import noop from 'utilities/src/react/noop'
 
+// Hook to search for tokens directly by address
+function useDirectTokenSearch(
+  address: string | null,
+  chainId: UniverseChainId | null,
+): { data: CurrencyInfo | null | undefined; isLoading: boolean } {
+  const result = useQuery({
+    queryKey: ['directTokenSearch', address, chainId],
+    queryFn: async () => {
+      if (!address || !chainId) {
+        return null
+      }
+      try {
+        const token = await fetchTokenDataDirectly(address, chainId)
+        return token ? searchTokenToCurrencyInfo(token) : null
+      } catch {
+        // Try other chains if the current one fails
+        const chainsToTry = [
+          UniverseChainId.CitreaTestnet,
+          UniverseChainId.Mainnet,
+          UniverseChainId.Base,
+          UniverseChainId.ArbitrumOne,
+          UniverseChainId.Optimism,
+        ].filter((c) => c !== chainId)
+
+        for (const fallbackChain of chainsToTry) {
+          try {
+            const token = await fetchTokenDataDirectly(address, fallbackChain)
+            if (token) {
+              return searchTokenToCurrencyInfo(token)
+            }
+          } catch {
+            continue
+          }
+        }
+        return null
+      }
+    },
+    enabled: !!address && !!chainId,
+    staleTime: 30000, // Cache for 30 seconds
+  })
+
+  return {
+    data: result.data,
+    isLoading: result.isLoading,
+  }
+}
+
 function useSectionsForSearchResults({
   chainFilter,
   searchFilter,
   activeTab,
   shouldPrioritizePools,
+  isValidAddress,
+  addressChainId,
 }: {
   chainFilter: UniverseChainId | null
   searchFilter: string | null
   activeTab: SearchTab
   shouldPrioritizePools: boolean
+  isValidAddress?: boolean
+  addressChainId?: UniverseChainId | null
 }): GqlResult<OnchainItemSection<SearchModalOption>[]> {
   const skipPoolSearchQuery = !isWeb || !searchFilter || (activeTab !== SearchTab.Pools && activeTab !== SearchTab.All)
   const {
@@ -60,14 +114,49 @@ function useSectionsForSearchResults({
     chainFilter,
     skip: !searchFilter || (activeTab !== SearchTab.Tokens && activeTab !== SearchTab.All),
   })
-  const tokenSearchResults = useCurrencyInfosToTokenOptions({ currencyInfos: searchResultCurrencies })
+  // Direct token search for addresses
+  const { data: directTokenResult, isLoading: directTokenLoading } = useDirectTokenSearch(
+    isValidAddress ? searchFilter : null,
+    addressChainId || null,
+  )
+
+  // Convert search results to token options
+  const regularTokenResults = useMemo(
+    () => useCurrencyInfosToTokenOptions({ currencyInfos: searchResultCurrencies }) || [],
+    [searchResultCurrencies],
+  )
+
+  // Combine regular search results with direct token search
+  const combinedTokenResults = useMemo(() => {
+    if (directTokenResult) {
+      // Convert to token option format
+      const directTokenOption = {
+        type: OnchainItemListOptionType.Token as const,
+        currencyInfo: directTokenResult,
+        quantity: null,
+        balanceUSD: null,
+      }
+
+      // Add direct token result at the beginning if it's not already in regular results
+      const existsInRegular = regularTokenResults.some(
+        (token) => token.currencyInfo.currencyId === directTokenResult.currencyId,
+      )
+
+      if (!existsInRegular) {
+        return [directTokenOption, ...regularTokenResults]
+      }
+    }
+
+    return regularTokenResults
+  }, [regularTokenResults, directTokenResult])
+
   const isPoolAddressSearch =
     searchFilter &&
     getValidAddress({ address: searchFilter, platform: Platform.EVM }) &&
     searchResultPools?.length === 1
   const tokenSearchResultsSection = useOnchainItemListSection({
     sectionKey: OnchainItemSectionName.Tokens,
-    options: isPoolAddressSearch ? [] : tokenSearchResults, // do not display tokens if pool address search (to avoid displaying V2 liquidity tokens in results)
+    options: isPoolAddressSearch ? [] : combinedTokenResults, // do not display tokens if pool address search (to avoid displaying V2 liquidity tokens in results)
   })
 
   const skipWalletSearchQuery = isWeb || (activeTab !== SearchTab.Wallets && activeTab !== SearchTab.All)
@@ -131,16 +220,16 @@ function useSectionsForSearchResults({
           ]
         }
         return {
-          data: !searchTokensLoading ? sections : [],
-          loading: searchTokensLoading, // only show loading&error state for loading tokens
-          error: (!tokenSearchResults && searchTokensError) || undefined,
+          data: !searchTokensLoading && !directTokenLoading ? sections : [],
+          loading: searchTokensLoading || directTokenLoading, // include direct token loading
+          error: (!tokenSearchResultsSection && searchTokensError) || undefined,
           refetch: refetchAll,
         }
       case SearchTab.Tokens:
         return {
           data: tokenSearchResultsSection ?? [],
-          loading: searchTokensLoading,
-          error: (!tokenSearchResults && searchTokensError) || undefined,
+          loading: searchTokensLoading || directTokenLoading,
+          error: (!tokenSearchResultsSection && searchTokensError) || undefined,
           refetch: refetchSearchTokens,
         }
       case SearchTab.Pools:
@@ -167,6 +256,7 @@ function useSectionsForSearchResults({
     }
   }, [
     activeTab,
+    directTokenLoading,
     nftCollectionSearchResultsSection,
     poolSearchOptions.length,
     poolSearchResultsSection,
@@ -182,7 +272,6 @@ function useSectionsForSearchResults({
     searchTokensError,
     searchTokensLoading,
     shouldPrioritizePools,
-    tokenSearchResults,
     tokenSearchResultsSection,
     walletSearchResultsLoading,
     walletSearchResultsSection,
@@ -210,6 +299,9 @@ function _SearchModalResultsList({
 }: SearchModalResultsListProps): JSX.Element {
   const { t } = useTranslation()
 
+  const isValidAddress = Boolean(searchFilter && getValidAddress({ address: searchFilter, platform: Platform.EVM }))
+  const addressChainId = isValidAddress ? chainFilter ?? parsedChainFilter ?? UniverseChainId.CitreaTestnet : null
+
   const {
     data: sections,
     loading,
@@ -221,6 +313,8 @@ function _SearchModalResultsList({
     searchFilter: debouncedParsedSearchFilter ?? debouncedSearchFilter,
     activeTab,
     shouldPrioritizePools: (debouncedParsedSearchFilter ?? debouncedSearchFilter)?.includes('/') ?? false,
+    isValidAddress,
+    addressChainId,
   })
 
   const userIsTyping = Boolean(searchFilter && debouncedSearchFilter !== searchFilter)

--- a/packages/uniswap/src/features/search/SearchModal/hooks/useFilterCallbacks.ts
+++ b/packages/uniswap/src/features/search/SearchModal/hooks/useFilterCallbacks.ts
@@ -5,6 +5,7 @@ import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { isTestnetChain } from 'uniswap/src/features/chains/utils'
 import { ModalNameType, WalletEventName } from 'uniswap/src/features/telemetry/constants'
 import { sendAnalyticsEvent } from 'uniswap/src/features/telemetry/send'
+import { isAddress } from 'utilities/src/addresses'
 
 export function useFilterCallbacks(
   chainId: UniverseChainId | null,
@@ -14,6 +15,8 @@ export function useFilterCallbacks(
   parsedChainFilter: UniverseChainId | null
   searchFilter: string | null
   parsedSearchFilter: string | null
+  isValidAddress: boolean
+  addressChainId: UniverseChainId | null
   onChangeChainFilter: (newChainFilter: UniverseChainId | null) => void
   onClearSearchFilter: () => void
   onChangeText: (newSearchFilter: string) => void
@@ -22,6 +25,8 @@ export function useFilterCallbacks(
   const [parsedChainFilter, setParsedChainFilter] = useState<UniverseChainId | null>(null)
   const [searchFilter, setSearchFilter] = useState<string | null>(null)
   const [parsedSearchFilter, setParsedSearchFilter] = useState<string | null>(null)
+  const [isValidAddress, setIsValidAddress] = useState<boolean>(false)
+  const [addressChainId, setAddressChainId] = useState<UniverseChainId | null>(null)
 
   const { chains: enabledChains } = useEnabledChains()
 
@@ -68,11 +73,26 @@ export function useFilterCallbacks(
 
   const onChangeText = useCallback((newSearchFilter: string) => setSearchFilter(newSearchFilter), [setSearchFilter])
 
+  // Check if search input is a valid Ethereum address
+  useEffect(() => {
+    const validAddress = isAddress(searchFilter)
+    setIsValidAddress(!!validAddress)
+
+    if (validAddress) {
+      // For valid addresses, use the current chain filter or default to CitreaTestnet
+      setAddressChainId(chainFilter || UniverseChainId.CitreaTestnet)
+    } else {
+      setAddressChainId(null)
+    }
+  }, [searchFilter, chainFilter])
+
   return {
     chainFilter,
     parsedChainFilter,
     searchFilter,
     parsedSearchFilter,
+    isValidAddress,
+    addressChainId,
     onChangeChainFilter,
     onClearSearchFilter,
     onChangeText,


### PR DESCRIPTION
## Summary
- Enable searching for tokens by entering contract addresses directly
- Navigate to swap interface with token as output when clicking token in search (web only)
- Automatically detect valid Ethereum addresses and search across multiple chains

## Changes
- Add direct token search functionality that queries token data by address
- Modify search result click behavior to navigate to swap with token as output on web
- Add address validation and chain fallback logic
- Try multiple chains if initial search fails (Citrea testnet, Mainnet, Base, etc.)

## Testing
1. Open navbar search on web
2. Paste a valid token contract address
3. Click on the token result - should navigate to swap with that token as output
4. On mobile, clicking should still navigate to token details page

This is a clean re-implementation of PR #166 with only the actual new changes.