### PR TITLE
fix: Remove all Get Help buttons from swap error modals

### DIFF
--- a/apps/web/src/pages/ExtensionPasskeyAuthPopUp/index.tsx
+++ b/apps/web/src/pages/ExtensionPasskeyAuthPopUp/index.tsx
@@ -1,12 +1,10 @@
-import { EnvelopeHeartIcon } from 'components/Icons/EnvelopeHeart'
 import { useExternallyConnectableExtensionId } from 'pages/ExtensionPasskeyAuthPopUp/useExternallyConnectableExtensionId'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router'
-import { Anchor, Button, Flex, SpinningLoader, Text } from 'ui/src'
+import { Button, Flex, SpinningLoader, Text } from 'ui/src'
 import { Passkey } from 'ui/src/components/icons/Passkey'
 import { UniswapLogo } from 'ui/src/components/icons/UniswapLogo'
-import { uniswapUrls } from 'uniswap/src/constants/urls'
 import { parseMessage } from 'uniswap/src/extension/messagePassing/platform'
 import {
   InterfaceToExtensionRequestType,
@@ -162,18 +160,6 @@ export default function ExtensionPasskeyAuthPopUp() {
       <Flex flexDirection="column" alignItems="center" justifyContent="center" minHeight="100vh">
         <Flex width="400px" padding="$spacing16" flexDirection="column" gap="$spacing16">
           <Flex row justifyContent="flex-end">
-            <Flex row width="fit-content">
-              <Anchor
-                target="_blank"
-                rel="noreferrer"
-                href={uniswapUrls.helpArticleUrls.passkeysInfo}
-                textDecorationLine="none"
-              >
-                <Button icon={<EnvelopeHeartIcon />} size="xxsmall" emphasis="secondary">
-                  {t('common.getHelp.button')}
-                </Button>
-              </Anchor>
-            </Flex>
           </Flex>
 
           <Flex alignItems="center">

--- a/packages/uniswap/src/features/passkey/PasskeysHelpModal.tsx
+++ b/packages/uniswap/src/features/passkey/PasskeysHelpModal.tsx
@@ -4,11 +4,8 @@ import { Button, Flex, Text, useSporeColors } from 'ui/src'
 import { AlertTriangleFilled } from 'ui/src/components/icons/AlertTriangleFilled'
 import { Passkey } from 'ui/src/components/icons/Passkey'
 import { Modal } from 'uniswap/src/components/modals/Modal'
-import { uniswapUrls } from 'uniswap/src/constants/urls'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import { ElementName, ModalName } from 'uniswap/src/features/telemetry/constants'
-import { TestID } from 'uniswap/src/test/fixtures/testIDs'
-import { openUri } from 'uniswap/src/utils/linking'
 import { isWeb } from 'utilities/src/platform'
 
 export enum PasskeysHelpModalTypes {
@@ -66,9 +63,6 @@ export function PasskeysHelpModal({
 }): JSX.Element {
   const { t } = useTranslation()
   const colors = useSporeColors()
-  const onPressGetHelp = async (): Promise<void> => {
-    await openUri({ uri: uniswapUrls.helpArticleUrls.passkeysInfo })
-  }
   const displayName = accountName ?? t('common.thisAccount')
   const modalContent = passkeysHelpModalContent[type]
   const title = modalContent.title(t)
@@ -111,11 +105,6 @@ export function PasskeysHelpModal({
         </Text>
 
         <Flex row alignSelf="stretch" gap="$spacing12" pt="$spacing24">
-          <Trace logPress element={ElementName.Confirm} modal={ModalName.PasskeysHelp}>
-            <Button testID={TestID.Confirm} emphasis="secondary" onPress={onPressGetHelp}>
-              <Text variant="buttonLabel2">{t('common.getHelp.button')}</Text>
-            </Button>
-          </Trace>
           <Trace logPress element={ElementName.BackButton} modal={ModalName.PasskeysHelp}>
             <Button emphasis="primary" onPress={onClose}>
               <Text variant="buttonLabel2" color="$surface1">

--- a/packages/uniswap/src/features/transactions/swap/review/SwapReviewScreen/SwapErrorScreen.tsx
+++ b/packages/uniswap/src/features/transactions/swap/review/SwapReviewScreen/SwapErrorScreen.tsx
@@ -1,10 +1,8 @@
 import { useTranslation } from 'react-i18next'
-import { Button, Flex, IconButton } from 'ui/src'
-import { HelpCenter } from 'ui/src/components/icons/HelpCenter'
+import { Flex, IconButton } from 'ui/src'
 import { X } from 'ui/src/components/icons/X'
 import { WarningModalContent } from 'uniswap/src/components/modals/WarningModal/WarningModal'
 import { WarningSeverity } from 'uniswap/src/components/modals/WarningModal/types'
-import { uniswapUrls } from 'uniswap/src/constants/urls'
 import { ModalName } from 'uniswap/src/features/telemetry/constants'
 import { TransactionModalInnerContainer } from 'uniswap/src/features/transactions/components/TransactionModal/TransactionModal'
 import { useTransactionModalContext } from 'uniswap/src/features/transactions/components/TransactionModal/TransactionModalContext'
@@ -14,7 +12,6 @@ import {
 } from 'uniswap/src/features/transactions/components/settings/stores/transactionSettingsStore/useTransactionSettingsStore'
 import { TransactionStepFailedError, getErrorContent } from 'uniswap/src/features/transactions/errors'
 import { TransactionStepType } from 'uniswap/src/features/transactions/steps/types'
-import { openUri } from 'uniswap/src/utils/linking'
 import { isWeb } from 'utilities/src/platform'
 
 export function SwapErrorScreen({
@@ -37,7 +34,7 @@ export function SwapErrorScreen({
   }))
   const { setSelectedProtocols } = useTransactionSettingsActions()
 
-  const { title, message, supportArticleURL, buttonText } = getErrorContent(t, submissionError)
+  const { title, message, buttonText } = getErrorContent(t, submissionError)
 
   const isUniswapXBackendError =
     submissionError instanceof TransactionStepFailedError &&
@@ -58,18 +55,11 @@ export function SwapErrorScreen({
     setSubmissionError(undefined)
   }
 
-  const onPressGetHelp = async (): Promise<void> => {
-    await openUri({ uri: supportArticleURL ?? uniswapUrls.helpUrl })
-  }
-
   return (
     <TransactionModalInnerContainer bottomSheetViewStyles={bottomSheetViewStyles} fullscreen={false}>
       <Flex gap="$spacing16">
         {isWeb && (
-          <Flex row justifyContent="flex-end" m="$spacing12" gap="$spacing8">
-            <Button fill={false} emphasis="tertiary" size="xxsmall" icon={<HelpCenter />} onPress={onPressGetHelp}>
-              {t('common.getHelp.button')}
-            </Button>
+          <Flex row justifyContent="flex-end" m="$spacing12">
             <IconButton size="xxsmall" variant="default" emphasis="text-only" icon={<X />} onPress={onClose} />
           </Flex>
         )}


### PR DESCRIPTION
## Problem
Users are constantly seeing a "Swap failed" error modal with a "Get Help" button that appears after swap failures. This button was attempting to open non-existent support URLs.

## Root Cause
- Commit #165 removed Get Help buttons from `apps/web` components
- But NOT from `packages/uniswap` cross-platform components
- The SwapErrorScreen in the uniswap package still had the Get Help button
- This component is used by all apps (Web, Mobile, Extension)

## Solution
Removed all remaining Get Help buttons from:
- SwapErrorScreen - the main culprit causing the swap error modal issue
- PasskeysHelpModal - removed unnecessary help button
- ExtensionPasskeyAuthPopUp - removed help link

## Impact
- Fixes the recurring swap error modal with Get Help button
- Prevents confusion from non-working support links
- Provides a cleaner error experience with just the retry option

## Testing
- TypeScript compilation passes
- No new linting errors introduced
- Swap error modal now only shows close button and retry option