### PR TITLE
Simplify navigation menu to show only Swap

### DIFF
--- a/apps/web/src/components/NavBar/Tabs/TabsContent.tsx
+++ b/apps/web/src/components/NavBar/Tabs/TabsContent.tsx
@@ -1,5 +1,3 @@
-import { CreditCardIcon } from 'components/Icons/CreditCard'
-import { Limit } from 'components/Icons/Limit'
 import { SwapV2 } from 'components/Icons/SwapV2'
 import { MenuItem } from 'components/NavBar/CompanyMenu/Content'
 import { useTheme } from 'lib/styled-components'
@@ -7,12 +5,8 @@ import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router'
 import { useIsBAppsCampaignVisible } from 'services/bappsCampaign/hooks'
 import { Text } from 'ui/src'
-import { CoinConvert } from 'ui/src/components/icons/CoinConvert'
 import { Compass } from 'ui/src/components/icons/Compass'
 import { Pools } from 'ui/src/components/icons/Pools'
-import { ReceiveAlt } from 'ui/src/components/icons/ReceiveAlt'
-import { FeatureFlags } from 'uniswap/src/features/gating/flags'
-import { useFeatureFlag } from 'uniswap/src/features/gating/hooks'
 
 export type TabsSection = {
   title: string
@@ -31,45 +25,14 @@ export const useTabsContent = (): TabsSection[] => {
   const { t } = useTranslation()
   const { pathname } = useLocation()
   const theme = useTheme()
-  const isFiatOffRampEnabled = useFeatureFlag(FeatureFlags.FiatOffRamp)
   const showBAppsTab = useIsBAppsCampaignVisible()
 
   const baseItems = [
     {
-      title: t('common.trade'),
+      title: t('common.swap'),
       href: '/swap',
-      isActive: pathname.startsWith('/swap') || pathname.startsWith('/limit') || pathname.startsWith('/send'),
-      icon: <CoinConvert color="$accent1" size="$icon.20" />,
-      items: [
-        {
-          label: t('common.swap'),
-          icon: <SwapV2 fill={theme.neutral2} />,
-          href: '/swap',
-          internal: true,
-        },
-        {
-          label: t('swap.limit'),
-          icon: <Limit fill={theme.neutral2} />,
-          href: '/limit',
-          internal: true,
-        },
-        {
-          label: t('common.buy.label'),
-          icon: <CreditCardIcon fill={theme.neutral2} />,
-          href: '/buy',
-          internal: true,
-        },
-        ...(isFiatOffRampEnabled
-          ? [
-              {
-                label: t('common.sell.label'),
-                icon: <ReceiveAlt fill={theme.neutral2} size={24} transform="rotate(180deg)" />,
-                href: '/sell',
-                internal: true,
-              },
-            ]
-          : []),
-      ],
+      isActive: pathname.startsWith('/swap'),
+      icon: <SwapV2 fill={theme.accent1} />,
     },
     {
       title: t('common.explore'),


### PR DESCRIPTION
## Summary
- Simplified navigation menu by removing the Trade dropdown
- Now shows "Swap" directly in the main navigation instead of "Trade" with 4 options

## Changes
- Removed Trade dropdown menu with Swap, Limit, Buy, and Sell options
- Changed navigation to show Swap directly as a main menu item
- Removed unused imports (CreditCardIcon, Limit, CoinConvert, ReceiveAlt)
- Removed unused feature flag for fiat off-ramp

## Test plan
- [x] Navigation menu displays correctly with Swap as direct link
- [x] Code compiles without errors
- [ ] Test navigation functionality in browser
- [ ] Verify Swap page loads correctly when clicked