### PR TITLE
Remove language selection from preferences menu

### DIFF
--- a/apps/web/src/components/NavBar/PreferencesMenu/Preferences.tsx
+++ b/apps/web/src/components/NavBar/PreferencesMenu/Preferences.tsx
@@ -6,7 +6,6 @@ import { Trans, useTranslation } from 'react-i18next'
 import { ThemeSelector } from 'theme/components/ThemeToggle'
 import { Flex, Text } from 'ui/src'
 import { useAppFiatCurrency } from 'uniswap/src/features/fiatCurrency/hooks'
-import { useCurrentLanguage, useLanguageInfo } from 'uniswap/src/features/language/hooks'
 
 const Pref = styled.div`
   display: flex;
@@ -60,19 +59,11 @@ export function PreferenceSettings({
 }) {
   const { t } = useTranslation()
   const activeLocalCurrency = useAppFiatCurrency()
-  const activeLanguage = useCurrentLanguage()
-  const languageInfo = useLanguageInfo(activeLanguage)
 
   const items: SettingItem[] = [
     {
       label: showThemeLabel ? t('themeToggle.theme') : undefined,
       component: <ThemeSelector compact fullWidth={!showThemeLabel} />,
-    },
-    {
-      label: t('common.language'),
-      component: (
-        <SelectButton label={languageInfo.displayName} onClick={() => setSettingsView(PreferencesView.LANGUAGE)} />
-      ),
     },
     {
       label: t('common.currency'),

--- a/apps/web/src/components/NavBar/PreferencesMenu/index.tsx
+++ b/apps/web/src/components/NavBar/PreferencesMenu/index.tsx
@@ -1,7 +1,6 @@
 import { NavDropdown, NavDropdownDefaultWrapper } from 'components/NavBar/NavDropdown/index'
 import { NavIcon } from 'components/NavBar/NavIcon'
 import { CurrencySettings } from 'components/NavBar/PreferencesMenu/Currency'
-import { LanguageSettings } from 'components/NavBar/PreferencesMenu/Language'
 import { PreferenceSettings } from 'components/NavBar/PreferencesMenu/Preferences'
 import { PreferencesView } from 'components/NavBar/PreferencesMenu/shared'
 import { useCallback, useState } from 'react'
@@ -11,10 +10,8 @@ import { MoreHorizontal } from 'ui/src/components/icons/MoreHorizontal'
 export function getSettingsViewIndex(view: PreferencesView) {
   if (view === PreferencesView.SETTINGS) {
     return 0
-  } else if (view === PreferencesView.LANGUAGE) {
-    return 1
   } else {
-    return 2
+    return 1
   }
 }
 
@@ -51,7 +48,6 @@ export function PreferenceMenu() {
               showThemeLabel={!media.sm}
               setSettingsView={(view: PreferencesView) => setSettingsView(view)}
             />
-            <LanguageSettings onExitMenu={handleExitMenu} />
             <CurrencySettings onExitMenu={handleExitMenu} />
           </AnimateTransition>
         </NavDropdownDefaultWrapper>


### PR DESCRIPTION
## Summary
- Removed language selection from Global preferences menu as it's no longer needed
- Simplified settings menu to show only Theme and Currency options

## Changes
- Removed language option from the settings items in Preferences.tsx
- Removed LanguageSettings component import and rendering from index.tsx
- Updated getSettingsViewIndex logic to handle only Settings and Currency views
- Removed unused imports for language-related hooks (useCurrentLanguage, useLanguageInfo)

## Test plan
- [x] Settings menu opens correctly
- [x] Only Theme and Currency options are displayed
- [x] Currency selection still works as expected
- [x] Theme toggle continues to function properly
- [ ] Verify no language option appears in the menu