### PR TITLE
Update campaign start date to September 26, 2025

### DIFF
--- a/apps/web/src/services/bappsCampaign/hooks.ts
+++ b/apps/web/src/services/bappsCampaign/hooks.ts
@@ -230,7 +230,7 @@ function useIsCampaignTimeActive(): boolean {
     }
 
     // Normal time-based logic
-    const campaignStartTime = new Date('2025-09-25T00:00:00.000Z').getTime()
+    const campaignStartTime = new Date('2025-09-26T12:00:00.000Z').getTime()
     const now = Date.now()
     return now >= campaignStartTime
   }, [hasUrlOverride])


### PR DESCRIPTION
## Summary
- Updated the campaign start date and time for the bApps campaign

## Changes
- Changed campaign start time from `2025-09-25T00:00:00.000Z` to `2025-09-26T12:00:00.000Z`
- This moves the campaign start to September 26, 2025 at 12:00 PM UTC

## Test plan
- [x] Campaign visibility logic updated
- [ ] Verify campaign shows/hides correctly based on new date
- [ ] Test with URL override parameter still works