### PR TITLE
Remove intro parameter from FAQ link

### DIFF
--- a/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
+++ b/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
@@ -253,7 +253,7 @@ export function NewsletterEtc() {
           title={t('common.faq')}
           description={<FAQList />}
           id="faq"
-          href="/?intro=true#faq"
+          href="/#faq"
         />
       </Flex>
     </SectionLayout>


### PR DESCRIPTION
## Summary
- Removed unnecessary `?intro=true` query parameter from the FAQ section link

## Changes
- Changed FAQ href from `/?intro=true#faq` to `/#faq` in NewsletterEtc.tsx
- This provides cleaner URLs while maintaining the same functionality
- Individual FAQ items (like #faq-juice-token) continue to work normally

## Test plan
- [x] FAQ link navigates correctly to the FAQ section
- [ ] Hash navigation to specific FAQ items still works (#faq-juice-token, #faq-new-questions)
- [ ] FAQ items still expand correctly when accessed via hash