### PR TITLE
fix: Handle Citrea native token (cBTC) in swap quotes

### DIFF
--- a/apps/web/src/pages/ExtensionPasskeyAuthPopUp/index.tsx
+++ b/apps/web/src/pages/ExtensionPasskeyAuthPopUp/index.tsx
@@ -159,8 +159,7 @@ export default function ExtensionPasskeyAuthPopUp() {
     <Trace logImpression page={InterfacePageName.ExtensionPasskeySignInPage}>
       <Flex flexDirection="column" alignItems="center" justifyContent="center" minHeight="100vh">
         <Flex width="400px" padding="$spacing16" flexDirection="column" gap="$spacing16">
-          <Flex row justifyContent="flex-end">
-          </Flex>
+          <Flex row justifyContent="flex-end"></Flex>
 
           <Flex alignItems="center">
             <UniswapLogo size="$icon.40" color="$accent1" />

--- a/apps/web/src/state/routing/types.ts
+++ b/apps/web/src/state/routing/types.ts
@@ -964,6 +964,7 @@ export enum SwapRouterNativeAssets {
   AVAX = 'AVAX',
   ETH = 'ETH',
   MON = 'MON',
+  CBTC = 'cBTC',
 }
 
 export enum URAQuoteType {

--- a/apps/web/src/state/routing/utils.ts
+++ b/apps/web/src/state/routing/utils.ts
@@ -537,6 +537,9 @@ export function currencyAddressForSwapQuote(currency: Currency): string {
     if (currency.chainId === UniverseChainId.Avalanche) {
       return SwapRouterNativeAssets.AVAX
     }
+    if (currency.chainId === UniverseChainId.CitreaTestnet) {
+      return SwapRouterNativeAssets.CBTC
+    }
     return SwapRouterNativeAssets.ETH
   }
 


### PR DESCRIPTION
## Summary

- Add CBTC to SwapRouterNativeAssets enum to properly identify Citrea's native token
- Update currencyAddressForSwapQuote function to return 'cBTC' instead of 'ETH' for Citrea network
- Fixes swap transaction failures when using native cBTC on Citrea testnet

## Problem

When users attempt to swap native cBTC on Citrea testnet, transactions fail with an STF (Safe Transfer From) error because the frontend incorrectly sends 'ETH' as the token address instead of 'cBTC', causing the API to look for wrapped tokens (WcBTC) instead of native tokens.

## Solution

Added Citrea-specific handling in the routing layer to correctly identify native tokens as 'cBTC' when preparing swap quotes for the Citrea network.

## Testing

- Verify native cBTC swaps work correctly on Citrea testnet
- Ensure no regression on other networks