### PR TITLE
fix: Remove unused imports and variables in uniswap package

### DIFF
--- a/packages/uniswap/src/constants/urls.ts
+++ b/packages/uniswap/src/constants/urls.ts
@@ -1,6 +1,6 @@
 import { config } from 'uniswap/src/config'
-import { isBetaEnv, isDevEnv, isPlaywrightEnv, isTestEnv } from 'utilities/src/environment/env'
-import { isAndroid, isExtension, isInterface, isMobileApp } from 'utilities/src/platform'
+import { isDevEnv, isPlaywrightEnv } from 'utilities/src/environment/env'
+import { isExtension, isMobileApp } from 'utilities/src/platform'
 
 enum TrafficFlows {
   GraphQL = 'graphql',
@@ -11,10 +11,6 @@ enum TrafficFlows {
   FOR = 'for',
   Scantastic = 'scantastic',
 }
-
-const FLOWS_USING_BETA = [TrafficFlows.FOR]
-
-const isDevOrBeta = isPlaywrightEnv() ? false : isDevEnv() || isBetaEnv()
 
 export const UNISWAP_WEB_HOSTNAME = 'bapp.juiceswap.xyz'
 const EMBEDDED_WALLET_HOSTNAME = isPlaywrightEnv() || isDevEnv() ? 'staging.ew.unihq.org' : UNISWAP_WEB_HOSTNAME
@@ -206,42 +202,12 @@ export const uniswapUrls = {
   },
 }
 
-function getCloudflarePrefix(flow?: TrafficFlows): string {
-  if (flow && isDevOrBeta && FLOWS_USING_BETA.includes(flow)) {
-    return `beta`
-  }
-
-  if (isMobileApp) {
-    return `${isAndroid ? 'android' : 'ios'}.wallet`
-  }
-
-  if (isExtension) {
-    return 'extension'
-  }
-
-  if (isPlaywrightEnv() || isInterface) {
-    return 'interface'
-  }
-
-  if (isTestEnv()) {
-    return 'wallet'
-  }
-
-  throw new Error('Could not determine app to generate Cloudflare prefix')
-}
-
-function getServicePrefix(flow?: TrafficFlows): string {
-  if (flow && (isPlaywrightEnv() || !(isDevOrBeta && FLOWS_USING_BETA.includes(flow)))) {
-    return flow + '.'
-  } else {
-    return ''
-  }
-}
-
 function getCloudflareApiBaseUrl(flow?: TrafficFlows): string {
   // TODO: Set up cloudflare gateway, temporarily use api.juiceswap.xyz for all flows
   // return `https://${getServicePrefix(flow)}${getCloudflarePrefix(flow)}.gateway.uniswap.org`
-  if (flow === TrafficFlows.TradingApi) return 'https://api.juiceswap.xyz'
+  if (flow === TrafficFlows.TradingApi) {
+    return 'https://api.juiceswap.xyz'
+  }
   return 'https://api.juiceswap.xyz'
 }
 

--- a/packages/uniswap/src/data/rest/exploreStats.ts
+++ b/packages/uniswap/src/data/rest/exploreStats.ts
@@ -15,11 +15,9 @@ import { uniswapGetTransport } from 'uniswap/src/data/rest/base'
  */
 export function useExploreStatsQuery<TSelectType>({
   input,
-  enabled = true,
   select,
 }: {
   input?: PartialMessage<ExploreStatsRequest>
-  enabled?: boolean
   select?: ((data: ExploreStatsResponse) => TSelectType) | undefined
 }): UseQueryResult<TSelectType, ConnectError> {
   // TODO: Enable once ExploreStats backend is configured

--- a/packages/uniswap/src/features/chains/evm/info/mainnet.ts
+++ b/packages/uniswap/src/features/chains/evm/info/mainnet.ts
@@ -1,6 +1,5 @@
 import { CurrencyAmount } from '@juiceswapxyz/sdk-core'
 import { ETHEREUM_LOGO, ETH_LOGO } from 'ui/src/assets'
-import { config } from 'uniswap/src/config'
 import { Chain as BackendChainId } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
 import {
   DEFAULT_MS_BEFORE_WARNING,


### PR DESCRIPTION
## Summary

- Remove unused functions and imports that were causing linting errors
- Clean up code to pass lint and typecheck validations

## Changes

- Remove unused functions  and  from urls.ts
- Remove unused  parameter from  function
- Remove unused  import from mainnet.ts
- Add curly braces to if statement for linting compliance
- Fix code formatting issues

## Testing

- ✅ Lint check passes
- ✅ Type check passes
- ✅ Build succeeds