### PR TITLE
update: Change landing page protocol description

### DIFF
--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -913,7 +913,7 @@
   "landing.exploreUniverse": "Explore the Universe",
   "landing.getStarted": "Trade on the juiciest DEX",
   "landing.helpCenter.body": "Browse FAQs and get support from our US-based support team",
-  "landing.protocolDescription": "JuiceSwap brings the power of Uniswap to Citrea. Swap tokens instantly, earn by providing liquidity, and experience true permissionless trading – optimized for Citrea's ecosystem.",
+  "landing.protocolDescription": "JuiceSwap is your DEX on Citrea. Swap tokens instantly, earn by providing liquidity, and experience true permissionless trading – optimized for Citrea's ecosystem.",
   "landing.protocolStats": "JuiceSwap Protocol stats",
   "landing.provideLiquidity.body": "Provide liquidity and collect fees using the JuiceSwap Interface.",
   "landing.provideLiquidity.subtitle": "Power onchain markets.",


### PR DESCRIPTION
## Summary

Update the protocol description on the landing page to better reflect JuiceSwap's positioning.

## Changes

- Changed from: "JuiceSwap brings the power of Uniswap to Citrea"
- Changed to: "JuiceSwap is your DEX on Citrea"
- Maintains emphasis on instant swaps, liquidity provision, and permissionless trading

## Testing

- ✅ Lint and typecheck pass
- ✅ Build succeeds