### PR TITLE
fix: Remove nested link structure in FAQ section

### DIFF
--- a/apps/web/src/components/Liquidity/LPIncentives/LPIncentiveAnnouncementBanner.tsx
+++ b/apps/web/src/components/Liquidity/LPIncentives/LPIncentiveAnnouncementBanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
-import { Button, Flex, IconButton, styled, Text } from 'ui/src'
+import { Button, Flex, IconButton, Text, styled } from 'ui/src'
 import { CoinStack } from 'ui/src/components/icons/CoinStack'
 import { X } from 'ui/src/components/icons/X'
 import { zIndexes } from 'ui/src/theme/zIndexes'

--- a/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
+++ b/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
@@ -253,7 +253,6 @@ export function NewsletterEtc() {
           title={t('common.faq')}
           description={<FAQList />}
           id="faq"
-          href="/#faq"
         />
       </Flex>
     </SectionLayout>


### PR DESCRIPTION
## Summary

Fix HTML validation warning about nested anchor tags in the FAQ section.

## Problem

The FAQ section had a nested link structure where the outer  component had an  prop, creating an anchor tag that wrapped the FAQ items which themselves contain anchor tags. This caused the HTML validation warning:
`Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>`

## Solution

Removed the `href` prop from the FAQ `UniverseRow` component. The FAQ section remains fully functional with individual FAQ items being clickable, but without the invalid nested link structure.

## Testing

- ✅ FAQ items are still individually clickable and expandable
- ✅ HTML validation warning is resolved
- ✅ No visual or functional regression