### PR TITLE
fix: disable Amplitude analytics initialization

### DIFF
--- a/apps/web/src/tracing/index.ts
+++ b/apps/web/src/tracing/index.ts
@@ -1,4 +1,4 @@
-import { setupAmplitude } from 'tracing/amplitude'
+// import { setupAmplitude } from 'tracing/amplitude'
 import { isRemoteReportingEnabled } from 'utils/env'
 
 if (isRemoteReportingEnabled()) {
@@ -6,4 +6,5 @@ if (isRemoteReportingEnabled()) {
   window.GIT_COMMIT_HASH = process.env.REACT_APP_GIT_COMMIT_HASH
 }
 
-setupAmplitude()
+// Amplitude analytics disabled - no tracking calls will be made
+// setupAmplitude()


### PR DESCRIPTION
## Summary
- Disabled Amplitude analytics initialization to prevent network requests and console errors
- Commented out `setupAmplitude()` call in tracing/index.ts
- Analytics toggle UI remains functional for potential future re-enabling

## Changes
- Prevents "Failed to fetch" errors in console from Amplitude SDK
- No analytics data will be sent to Amplitude servers
- Analytics preference toggle still visible but has no effect while disabled

## Test plan
- [x] Verify no Amplitude network requests in browser DevTools
- [x] Confirm no "Failed to fetch" errors in console
- [x] Check that application functions normally without analytics