### PR TITLE
feat: Simplify mobile navigation menu

### DIFF
--- a/apps/web/src/components/Liquidity/LPIncentives/LPIncentiveAnnouncementBanner.tsx
+++ b/apps/web/src/components/Liquidity/LPIncentives/LPIncentiveAnnouncementBanner.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
-import { Button, Flex, IconButton, styled, Text } from 'ui/src'
+import { Button, Flex, IconButton, Text, styled } from 'ui/src'
 import { CoinStack } from 'ui/src/components/icons/CoinStack'
 import { X } from 'ui/src/components/icons/X'
 import { zIndexes } from 'ui/src/theme/zIndexes'

--- a/apps/web/src/components/NavBar/CompanyMenu/MobileMenuDrawer.tsx
+++ b/apps/web/src/components/NavBar/CompanyMenu/MobileMenuDrawer.tsx
@@ -1,163 +1,39 @@
-import { HelpModal } from 'components/HelpModal/HelpModal'
-import { MenuSectionTitle, useMenuContent } from 'components/NavBar/CompanyMenu/Content'
 import { MenuLink } from 'components/NavBar/CompanyMenu/MenuDropdown'
-import { LegalAndPrivacyMenu } from 'components/NavBar/LegalAndPrivacyMenu'
 import { NavDropdown } from 'components/NavBar/NavDropdown'
-import { getSettingsViewIndex } from 'components/NavBar/PreferencesMenu'
-import { CurrencySettings } from 'components/NavBar/PreferencesMenu/Currency'
-import { LanguageSettings } from 'components/NavBar/PreferencesMenu/Language'
-import { PreferencesView } from 'components/NavBar/PreferencesMenu/shared'
 import { useTabsContent } from 'components/NavBar/Tabs/TabsContent'
-import { useTheme } from 'lib/styled-components'
-import { Socials } from 'pages/Landing/sections/Footer'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { ChevronDown } from 'react-feather'
+import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Accordion, AnimateTransition, Flex, Separator, Square, Text } from 'ui/src'
-import { FeatureFlags } from 'uniswap/src/features/gating/flags'
-import { useFeatureFlag } from 'uniswap/src/features/gating/hooks'
+import { Flex, Text } from 'ui/src'
 import { TestID } from 'uniswap/src/test/fixtures/testIDs'
-
-function MenuSection({
-  title,
-  children,
-  collapsible = true,
-}: {
-  title: string
-  children: JSX.Element | JSX.Element[]
-  collapsible?: boolean
-}) {
-  const theme = useTheme()
-
-  return (
-    <Accordion.Item value={title} disabled={!collapsible}>
-      <Flex gap="10px">
-        <Accordion.Trigger flexDirection="row" p="0" gap="4px">
-          {({ open }: { open: boolean }) => (
-            <>
-              <Text variant="body4" color="$neutral2">
-                {title}
-              </Text>
-              {collapsible && (
-                <Square animation="200ms" rotate={open ? '-180deg' : '0deg'}>
-                  <ChevronDown size="20px" color={theme.neutral2} />
-                </Square>
-              )}
-            </>
-          )}
-        </Accordion.Trigger>
-        <Accordion.Content p="0" forceMount={!collapsible || undefined}>
-          <Flex gap="10px">{children}</Flex>
-        </Accordion.Content>
-      </Flex>
-    </Accordion.Item>
-  )
-}
 
 // eslint-disable-next-line import/no-unused-modules
 export function MobileMenuDrawer({ isOpen, closeMenu }: { isOpen: boolean; closeMenu: () => void }) {
-  const [openSections, setOpenSections] = useState<string[]>()
-  const [settingsView, setSettingsView] = useState<PreferencesView>(PreferencesView.SETTINGS)
-  const isConversionTrackingEnabled = useFeatureFlag(FeatureFlags.ConversionTracking)
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const changeView = useCallback(
-    (view: PreferencesView) => {
-      setSettingsView(view)
-      if (dropdownRef.current) {
-        dropdownRef.current.scroll({
-          top: 0,
-        })
-      }
-    },
-    [setSettingsView, dropdownRef],
-  )
-  const onExitPreferencesMenu = useCallback(() => changeView(PreferencesView.SETTINGS), [changeView])
   const { t } = useTranslation()
   const tabsContent = useTabsContent()
-  const productContent = useMenuContent({
-    keys: [MenuSectionTitle.Products],
-  })
-  const menuContent = useMenuContent({
-    keys: [MenuSectionTitle.Protocol, MenuSectionTitle.Company],
-  })
-
-  // Collapse sections on close
-  useEffect(() => {
-    if (!isOpen) {
-      setTimeout(() => setOpenSections([]), 300)
-    }
-  }, [isOpen])
 
   return (
     <NavDropdown dropdownRef={dropdownRef} isOpen={isOpen} dataTestId={TestID.CompanyMenuMobileDrawer}>
       <Flex pt="$spacing12" pb="$spacing32" px="$spacing24">
-        <AnimateTransition
-          currentIndex={getSettingsViewIndex(settingsView)}
-          animationType={settingsView === PreferencesView.SETTINGS ? 'forward' : 'backward'}
-        >
-          <Accordion
-            overflow="hidden"
-            width="100%"
-            type="multiple"
-            value={openSections}
-            onValueChange={setOpenSections}
-          >
-            <Flex gap="$spacing24">
-              <MenuSection title={t('common.app')} collapsible={false}>
-                {tabsContent.map((tab, index) => (
-                  <MenuLink
-                    key={`${tab.title}_${index}}`}
-                    label={tab.title}
-                    href={tab.href}
-                    internal
-                    closeMenu={closeMenu}
-                    icon={tab.icon}
-                  />
-                ))}
-              </MenuSection>
-              {Object.values(productContent).map((sectionContent, index) => (
-                <MenuSection key={`${sectionContent.title}_${index}`} title={sectionContent.title} collapsible={false}>
-                  {sectionContent.items.map(({ label, href, internal, icon }, index) => (
-                    <MenuLink
-                      key={`${label}_${index}}`}
-                      label={label}
-                      href={href}
-                      internal={internal}
-                      closeMenu={closeMenu}
-                      icon={icon}
-                    />
-                  ))}
-                </MenuSection>
+        <Flex gap="$spacing24">
+          <Flex gap="10px">
+            <Text variant="body4" color="$neutral2" mb="$spacing8">
+              {t('common.app')}
+            </Text>
+            <Flex gap="10px">
+              {tabsContent.map((tab, index) => (
+                <MenuLink
+                  key={`${tab.title}_${index}}`}
+                  label={tab.title}
+                  href={tab.href}
+                  internal
+                  closeMenu={closeMenu}
+                  icon={tab.icon}
+                />
               ))}
-
-              <Separator backgroundColor="$surface3" />
-
-              {Object.values(menuContent).map((sectionContent, index) => (
-                <MenuSection key={`${sectionContent.title}_${index}`} title={sectionContent.title}>
-                  {sectionContent.items.map(({ label, href, internal }, index) => (
-                    <MenuLink
-                      key={`${label}_${index}}`}
-                      label={label}
-                      href={href}
-                      internal={internal}
-                      closeMenu={closeMenu}
-                    />
-                  ))}
-                </MenuSection>
-              ))}
-              {isConversionTrackingEnabled && <LegalAndPrivacyMenu closeMenu={closeMenu} />}
-              <Flex row width="100%" justifyContent="space-between" alignItems="flex-end">
-                <HelpModal showOnMobile />
-                <Flex gap="$spacing16">
-                  <Socials iconSize="20px" />
-                </Flex>
-              </Flex>
             </Flex>
-          </Accordion>
-
-          <LanguageSettings onExitMenu={onExitPreferencesMenu} />
-          <CurrencySettings onExitMenu={onExitPreferencesMenu} />
-        </AnimateTransition>
+          </Flex>
+        </Flex>
       </Flex>
     </NavDropdown>
   )

--- a/apps/web/src/components/NavBar/CompanyMenu/index.tsx
+++ b/apps/web/src/components/NavBar/CompanyMenu/index.tsx
@@ -1,28 +1,14 @@
-import { ArrowChangeDown } from 'components/Icons/ArrowChangeDown'
 import { NavIcon } from 'components/Logo/NavIcon'
-import { MenuDropdown } from 'components/NavBar/CompanyMenu/MenuDropdown'
 import { MobileMenuDrawer } from 'components/NavBar/CompanyMenu/MobileMenuDrawer'
-import { useIsMobileDrawer } from 'components/NavBar/ScreenSizes'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router'
-import { Flex, Popover, Text, styled, useIsTouchDevice, useMedia } from 'ui/src'
+import { Flex, Popover, Text, useMedia } from 'ui/src'
 import { Hamburger } from 'ui/src/components/icons/Hamburger'
 import { TestID } from 'uniswap/src/test/fixtures/testIDs'
-
-const ArrowDownWrapper = styled(Text, {
-  color: '$neutral2',
-  '$group-hover': { color: '$neutral1' },
-  variants: {
-    open: {
-      true: { color: '$neutral1' },
-    },
-  },
-})
 
 export function CompanyMenu() {
   const popoverRef = useRef<Popover>(null)
   const media = useMedia()
-  const isMobileDrawer = useIsMobileDrawer()
   const isLargeScreen = !media.xxl
   const location = useLocation()
   const [isOpen, setIsOpen] = useState(false)
@@ -32,39 +18,51 @@ export function CompanyMenu() {
   }, [popoverRef])
   useEffect(() => closeMenu(), [location, closeMenu])
 
-  const isTouchDevice = useIsTouchDevice()
+  if (media.md) {
+    // Mobile: Show hamburger menu for navigation
+    return (
+      <Popover ref={popoverRef} placement="bottom" hoverable={false} stayInFrame allowFlip onOpenChange={setIsOpen}>
+        <Popover.Trigger data-testid={TestID.NavCompanyMenu}>
+          <Flex
+            row
+            alignItems="center"
+            gap="$gap4"
+            p="$spacing8"
+            cursor="pointer"
+            group
+            $platform-web={{ containerType: 'normal' }}
+          >
+            <Link to="/" style={{ textDecoration: 'none' }}>
+              <Flex row alignItems="center" gap="$gap4" data-testid={TestID.NavUniswapLogo}>
+                <NavIcon />
+                {isLargeScreen && (
+                  <Text variant="subheading1" color="$accent1" userSelect="none">
+                    JuiceSwap
+                  </Text>
+                )}
+              </Flex>
+            </Link>
+            <Hamburger size={22} color="$neutral2" cursor="pointer" ml="16px" />
+          </Flex>
+        </Popover.Trigger>
+        <MobileMenuDrawer isOpen={isOpen} closeMenu={closeMenu} />
+      </Popover>
+    )
+  }
 
+  // Desktop: Just show logo, no dropdown
   return (
-    <Popover ref={popoverRef} placement="bottom" hoverable stayInFrame allowFlip onOpenChange={setIsOpen}>
-      <Popover.Trigger data-testid={TestID.NavCompanyMenu}>
-        <Flex
-          row
-          alignItems="center"
-          gap="$gap4"
-          p="$spacing8"
-          cursor="pointer"
-          group
-          $platform-web={{ containerType: 'normal' }}
-        >
-          <Link to="/" style={{ textDecoration: 'none' }}>
-            <Flex row alignItems="center" gap="$gap4" data-testid={TestID.NavUniswapLogo}>
-              <NavIcon />
-              {isLargeScreen && (
-                <Text variant="subheading1" color="$accent1" userSelect="none">
-                  JuiceSwap
-                </Text>
-              )}
-            </Flex>
-          </Link>
-          {(media.md || isTouchDevice) && <Hamburger size={22} color="$neutral2" cursor="pointer" ml="16px" />}
-          {!media.md && !isTouchDevice && (
-            <ArrowDownWrapper open={isOpen}>
-              <ArrowChangeDown width="12px" height="12px" />
-            </ArrowDownWrapper>
+    <Flex row alignItems="center" gap="$gap4" p="$spacing8" $platform-web={{ containerType: 'normal' }}>
+      <Link to="/" style={{ textDecoration: 'none' }}>
+        <Flex row alignItems="center" gap="$gap4" data-testid={TestID.NavUniswapLogo}>
+          <NavIcon />
+          {isLargeScreen && (
+            <Text variant="subheading1" color="$accent1" userSelect="none">
+              JuiceSwap
+            </Text>
           )}
         </Flex>
-      </Popover.Trigger>
-      {isMobileDrawer ? <MobileMenuDrawer isOpen={isOpen} closeMenu={closeMenu} /> : <MenuDropdown close={closeMenu} />}
-    </Popover>
+      </Link>
+    </Flex>
   )
 }

--- a/apps/web/src/components/NavBar/CompanyMenu/index.tsx
+++ b/apps/web/src/components/NavBar/CompanyMenu/index.tsx
@@ -1,22 +1,41 @@
+import { ArrowChangeDown } from 'components/Icons/ArrowChangeDown'
 import { NavIcon } from 'components/Logo/NavIcon'
-import { useCallback, useEffect, useRef } from 'react'
+import { MenuDropdown } from 'components/NavBar/CompanyMenu/MenuDropdown'
+import { MobileMenuDrawer } from 'components/NavBar/CompanyMenu/MobileMenuDrawer'
+import { useIsMobileDrawer } from 'components/NavBar/ScreenSizes'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router'
-import { Flex, Popover, Text, useMedia } from 'ui/src'
+import { Flex, Popover, Text, styled, useIsTouchDevice, useMedia } from 'ui/src'
+import { Hamburger } from 'ui/src/components/icons/Hamburger'
 import { TestID } from 'uniswap/src/test/fixtures/testIDs'
+
+const ArrowDownWrapper = styled(Text, {
+  color: '$neutral2',
+  '$group-hover': { color: '$neutral1' },
+  variants: {
+    open: {
+      true: { color: '$neutral1' },
+    },
+  },
+})
 
 export function CompanyMenu() {
   const popoverRef = useRef<Popover>(null)
   const media = useMedia()
+  const isMobileDrawer = useIsMobileDrawer()
   const isLargeScreen = !media.xxl
   const location = useLocation()
+  const [isOpen, setIsOpen] = useState(false)
 
   const closeMenu = useCallback(() => {
     popoverRef.current?.close()
   }, [popoverRef])
   useEffect(() => closeMenu(), [location, closeMenu])
 
+  const isTouchDevice = useIsTouchDevice()
+
   return (
-    <Popover ref={popoverRef} placement="bottom" hoverable stayInFrame allowFlip>
+    <Popover ref={popoverRef} placement="bottom" hoverable stayInFrame allowFlip onOpenChange={setIsOpen}>
       <Popover.Trigger data-testid={TestID.NavCompanyMenu}>
         <Flex
           row
@@ -37,8 +56,15 @@ export function CompanyMenu() {
               )}
             </Flex>
           </Link>
+          {(media.md || isTouchDevice) && <Hamburger size={22} color="$neutral2" cursor="pointer" ml="16px" />}
+          {!media.md && !isTouchDevice && (
+            <ArrowDownWrapper open={isOpen}>
+              <ArrowChangeDown width="12px" height="12px" />
+            </ArrowDownWrapper>
+          )}
         </Flex>
       </Popover.Trigger>
+      {isMobileDrawer ? <MobileMenuDrawer isOpen={isOpen} closeMenu={closeMenu} /> : <MenuDropdown close={closeMenu} />}
     </Popover>
   )
 }

--- a/apps/web/src/components/NavBar/index.tsx
+++ b/apps/web/src/components/NavBar/index.tsx
@@ -73,10 +73,10 @@ function useShouldHideChainSelector() {
 }
 
 export default function Navbar() {
-  // const isLandingPage = useIsPage(PageType.LANDING)
+  const isLandingPage = useIsPage(PageType.LANDING)
 
   const media = useMedia()
-  // const isSmallScreen = media.md
+  const isSmallScreen = media.md
   const areTabsVisible = useTabsVisible()
   const collapseSearchBar = media.xl
   const account = useAccount()
@@ -98,7 +98,7 @@ export default function Navbar() {
 
         <Right>
           {collapseSearchBar && <SearchBar />}
-          {/* {!isEmbeddedWalletEnabled && isLandingPage && !isSmallScreen && <NewUserCTAButton />} */}
+          {!isEmbeddedWalletEnabled && isLandingPage && !isSmallScreen && <NewUserCTAButton />}
           {!account.isConnected && <PreferenceMenu />}
           {!hideChainSelector && <ChainSelector />}
           {isTestnetModeEnabled && <TestnetModeTooltip />}


### PR DESCRIPTION
## Summary
- Remove hamburger menu from desktop view (only visible on mobile ≤640px)
- Simplify mobile drawer to show only essential navigation tabs (Swap, Explore, Pool)
- Remove unnecessary menu sections from mobile view (Products, Protocol, Company, Legal, Social links)

## Changes
- Desktop users see only the logo without dropdown functionality (navigation via visible tabs)
- Mobile users get a streamlined hamburger menu with just the core navigation options
- Cleaner, more focused user experience on both platforms

## Test plan
- [x] Test on desktop viewport (>640px) - no hamburger menu visible
- [x] Test on mobile viewport (≤640px) - hamburger menu visible and functional
- [x] Verify mobile menu shows only App navigation items
- [x] Ensure desktop navigation tabs work correctly