### PR TITLE
fix: Disable non-existent API endpoints to prevent 404 errors

### DIFF
--- a/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.test.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.test.ts
@@ -3,49 +3,26 @@ const mockFetch = jest.fn()
 global.fetch = mockFetch
 
 import { checkWalletDelegation } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
-import {
-  Address,
-  ChainId,
-  WalletCheckDelegationRequestBody,
-  WalletCheckDelegationResponseBody,
-} from 'uniswap/src/data/tradingApi/__generated__'
-
-// Helper function to create a mock Response
-const createMockResponse = (data: WalletCheckDelegationResponseBody): Partial<Response> => ({
-  ok: true,
-  status: 200,
-  json: jest.fn().mockResolvedValue(data),
-})
+import { Address, ChainId, WalletCheckDelegationRequestBody } from 'uniswap/src/data/tradingApi/__generated__'
 
 const mockCheckWalletDelegationWithoutBatching = mockFetch
 
 describe('checkWalletDelegation', () => {
   const mockAddress1 = '0x1234567890abcdef1234567890abcdef12345678' as Address
   const mockAddress2 = '0xabcdef1234567890abcdef1234567890abcdef12' as Address
-  const mockAddress3 = '0x9876543210fedcba9876543210fedcba98765432' as Address
 
   const mockChainId1 = 1 as ChainId
   const mockChainId2 = 137 as ChainId
-
-  const mockDelegationResponse: WalletCheckDelegationResponseBody = {
-    requestId: 'test-request-id',
-    delegationDetails: {
-      [mockAddress1]: {
-        '1': {
-          isWalletDelegatedToUniswap: true,
-          currentDelegationAddress: '0xdeadbeef',
-          latestDelegationAddress: '0xdeadbeef',
-        },
-      },
-    },
-  }
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  describe('when no wallet addresses are provided', () => {
-    it('should return empty delegation details without making API call', async () => {
+  // NOTE: The /v1/wallet/check_delegation endpoint is currently disabled
+  // These tests verify that the disabled endpoint returns empty responses
+
+  describe('when endpoint is disabled', () => {
+    it('should return empty delegation details without making API call when no wallet addresses provided', async () => {
       const params: WalletCheckDelegationRequestBody = {
         walletAddresses: [],
         chainIds: [mockChainId1],
@@ -73,380 +50,54 @@ describe('checkWalletDelegation', () => {
       })
       expect(mockCheckWalletDelegationWithoutBatching).not.toHaveBeenCalled()
     })
-  })
 
-  describe('when request is under batch threshold', () => {
-    it('should make single API call for small request', async () => {
+    it('should return empty response for single wallet address', async () => {
       const params: WalletCheckDelegationRequestBody = {
         walletAddresses: [mockAddress1],
         chainIds: [mockChainId1],
       }
-
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(createMockResponse(mockDelegationResponse))
 
       const result = await checkWalletDelegation(params)
 
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(1)
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          body: JSON.stringify(params),
-        }),
-      )
-      expect(result).toEqual(mockDelegationResponse)
-    })
-
-    it('should make single API call when total combinations equal threshold', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1],
-        chainIds: [mockChainId1],
-      }
-
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(createMockResponse(mockDelegationResponse))
-
-      // Set threshold to exactly match the combinations (1 wallet * 1 chain = 1)
-      const result = await checkWalletDelegation(params, 1)
-
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(mockDelegationResponse)
-    })
-  })
-
-  describe('when request exceeds batch threshold', () => {
-    it('should split into multiple batches and merge responses', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1, mockAddress2, mockAddress3],
-        chainIds: [mockChainId1, mockChainId2],
-      }
-
-      const response1: WalletCheckDelegationResponseBody = {
-        requestId: 'batch-1',
-        delegationDetails: {
-          [mockAddress1]: {
-            '1': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xdeadbeef',
-              latestDelegationAddress: '0xdeadbeef',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xfeedface',
-            },
-          },
-        },
-      }
-
-      const response2: WalletCheckDelegationResponseBody = {
-        requestId: 'batch-2',
-        delegationDetails: {
-          [mockAddress2]: {
-            '1': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xdeadbeef',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xfeedface',
-              latestDelegationAddress: '0xfeedface',
-            },
-          },
-        },
-      }
-
-      const response3: WalletCheckDelegationResponseBody = {
-        requestId: 'batch-3',
-        delegationDetails: {
-          [mockAddress3]: {
-            '1': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xbadcafe',
-              latestDelegationAddress: '0xbadcafe',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xcafebabe',
-            },
-          },
-        },
-      }
-
-      mockCheckWalletDelegationWithoutBatching
-        .mockResolvedValueOnce(createMockResponse(response1))
-        .mockResolvedValueOnce(createMockResponse(response2))
-        .mockResolvedValueOnce(createMockResponse(response3))
-
-      // Set threshold to 2 (should create 3 batches: 1 wallet per batch since 1 wallet * 2 chains = 2)
-      const result = await checkWalletDelegation(params, 2)
-
-      const expectedMergedResponse: WalletCheckDelegationResponseBody = {
-        requestId: response1.requestId,
-        delegationDetails: {
-          ...response1.delegationDetails,
-          ...response2.delegationDetails,
-          ...response3.delegationDetails,
-        },
-      }
-
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(3)
-      expect(result).toEqual(expectedMergedResponse)
-    })
-
-    it('should handle batching with custom threshold', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1, mockAddress2],
-        chainIds: [mockChainId1, mockChainId2],
-      }
-
-      const response1: WalletCheckDelegationResponseBody = {
-        requestId: 'batch-1',
-        delegationDetails: {
-          [mockAddress1]: {
-            '1': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xdeadbeef',
-              latestDelegationAddress: '0xdeadbeef',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xfeedface',
-            },
-          },
-        },
-      }
-
-      const response2: WalletCheckDelegationResponseBody = {
-        requestId: 'batch-2',
-        delegationDetails: {
-          [mockAddress2]: {
-            '1': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xdeadbeef',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xfeedface',
-              latestDelegationAddress: '0xfeedface',
-            },
-          },
-        },
-      }
-
-      mockCheckWalletDelegationWithoutBatching
-        .mockResolvedValueOnce(createMockResponse(response1))
-        .mockResolvedValueOnce(createMockResponse(response2))
-
-      // 2 wallets * 2 chains = 4 combinations, threshold = 3, so should batch
-      const result = await checkWalletDelegation(params, 3)
-
-      const expectedMergedResponse: WalletCheckDelegationResponseBody = {
-        requestId: response1.requestId,
-        delegationDetails: {
-          ...response1.delegationDetails,
-          ...response2.delegationDetails,
-        },
-      }
-
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(2)
-      expect(result).toEqual(expectedMergedResponse)
-    })
-  })
-
-  describe('edge cases', () => {
-    it('should handle empty response properly', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1],
-        chainIds: [mockChainId1],
-      }
-
-      const emptyResponse: WalletCheckDelegationResponseBody = {
-        requestId: 'empty-request',
+      // Endpoint is disabled, should not make API calls
+      expect(mockCheckWalletDelegationWithoutBatching).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        requestId: '',
         delegationDetails: {},
-      }
-
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(createMockResponse(emptyResponse))
-
-      const result = await checkWalletDelegation(params)
-
-      expect(result).toEqual(emptyResponse)
+      })
     })
 
-    it('should handle single wallet with multiple chains', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1],
-        chainIds: [mockChainId1, mockChainId2],
-      }
-
-      const response: WalletCheckDelegationResponseBody = {
-        requestId: 'multi-chain',
-        delegationDetails: {
-          [mockAddress1]: {
-            '1': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xdeadbeef',
-              latestDelegationAddress: '0xdeadbeef',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xfeedface',
-            },
-          },
-        },
-      }
-
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(createMockResponse(response))
-
-      const result = await checkWalletDelegation(params)
-
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(response)
-    })
-
-    it('should handle multiple wallets with single chain', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1, mockAddress2],
-        chainIds: [mockChainId1],
-      }
-
-      const response: WalletCheckDelegationResponseBody = {
-        requestId: 'multi-wallet',
-        delegationDetails: {
-          [mockAddress1]: {
-            '1': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xdeadbeef',
-              latestDelegationAddress: '0xdeadbeef',
-            },
-          },
-          [mockAddress2]: {
-            '1': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xdeadbeef',
-            },
-          },
-        },
-      }
-
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(createMockResponse(response))
-
-      const result = await checkWalletDelegation(params)
-
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(response)
-    })
-  })
-
-  describe('error handling', () => {
-    it('should propagate API errors', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1],
-        chainIds: [mockChainId1],
-      }
-
-      const apiError = new Error('API Error')
-      mockCheckWalletDelegationWithoutBatching.mockRejectedValue(apiError)
-
-      await expect(checkWalletDelegation(params)).rejects.toThrow('API Error')
-    })
-
-    it('should use chainIds.length as effective threshold when batchThreshold is smaller', async () => {
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: [mockAddress1],
-        chainIds: [mockChainId1, mockChainId2], // 2 chains
-      }
-
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(createMockResponse(mockDelegationResponse))
-
-      // Pass batchThreshold of 1, which is less than chainIds.length (2)
-      // Should use 2 as effective threshold (1 wallet * 2 chains = 2, which equals effective threshold)
-      const result = await checkWalletDelegation(params, 1)
-
-      // Should make a single API call since combinations (2) equals effective threshold (2)
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(1)
-      expect(result).toEqual(mockDelegationResponse)
-    })
-
-    it('should handle partial batch failures', async () => {
+    it('should return empty response for multiple wallet addresses', async () => {
       const params: WalletCheckDelegationRequestBody = {
         walletAddresses: [mockAddress1, mockAddress2],
         chainIds: [mockChainId1, mockChainId2],
       }
 
-      const response1: WalletCheckDelegationResponseBody = {
-        requestId: 'batch-1',
-        delegationDetails: {
-          [mockAddress1]: {
-            '1': {
-              isWalletDelegatedToUniswap: true,
-              currentDelegationAddress: '0xdeadbeef',
-              latestDelegationAddress: '0xdeadbeef',
-            },
-            '137': {
-              isWalletDelegatedToUniswap: false,
-              currentDelegationAddress: null,
-              latestDelegationAddress: '0xfeedface',
-            },
-          },
-        },
-      }
+      const result = await checkWalletDelegation(params)
 
-      mockCheckWalletDelegationWithoutBatching
-        .mockResolvedValueOnce(createMockResponse(response1))
-        .mockRejectedValueOnce(new Error('Batch 2 failed'))
-
-      // Should fail if any batch fails
-      await expect(checkWalletDelegation(params, 2)).rejects.toThrow('Batch 2 failed')
-    })
-  })
-
-  describe('default threshold behavior', () => {
-    it('should use default threshold when not provided', async () => {
-      // Create a request that would exceed the default threshold (140)
-      const manyWallets = Array.from({ length: 15 }, (_, i) => `0x${i.toString().padStart(40, '0')}` as Address)
-      const params: WalletCheckDelegationRequestBody = {
-        walletAddresses: manyWallets,
-        chainIds: [mockChainId1, mockChainId2, 42 as ChainId, 56 as ChainId, 100 as ChainId], // 5 chains
-      }
-
-      // 15 wallets * 5 chains = 75 combinations, under default threshold of 140, should be single call
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(
-        createMockResponse({
-          requestId: 'single-call',
-          delegationDetails: {},
-        }),
-      )
-
-      await checkWalletDelegation(params)
-
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(1)
+      // Endpoint is disabled, should not make API calls
+      expect(mockCheckWalletDelegationWithoutBatching).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        requestId: '',
+        delegationDetails: {},
+      })
     })
 
-    it('should batch when exceeding default threshold', async () => {
-      // Create a request that would exceed the default threshold (140)
-      const manyWallets = Array.from({ length: 30 }, (_, i) => `0x${i.toString().padStart(40, '0')}` as Address)
+    it('should return empty response regardless of batch threshold', async () => {
+      const manyWallets = Array.from({ length: 100 }, (_, i) => `0x${i.toString().padStart(40, '0')}` as Address)
       const params: WalletCheckDelegationRequestBody = {
         walletAddresses: manyWallets,
-        chainIds: [mockChainId1, mockChainId2, 42 as ChainId, 56 as ChainId, 100 as ChainId], // 5 chains
+        chainIds: [mockChainId1, mockChainId2],
       }
 
-      // 30 wallets * 5 chains = 150 combinations, exceeds default threshold of 140, should batch
-      mockCheckWalletDelegationWithoutBatching.mockResolvedValue(
-        createMockResponse({
-          requestId: 'batch-response',
-          delegationDetails: {},
-        }),
-      )
+      const result = await checkWalletDelegation(params, 10)
 
-      await checkWalletDelegation(params)
-
-      // Should make multiple calls (150 combinations / 5 chains = 30 wallets, but max per batch is 140/5 = 28)
-      expect(mockCheckWalletDelegationWithoutBatching).toHaveBeenCalledTimes(2)
+      // Endpoint is disabled, should not make API calls even with batching
+      expect(mockCheckWalletDelegationWithoutBatching).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        requestId: '',
+        delegationDetails: {},
+      })
     })
   })
 })

--- a/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
@@ -457,16 +457,22 @@ export async function fetchOrdersWithoutIds({
   })
 }
 
-export async function fetchSwappableTokens(params: SwappableTokensParams): Promise<GetSwappableTokensResponse> {
-  return await TradingApiClient.get<GetSwappableTokensResponse>(uniswapUrls.tradingApiPaths.swappableTokens, {
-    params: {
-      tokenIn: params.tokenIn,
-      tokenInChainId: params.tokenInChainId,
-    },
-    headers: {
-      ...getFeatureFlaggedHeaders(),
-    },
-  })
+export async function fetchSwappableTokens(_params: SwappableTokensParams): Promise<GetSwappableTokensResponse> {
+  // DISABLED: Endpoint /v1/swappable_tokens does not exist in backend API
+  return {
+    requestId: '',
+    tokens: [],
+  }
+
+  // return await TradingApiClient.get<GetSwappableTokensResponse>(uniswapUrls.tradingApiPaths.swappableTokens, {
+  //   params: {
+  //     tokenIn: _params.tokenIn,
+  //     tokenInChainId: _params.tokenInChainId,
+  //   },
+  //   headers: {
+  //     ...getFeatureFlaggedHeaders(),
+  //   },
+  // })
 }
 
 export async function createLpPosition(params: CreateLPPositionRequest): Promise<CreateLPPositionResponse> {
@@ -597,19 +603,25 @@ function chunkWalletAddresses(params: {
 }
 
 export async function checkWalletDelegationWithoutBatching(
-  params: WalletCheckDelegationRequestBody,
+  _params: WalletCheckDelegationRequestBody,
 ): Promise<WalletCheckDelegationResponseBody> {
-  return await TradingApiClient.post<WalletCheckDelegationResponseBody>(
-    uniswapUrls.tradingApiPaths.wallet.checkDelegation,
-    {
-      body: JSON.stringify({
-        ...params,
-      }),
-      headers: {
-        ...getFeatureFlaggedHeaders(),
-      },
-    },
-  )
+  // DISABLED: Endpoint /v1/wallet/check_delegation does not exist in backend API
+  return {
+    requestId: '',
+    delegationDetails: {},
+  }
+
+  // return await TradingApiClient.post<WalletCheckDelegationResponseBody>(
+  //   uniswapUrls.tradingApiPaths.wallet.checkDelegation,
+  //   {
+  //     body: JSON.stringify({
+  //       ..._params,
+  //     }),
+  //     headers: {
+  //       ...getFeatureFlaggedHeaders(),
+  //     },
+  //   },
+  // )
 }
 
 function mergeDelegationResponses(responses: WalletCheckDelegationResponseBody[]): WalletCheckDelegationResponseBody {


### PR DESCRIPTION
Disabled /v1/swappable_tokens and /v1/wallet/check_delegation API calls as these endpoints do not exist in the backend API, causing 404 errors. The functions now return empty responses instead of making actual API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)