### PR TITLE
fix: Use dynamic rate limit duration from API response

### DIFF
--- a/packages/uniswap/src/data/apiClients/FetchError.ts
+++ b/packages/uniswap/src/data/apiClients/FetchError.ts
@@ -2,6 +2,7 @@ export class FetchError extends Error {
   response: Response
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data?: any
+  retryAfter?: number // Time in seconds to wait before retrying
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor({ response, data, cause }: { response: Response; data?: any; cause?: unknown }) {
@@ -10,6 +11,19 @@ export class FetchError extends Error {
     this.response = response
     this.data = data
     this.cause = cause
+
+    // Extract retryAfter from response body or Retry-After header
+    if (data?.retryAfter && typeof data.retryAfter === 'number') {
+      this.retryAfter = data.retryAfter
+    } else {
+      const retryAfterHeader = response.headers.get('Retry-After')
+      if (retryAfterHeader) {
+        const parsed = parseInt(retryAfterHeader, 10)
+        if (!isNaN(parsed)) {
+          this.retryAfter = parsed
+        }
+      }
+    }
   }
 }
 

--- a/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormWarningModals/RateLimitModal.tsx
+++ b/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormWarningModals/RateLimitModal.tsx
@@ -6,7 +6,7 @@ import { WarningModal } from 'uniswap/src/components/modals/WarningModal/Warning
 import { WarningSeverity } from 'uniswap/src/components/modals/WarningModal/types'
 import { ModalName } from 'uniswap/src/features/telemetry/constants'
 
-const RATE_LIMIT_DURATION = 60 // seconds
+const DEFAULT_RATE_LIMIT_DURATION = 60 // seconds (fallback if API doesn't provide duration)
 
 interface RateLimitModalProps {
   isOpen: boolean
@@ -15,13 +15,21 @@ interface RateLimitModalProps {
 
 export function RateLimitModal({ isOpen, onClose }: RateLimitModalProps): JSX.Element {
   const { t } = useTranslation()
-  const [remainingSeconds, setRemainingSeconds] = useState(RATE_LIMIT_DURATION)
+  // Get the duration from global state (set by tradeRepository when rate limit error occurs)
+  const rateLimitDuration = globalThis.__RATE_LIMIT_DURATION__ ?? DEFAULT_RATE_LIMIT_DURATION
+  const [remainingSeconds, setRemainingSeconds] = useState(rateLimitDuration)
 
   useEffect(() => {
     if (!isOpen) {
-      setRemainingSeconds(RATE_LIMIT_DURATION)
+      // Reset to the current rate limit duration when modal closes
+      const currentDuration = globalThis.__RATE_LIMIT_DURATION__ ?? DEFAULT_RATE_LIMIT_DURATION
+      setRemainingSeconds(currentDuration)
       return undefined
     }
+
+    // Initialize with the current rate limit duration when modal opens
+    const initialDuration = globalThis.__RATE_LIMIT_DURATION__ ?? DEFAULT_RATE_LIMIT_DURATION
+    setRemainingSeconds(initialDuration)
 
     // Start countdown when modal opens
     const interval = setInterval(() => {

--- a/packages/uniswap/src/features/transactions/swap/hooks/useRateLimitHandler.ts
+++ b/packages/uniswap/src/features/transactions/swap/hooks/useRateLimitHandler.ts
@@ -5,10 +5,13 @@ import { useSwapFormWarningStoreActions } from 'uniswap/src/features/transaction
 declare global {
   interface Window {
     __RATE_LIMIT_END_TIME__?: number
+    __RATE_LIMIT_DURATION__?: number // Duration in seconds from API
     __RATE_LIMIT_TRIGGER__?: () => void
   }
   // eslint-disable-next-line no-var
   var __RATE_LIMIT_END_TIME__: number | undefined
+  // eslint-disable-next-line no-var
+  var __RATE_LIMIT_DURATION__: number | undefined
   // eslint-disable-next-line no-var
   var __RATE_LIMIT_TRIGGER__: (() => void) | undefined
 }

--- a/packages/uniswap/src/features/transactions/swap/services/tradeService/tradeRepository.ts
+++ b/packages/uniswap/src/features/transactions/swap/services/tradeService/tradeRepository.ts
@@ -55,8 +55,11 @@ export function createTradeRepository(ctx: {
       } catch (error) {
         // Check if this is a rate limit error
         if (isRateLimitFetchError(error)) {
-          // Set global rate limit end time (60 seconds from now)
-          globalThis.__RATE_LIMIT_END_TIME__ = Date.now() + 60000
+          // Extract retryAfter duration from error (default to 60 seconds if not provided)
+          const retryAfterSeconds = (error as { retryAfter?: number }).retryAfter ?? 60
+          // Set global rate limit end time
+          globalThis.__RATE_LIMIT_END_TIME__ = Date.now() + retryAfterSeconds * 1000
+          globalThis.__RATE_LIMIT_DURATION__ = retryAfterSeconds
           // Trigger the rate limit modal via global handler
           globalThis.__RATE_LIMIT_TRIGGER__?.()
         }
@@ -105,8 +108,11 @@ export function createTradeRepository(ctx: {
       } catch (error) {
         // Check if this is a rate limit error
         if (isRateLimitFetchError(error)) {
-          // Set global rate limit end time (60 seconds from now)
-          globalThis.__RATE_LIMIT_END_TIME__ = Date.now() + 60000
+          // Extract retryAfter duration from error (default to 60 seconds if not provided)
+          const retryAfterSeconds = (error as { retryAfter?: number }).retryAfter ?? 60
+          // Set global rate limit end time
+          globalThis.__RATE_LIMIT_END_TIME__ = Date.now() + retryAfterSeconds * 1000
+          globalThis.__RATE_LIMIT_DURATION__ = retryAfterSeconds
           // Trigger the rate limit modal via global handler
           globalThis.__RATE_LIMIT_TRIGGER__?.()
         }


### PR DESCRIPTION
The rate limit modal was showing a hardcoded 60-second countdown, but the API returns 600 seconds (10 minutes). This caused user confusion as the modal would close after 1 minute, but users would still hit rate limits for the full 10 minutes.

Changes:
- Updated FetchError to extract retryAfter from API response body or Retry-After header
- Added global state to store rate limit duration from API
- Modified tradeRepository to use dynamic retryAfter value instead of hardcoded 60 seconds
- Updated RateLimitModal to display the actual rate limit duration from the API
- Fallback to 60 seconds if API doesn't provide retryAfter value