### PR TITLE
fix: Use JuiceSwap GraphQL endpoint instead of Uniswap fallback

### DIFF
--- a/apps/web/.env.development
+++ b/apps/web/.env.development
@@ -2,9 +2,7 @@
 # Loaded when running: yarn dev or yarn build:development
 
 # JuiceSwap Development API Endpoints
-# Note: GraphQL uses localhost:42069 which auto-redirects to Uniswap Beta GraphQL
-# because JuiceSwap API doesn't have GraphQL endpoints (only REST)
-REACT_APP_AWS_API_ENDPOINT="http://localhost:42069/v1/graphql"
+REACT_APP_AWS_API_ENDPOINT="https://dev.api.juiceswap.com/v1/graphql"
 REACT_APP_UNISWAP_GATEWAY_DNS="https://dev.api.juiceswap.com"
 REACT_APP_TRADING_API_URL_OVERRIDE="https://dev.api.juiceswap.com"
 REACT_APP_CUSTOM_QUOTE_API_URL="https://dev.api.juiceswap.com"

--- a/apps/web/src/appGraphql/data/apollo/client.ts
+++ b/apps/web/src/appGraphql/data/apollo/client.ts
@@ -2,14 +2,9 @@ import { ApolloClient, HttpLink } from '@apollo/client'
 import { setupSharedApolloCache } from 'uniswap/src/data/cache'
 // import { getDatadogApolloLink } from 'utilities/src/logger/datadog/datadogLink' // Commented out - Datadog disabled
 
-let apiUrl = process.env.REACT_APP_AWS_API_ENDPOINT
+const apiUrl = process.env.REACT_APP_AWS_API_ENDPOINT
 if (!apiUrl) {
   throw new Error('REACT_APP_AWS_API_ENDPOINT is not configured in environment variables')
-}
-
-// Prevent localhost GraphQL endpoints from being used to avoid CSP errors
-if (apiUrl.includes('localhost:42069')) {
-  apiUrl = 'https://beta.gateway.uniswap.org/v1/graphql'
 }
 
 const httpLink = new HttpLink({ uri: apiUrl })


### PR DESCRIPTION
The development environment was incorrectly configured to use localhost:42069 for GraphQL, which triggered a fallback to Uniswap's beta.gateway.uniswap.org. This caused CORS errors and 400 Bad Requests.

JuiceSwap does have a GraphQL endpoint at dev.api.juiceswap.com/v1/graphql with queries for:
- swaps (transaction statuses)
- quote (swap quotes)
- health (health check)

Changes:
- Updated .env.development to use dev.api.juiceswap.com/v1/graphql directly
- Removed incorrect comment claiming JuiceSwap has no GraphQL
- Removed localhost:42069 fallback logic in Apollo client that redirected to Uniswap
- Changed apiUrl from let to const as it no longer needs reassignment

This fixes CORS errors but note that Uniswap-specific queries (portfolios, assetActivities, etc.) will still fail as they don't exist in JuiceSwap's GraphQL schema.