### PR TITLE
Disable optional services (Amplitude, Statsig, Unitags, Scantastic, FOR)

### DIFF
--- a/apps/web/src/tracing/amplitude.ts
+++ b/apps/web/src/tracing/amplitude.ts
@@ -7,15 +7,16 @@ import { ApplicationTransport } from 'utilities/src/telemetry/analytics/Applicat
 import { analytics, getAnalyticsAtomDirect } from 'utilities/src/telemetry/analytics/analytics'
 
 export function setupAmplitude() {
-  getAnalyticsAtomDirect(true).then((allowAnalytics) => {
-    analytics.init({
-      transportProvider: new ApplicationTransport({
-        serverUrl: uniswapUrls.amplitudeProxyUrl,
-        appOrigin: OriginApplication.INTERFACE,
-        reportOriginCountry: (country: string) => store.dispatch(setOriginCountry(country)),
-      }),
-      allowed: allowAnalytics,
-      initHash: process.env.REACT_APP_GIT_COMMIT_HASH,
-    })
-  })
+  // Amplitude analytics disabled
+  // getAnalyticsAtomDirect(true).then((allowAnalytics) => {
+  //   analytics.init({
+  //     transportProvider: new ApplicationTransport({
+  //       serverUrl: uniswapUrls.amplitudeProxyUrl,
+  //       appOrigin: OriginApplication.INTERFACE,
+  //       reportOriginCountry: (country: string) => store.dispatch(setOriginCountry(country)),
+  //     }),
+  //     allowed: allowAnalytics,
+  //     initHash: process.env.REACT_APP_GIT_COMMIT_HASH,
+  //   })
+  // })
 }

--- a/packages/uniswap/src/constants/urls.ts
+++ b/packages/uniswap/src/constants/urls.ts
@@ -4,15 +4,10 @@ import { isAndroid, isExtension, isInterface, isMobileApp } from 'utilities/src/
 
 enum TrafficFlows {
   GraphQL = 'graphql',
-  Metrics = 'metrics',
-  Gating = 'gating',
   TradingApi = 'trading-api-labs',
-  Unitags = 'unitags',
-  FOR = 'for',
-  Scantastic = 'scantastic',
 }
 
-const FLOWS_USING_BETA = [TrafficFlows.FOR]
+const FLOWS_USING_BETA: TrafficFlows[] = []
 
 const isDevOrBeta = isPlaywrightEnv() ? false : isDevEnv() || isBetaEnv()
 
@@ -127,17 +122,15 @@ export const uniswapUrls = {
   apiBaseUrlV2: config.apiBaseUrlV2Override || `${getCloudflareApiBaseUrl()}/v2`,
   graphQLUrl: config.graphqlUrlOverride || `${getCloudflareApiBaseUrl(TrafficFlows.GraphQL)}/v1/graphql`,
 
-  // Proxies
-  amplitudeProxyUrl:
-    config.amplitudeProxyUrlOverride || `${getCloudflareApiBaseUrl(TrafficFlows.Metrics)}/v1/amplitude-proxy`,
-  statsigProxyUrl: config.statsigProxyUrlOverride || `${getCloudflareApiBaseUrl(TrafficFlows.Gating)}/v1/statsig-proxy`,
-
-  // Feature service URL's
-  unitagsApiUrl: config.unitagsApiUrlOverride || `${getCloudflareApiBaseUrl(TrafficFlows.Unitags)}/v2/unitags`,
-  scantasticApiUrl:
-    config.scantasticApiUrlOverride || `${getCloudflareApiBaseUrl(TrafficFlows.Scantastic)}/v2/scantastic`,
-  forApiUrl: config.forApiUrlOverride || `${getCloudflareApiBaseUrl(TrafficFlows.FOR)}/v2/FOR.v1.FORService`,
+  // Trading API
   tradingApiUrl: config.tradingApiUrlOverride || getCloudflareApiBaseUrl(TrafficFlows.TradingApi),
+
+  // Disabled services (kept for backwards compatibility)
+  amplitudeProxyUrl: config.amplitudeProxyUrlOverride || '',
+  statsigProxyUrl: config.statsigProxyUrlOverride || '',
+  unitagsApiUrl: config.unitagsApiUrlOverride || '',
+  scantasticApiUrl: config.scantasticApiUrlOverride || '',
+  forApiUrl: config.forApiUrlOverride || '',
 
   // Merkl Docs for LP Incentives
   merklDocsUrl: 'https://docs.merkl.xyz/earn-with-merkl/faq-earn#how-are-aprs-calculated',

--- a/packages/uniswap/src/data/apiClients/unitagsApi/UnitagsApiClient.ts
+++ b/packages/uniswap/src/data/apiClients/unitagsApi/UnitagsApiClient.ts
@@ -20,7 +20,7 @@ import {
 } from 'uniswap/src/features/unitags/types'
 
 const UnitagsApiClient = createApiClient({
-  baseUrl: uniswapUrls.unitagsApiUrl,
+  baseUrl: '', // Unitags service disabled
 })
 
 export async function fetchUsername(params: UnitagUsernameRequest): Promise<UnitagUsernameResponse> {

--- a/packages/uniswap/src/features/gating/statsigBaseConfig.ts
+++ b/packages/uniswap/src/features/gating/statsigBaseConfig.ts
@@ -3,7 +3,8 @@ import { getStatsigEnvName } from 'uniswap/src/features/gating/getStatsigEnvName
 import { StatsigOptions, getOverrideAdapter } from 'uniswap/src/features/gating/sdk/statsig'
 
 export const statsigBaseConfig: StatsigOptions = {
-  networkConfig: { api: uniswapUrls.statsigProxyUrl },
+  // Statsig feature flags disabled - using local overrides only
+  networkConfig: { api: '' }, // Disabled: uniswapUrls.statsigProxyUrl
   environment: {
     tier: getStatsigEnvName(),
   },


### PR DESCRIPTION
- Disable Amplitude analytics in setupAmplitude()
- Disable Statsig proxy by setting empty API URL
- Disable Unitags API client with empty baseUrl
- Remove TrafficFlows enum entries for disabled services (Metrics, Gating, Unitags, FOR, Scantastic)
- Set disabled service URLs to empty strings in urls.ts
- Keep config properties for backwards compatibility