### PR TITLE
Remove 'You receive' row from swap review modal

### DIFF
--- a/packages/uniswap/src/features/transactions/TransactionDetails/TransactionDetails.tsx
+++ b/packages/uniswap/src/features/transactions/TransactionDetails/TransactionDetails.tsx
@@ -17,7 +17,6 @@ import { ListSeparatorToggle } from 'uniswap/src/features/transactions/Transacti
 import { SwapFee } from 'uniswap/src/features/transactions/TransactionDetails/SwapFee'
 import { SwapReviewTokenWarningCard } from 'uniswap/src/features/transactions/TransactionDetails/SwapReviewTokenWarningCard'
 import { TransactionWarning } from 'uniswap/src/features/transactions/TransactionDetails/TransactionWarning'
-import { UserReceiveAmount } from 'uniswap/src/features/transactions/TransactionDetails/UserReceiveAmount'
 import type {
   FeeOnTransferFeeGroupProps,
   TokenWarningProps,
@@ -58,7 +57,6 @@ interface TransactionDetailsProps {
   RateInfo?: JSX.Element
   transactionUSDValue?: Maybe<CurrencyAmount<Currency>>
   txSimulationErrors?: TransactionFailureReason[]
-  amountUserWillReceive?: CurrencyAmount<Currency>
   includesDelegation?: boolean
 }
 
@@ -92,7 +90,6 @@ export function TransactionDetails({
   estimatedBridgingTime,
   RoutingInfo,
   RateInfo,
-  amountUserWillReceive,
   includesDelegation,
 }: PropsWithChildren<TransactionDetailsProps>): JSX.Element {
   const { t } = useTranslation()
@@ -165,9 +162,6 @@ export function TransactionDetails({
               </Flex>
             </AnimatePresence>
           ) : null}
-          {amountUserWillReceive && outputCurrency && priceUXEnabled && (
-            <UserReceiveAmount amountUserWillReceive={amountUserWillReceive} outputCurrency={outputCurrency} />
-          )}
         </Flex>
         {setTokenWarningChecked && tokenWarningProps && (
           <SwapReviewTokenWarningCard

--- a/packages/uniswap/src/features/transactions/swap/review/SwapDetails/SwapDetails.tsx
+++ b/packages/uniswap/src/features/transactions/swap/review/SwapDetails/SwapDetails.tsx
@@ -128,7 +128,6 @@ export function SwapDetails({
         estimatedBridgingTime={estimatedBridgingTime}
         isBridgeTrade={isBridgeTrade ?? false}
         txSimulationErrors={txSimulationErrors}
-        amountUserWillReceive={derivedSwapInfo.outputAmountUserWillReceive ?? undefined}
         includesDelegation={includesDelegation}
         onShowWarning={onShowWarning}
       >


### PR DESCRIPTION
The 'You receive' amount display in the swap review modal was showing incorrect values due to rounding issues with small amounts. Since this information is already displayed in the swap details above, this redundant row has been removed to avoid confusion.