### PR TITLE
fix: Correct USDC token address and add cUSD for Citrea Testnet

### DIFF
--- a/packages/uniswap/src/features/chains/evm/info/citrea.ts
+++ b/packages/uniswap/src/features/chains/evm/info/citrea.ts
@@ -12,12 +12,13 @@ import {
 } from 'uniswap/src/features/chains/types'
 import { Platform } from 'uniswap/src/features/platforms/types/Platform'
 import { ElementName } from 'uniswap/src/features/telemetry/constants'
-import { buildCUSD } from 'uniswap/src/features/tokens/stablecoin'
+import { buildCUSD, buildUSDC } from 'uniswap/src/features/tokens/stablecoin'
 import { defineChain } from 'viem'
 
 const testnetTokens = buildChainTokens({
   stables: {
-    USDC: buildCUSD('0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0', UniverseChainId.CitreaTestnet),
+    USDC: buildUSDC('0x36c16eaC6B0Ba6c50f494914ff015fCa95B7835F', UniverseChainId.CitreaTestnet),
+    CUSD: buildCUSD('0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0', UniverseChainId.CitreaTestnet),
   },
 })
 


### PR DESCRIPTION
## Problem
Swapping from cBTC to cUSD worked, but swapping from cUSD to USDC failed with "NO_ROUTE" error, despite pools existing in the backend API.

## Root Cause
The USDC token configuration in citrea.ts used the wrong address:
- Configured: 0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0 (cUSD address)
- Should be: 0x36c16eaC6B0Ba6c50f494914ff015fCa95B7835F (USDC address)

Additionally, the wrong builder function was used:
- Used: buildCUSD() (18 decimals, symbol 'cUSD')
- Should use: buildUSDC() (6 decimals, symbol 'USDC')

## Why This Caused the Issue
When a user tried to swap cUSD → USDC:
1. User selects: Input=cUSD (0x2fFC...), Output="USDC"
2. Frontend sends: tokenIn=0x2fFC..., tokenOut=0x2fFC... (same token!)
3. API cannot find route because it's the same token

The API has correct pool definitions:
- CUSD/USDC pool exists (FeeAmount.LOW)
- USDC/WCBTC pools exist (multiple fee tiers)
- CUSD/WCBTC pool exists

But the frontend never queried them due to wrong token address.

## Evidence
1. API token definitions (/api/src/providers/citreaStaticPools.ts):
   - CUSD: 0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0 (18 decimals)
   - USDC: 0x36c16eaC6B0Ba6c50f494914ff015fCa95B7835F (6 decimals)

2. Frontend hardcodedTokens.ts correctly defines both:
   - citreaCusdCurrency: 0x2fFC... symbol 'cUSD'
   - citreaUsdcCurrency: 0x36c1... symbol 'USDC'

3. API has CUSD/USDC pool configured (lines 124-129 of citreaStaticPools.ts)

## Solution
1. Changed USDC to use buildUSDC() with correct address (0x36c1...)
2. Added CUSD as separate token using buildCUSD() with address (0x2fFC...)
3. Both stablecoins are now properly available for trading

## Testing
- Type checks pass: yarn g:typecheck ✓
- This fix has existed since initial Citrea integration (commit 616f5d277)

🤖 Generated with [Claude Code](https://claude.com/claude-code)