### PR TITLE
Remove Merkl docs dependencies

### DIFF
--- a/apps/web/src/components/Pools/PoolTable/PoolTable.tsx
+++ b/apps/web/src/components/Pools/PoolTable/PoolTable.tsx
@@ -130,14 +130,7 @@ function PoolTableHeader({
     [PoolSortFields.Volume30D]: t('pool.volume.thirtyDay'),
     [PoolSortFields.VolOverTvl]: undefined,
     [PoolSortFields.Apr]: t('pool.apr.description'),
-    [PoolSortFields.RewardApr]: (
-      <>
-        {t('pool.incentives.merklDocs')}
-        {/* TODO: Re-enable once support.juiceswap.xyz is configured
-        <LearnMoreLink textVariant="buttonLabel4" url={uniswapUrls.merklDocsUrl} />
-        */}
-      </>
-    ),
+    [PoolSortFields.RewardApr]: t('pool.apr.reward'),
   }
   const HEADER_TEXT = {
     [PoolSortFields.TVL]: t('common.totalValueLocked'),

--- a/packages/uniswap/src/constants/urls.ts
+++ b/packages/uniswap/src/constants/urls.ts
@@ -132,9 +132,6 @@ export const uniswapUrls = {
   scantasticApiUrl: config.scantasticApiUrlOverride || '',
   forApiUrl: config.forApiUrlOverride || '',
 
-  // Merkl Docs for LP Incentives
-  merklDocsUrl: 'https://docs.merkl.xyz/earn-with-merkl/faq-earn#how-are-aprs-calculated',
-
   // Embedded Wallet URL's
   // Totally fine that these are public
   evervaultDevUrl: 'https://embedded-wallet-dev.app-907329d19a06.enclave.evervault.com',

--- a/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/YouReceiveDetails/YouReceiveDetails.web.tsx
+++ b/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/YouReceiveDetails/YouReceiveDetails.web.tsx
@@ -19,7 +19,6 @@ import {
   BestRouteUniswapXTooltip,
 } from 'uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormTooltips/BestRouteTooltip'
 import { SwapFeeOnTransferTooltip } from 'uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormTooltips/FeeDetailsTooltip'
-import { LargePriceDifferenceTooltip } from 'uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormTooltips/LargePriceDifferenceTooltip'
 import {
   AutoSlippageBadge,
   MaxSlippageTooltip,
@@ -128,8 +127,8 @@ function PriceDifferenceDisplay({
 }: {
   priceDifference: UsePriceDifferenceReturnType
 }): JSX.Element | null {
-  const { t } = useTranslation()
-  const { formatPercent } = useLocalizationContext()
+  // const { t } = useTranslation()
+  // const { formatPercent } = useLocalizationContext()
 
   if (!priceDifference.showPriceDifferenceWarning) {
     return null

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -1352,7 +1352,6 @@
   "pool.incentives.collectRewardsCanceled": "Collect rewards canceled",
   "pool.incentives.daysLeft": "days left",
   "pool.incentives.eligible": "Eligible pools have token rewards so you can earn more",
-  "pool.incentives.merklDocs": "Calculated by Merkl from emission rewards and pool TVL.",
   "pool.incentives.rewardsDistribution": "Rewards distribution",
   "pool.incentives.rewardsEarned": "Rewards earned",
   "pool.incentives.similarPoolHasRewards": "A similar pool has UNI rewards",


### PR DESCRIPTION
- Remove merklDocsUrl from constants/urls.ts
- Remove pool.incentives.merklDocs translation string
- Simplify PoolTable header tooltip to use standard translation
- Comment out unused variables in PriceDifferenceDisplay