### PR TITLE
Add automatic NFT import to wallet after claim

### DIFF
--- a/apps/web/src/pages/FirstSqueezer/NFTClaimSection.tsx
+++ b/apps/web/src/pages/FirstSqueezer/NFTClaimSection.tsx
@@ -78,7 +78,7 @@ interface NFTClaimSectionProps {
 }
 
 export function NFTClaimSection({ isEligible, walletAddress }: NFTClaimSectionProps) {
-  const { claim, isClaiming, error, claimResult } = useClaimNFT()
+  const { claim, isClaiming, error, claimResult, isRabbyWallet } = useClaimNFT()
   const [showConfetti, setShowConfetti] = useState(false)
   const { width, height } = useWindowSize()
 
@@ -178,6 +178,7 @@ export function NFTClaimSection({ isEligible, walletAddress }: NFTClaimSectionPr
       {walletAddress && (
         <Text variant="body4" color="$neutral3" textAlign="center">
           NFT will be minted to: {walletAddress.slice(0, 6)}...{walletAddress.slice(-4)}
+          {isRabbyWallet && ' (use MetaMask for auto-import)'}
         </Text>
       )}
     </ClaimContainer>


### PR DESCRIPTION
## Summary

After a user successfully claims their First Squeezer NFT, the wallet will now automatically prompt them to add the NFT to their wallet using the `wallet_watchAsset` RPC method. This eliminates the need for users to manually import the NFT.

## Changes

- **Token ID extraction**: Parse the transaction receipt to extract the NFT token ID from the ERC-721 Transfer event logs
- **Contract address storage**: Store the NFT contract address during the claim process for later use
- **Automatic wallet import**: After successful claim confirmation, automatically call `wallet_watchAsset` to prompt the user to add the NFT
- **Token ID display**: Show the token ID in the success message

## How it works

1. User clicks "Claim NFT" button
2. Transaction is submitted and confirmed on Citrea Testnet
3. Token ID is extracted from the transaction receipt
4. Wallet (e.g., MetaMask) automatically prompts the user to add the NFT with the correct contract address and token ID
5. User approves and the NFT appears in their wallet

## Testing

Tested on Citrea Testnet with MetaMask. After claiming the NFT, MetaMask automatically showed the "Add suggested NFT" dialog.