### PR TITLE
Fix First Squeezer campaign timing

### DIFF
--- a/apps/web/src/services/firstSqueezerCampaign/hooks.ts
+++ b/apps/web/src/services/firstSqueezerCampaign/hooks.ts
@@ -132,7 +132,9 @@ function useUrlFirstSqueezerOverride(): boolean {
 function useIsFirstSqueezerTimeActive(): boolean {
   const hasUrlOverride = useUrlFirstSqueezerOverride()
 
-  // Campaign start time: October 22, 2025 at 00:00 UTC
+  // Campaign times match smart contract:
+  // Start: October 22, 2025 13:30:00 UTC (timestamp: 1761139800)
+  // End: October 26, 2025 23:59:59 UTC (timestamp: 1761523199)
   return useMemo(() => {
     // URL Override has priority - if active, campaign is always on
     if (hasUrlOverride) {
@@ -140,9 +142,10 @@ function useIsFirstSqueezerTimeActive(): boolean {
     }
 
     // Normal time-based logic
-    const campaignStartTime = new Date('2025-10-22T00:00:00.000Z').getTime()
+    const campaignStartTime = new Date('2025-10-22T13:30:00.000Z').getTime()
+    const campaignEndTime = new Date('2025-10-26T23:59:59.000Z').getTime()
     const now = Date.now()
-    return now >= campaignStartTime
+    return now >= campaignStartTime && now <= campaignEndTime
   }, [hasUrlOverride])
 }
 


### PR DESCRIPTION
## Summary
Updates the First Squeezer campaign visibility timing to match the smart contract deployment.

## Changes
- **Campaign Start**: Updated from October 22, 2025 00:00:00 UTC to **13:30:00 UTC**
- **Campaign End**: Added end date of **October 26, 2025 23:59:59 UTC** (previously unlimited)

## Impact
This ensures frontend components (banner, navigation tab, campaign page) are only visible during the active campaign period as defined in the `FirstSqueezerNFT` smart contract:
- `CAMPAIGN_START = 1761139800` (Oct 22, 2025 13:30:00 UTC)
- `CAMPAIGN_END = 1761523199` (Oct 26, 2025 23:59:59 UTC)

## Test Plan
- [ ] Verify banner does not show before campaign start
- [ ] Verify banner shows during campaign period (Oct 22-26)
- [ ] Verify banner does not show after campaign end
- [ ] Verify navigation tab follows same visibility rules
- [ ] Test URL override (`?first-squeezer=true`) still works for testing