### PR TITLE
Remove Solana wallet support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -70,7 +70,6 @@
     "@crowdin/cli": "3.14.0",
     "@ethersproject/experimental": "5.7.0",
     "@playwright/test": "1.49.1",
-    "@solana/wallet-adapter-base": "0.9.27",
     "@storybook/addon-essentials": "8.5.2",
     "@storybook/addon-interactions": "8.5.2",
     "@storybook/blocks": "8.5.2",

--- a/apps/web/src/components/TopLevelModals/index.tsx
+++ b/apps/web/src/components/TopLevelModals/index.tsx
@@ -60,7 +60,6 @@ export default function TopLevelModals() {
       <ModalRenderer modalName={ModalName.PrivacyPolicy} />
       <ModalRenderer modalName={ModalName.PrivacyChoices} />
       <ModalRenderer modalName={ModalName.FeatureFlags} />
-      <ModalRenderer modalName={ModalName.SolanaPromo} />
       {shouldShowDevFlags && <ModalRenderer modalName={ModalName.DevFlags} />}
       <ModalRenderer modalName={ModalName.AddLiquidity} />
       <ModalRenderer modalName={ModalName.RemoveLiquidity} />

--- a/apps/web/src/features/wallet/connection/connectors/multiplatform.test.ts
+++ b/apps/web/src/features/wallet/connection/connectors/multiplatform.test.ts
@@ -1,6 +1,7 @@
 import { deduplicateWalletConnectorMeta } from 'features/wallet/connection/connectors/multiplatform'
 import type { WalletConnectorMeta } from 'features/wallet/connection/types/WalletConnectorMeta'
 import { METAMASK_CONNECTOR } from 'test-utils/wallets/fixtures'
+import { CONNECTION_PROVIDER_IDS } from 'uniswap/src/constants/web3'
 import { describe, expect, it } from 'vitest'
 
 describe('multiplatform connectors', () => {
@@ -50,207 +51,46 @@ describe('multiplatform connectors', () => {
       expect(result).toEqual(expect.arrayContaining(walletConnectors))
     })
 
-    it('should not deduplicate solana connectors with exact same name on same platform', () => {
+    it('should not merge custom connectors with same name', () => {
       // Arrange
       const walletConnectors: WalletConnectorMeta[] = [
         {
-          name: 'Phantom',
-          icon: 'phantom.svg',
-          solana: { walletName: 'Phantom' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'Phantom',
-          icon: 'phantom-alt.svg',
-          solana: { walletName: 'Phantom' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toEqual(expect.arrayContaining(walletConnectors))
-    })
-
-    it('should merge connectors with same name on different platforms', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'MetaMask',
-          icon: 'metamask.svg',
-          wagmi: { id: 'metamask', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'MetaMask',
-          icon: 'metamask-wallet.svg',
-          solana: { walletName: 'MetaMask' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'MetaMask',
-        icon: 'metamask.svg',
-        wagmi: { id: 'metamask', type: 'injected' },
-        solana: { walletName: 'MetaMask' as any },
-        isInjected: true,
-        analyticsWalletType: 'Browser Extension',
-      })
-    })
-
-    it('should merge different-platform connectors whose whose names differ by inclusion of "Wallet" in one of the names', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'Phantom',
-          icon: 'phantom.svg',
-          wagmi: { id: 'phantom', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'Phantom Wallet',
-          icon: 'phantom-wallet.svg',
-          solana: { walletName: 'Phantom' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'Phantom',
-        icon: 'phantom.svg',
-        wagmi: { id: 'phantom', type: 'injected' },
-        solana: { walletName: 'Phantom' as any },
-        isInjected: true,
-        analyticsWalletType: 'Browser Extension',
-      })
-    })
-
-    it('should preserve different connectors with different names', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'MetaMask',
-          icon: 'metamask.svg',
-          wagmi: { id: 'metamask', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'Coinbase Wallet',
-          icon: 'coinbase.svg',
-          wagmi: { id: 'coinbase', type: 'coinbaseWallet' },
+          name: 'WalletConnect',
+          icon: 'wc.svg',
+          wagmi: { id: 'walletconnect', type: 'injected' },
           isInjected: false,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'Phantom',
-          icon: 'phantom.svg',
-          solana: { walletName: 'Phantom' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(3)
-      expect(result).toEqual(
-        expect.arrayContaining([
-          {
-            name: 'MetaMask',
-            icon: 'metamask.svg',
-            wagmi: { id: 'metamask', type: 'injected' },
-            isInjected: true,
-            analyticsWalletType: 'Browser Extension',
-          },
-          {
-            name: 'Coinbase Wallet',
-            icon: 'coinbase.svg',
-            wagmi: { id: 'coinbase', type: 'coinbaseWallet' },
-            isInjected: false,
-            analyticsWalletType: 'Browser Extension',
-          },
-          {
-            name: 'Phantom',
-            icon: 'phantom.svg',
-            solana: { walletName: 'Phantom' as any },
-            isInjected: true,
-            analyticsWalletType: 'Browser Extension',
-          },
-        ]),
-      )
-    })
-
-    it('should merge wagmi and solana connectors with same name', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'Phantom',
-          icon: 'phantom.svg',
-          wagmi: { id: 'phantom', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'Phantom',
-          icon: 'phantom-solana.svg',
-          solana: { walletName: 'Phantom' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'Phantom',
-        icon: 'phantom.svg',
-        wagmi: { id: 'phantom', type: 'injected' },
-        solana: { walletName: 'Phantom' as any },
-        isInjected: true,
-        analyticsWalletType: 'Browser Extension',
-      })
-    })
-
-    it('should not merge custom connectors with other connectors', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'Custom Connector',
-          icon: 'normal.svg',
-          wagmi: { id: 'normalConnectorId', type: 'injected' },
-          customConnectorId: 'uniswapWalletConnect',
-          isInjected: true,
           analyticsWalletType: 'Wallet Connect',
         },
         {
-          name: 'Custom Connector',
-          icon: 'sus.svg',
-          solana: { walletName: 'Malicious Extension' as any },
+          name: 'WalletConnect',
+          icon: 'custom.svg',
+          customConnectorId: CONNECTION_PROVIDER_IDS.UNISWAP_WALLET_CONNECT_CONNECTOR_ID,
+          isInjected: false,
+          analyticsWalletType: 'Wallet Connect',
+        },
+      ]
+
+      // Act
+      const result = deduplicateWalletConnectorMeta(walletConnectors)
+
+      // Assert - should not merge when one has customConnectorId
+      expect(result).toHaveLength(2)
+    })
+
+    it('should handle connectors with different names', () => {
+      // Arrange
+      const walletConnectors: WalletConnectorMeta[] = [
+        {
+          name: 'MetaMask',
+          icon: 'metamask.svg',
+          wagmi: { id: 'metamask', type: 'injected' },
+          isInjected: true,
+          analyticsWalletType: 'Browser Extension',
+        },
+        {
+          name: 'Coinbase',
+          icon: 'coinbase.svg',
+          wagmi: { id: 'coinbase', type: 'injected' },
           isInjected: true,
           analyticsWalletType: 'Browser Extension',
         },
@@ -260,10 +100,10 @@ describe('multiplatform connectors', () => {
       const result = deduplicateWalletConnectorMeta(walletConnectors)
 
       // Assert
-      expect(result).toEqual(walletConnectors)
+      expect(result).toHaveLength(2)
     })
 
-    it('should not deduplicate connectors if more than 2 connectors have the same normalized name', () => {
+    it('should normalize names for matching (case insensitive, remove "wallet" suffix)', () => {
       // Arrange
       const walletConnectors: WalletConnectorMeta[] = [
         {
@@ -274,16 +114,9 @@ describe('multiplatform connectors', () => {
           analyticsWalletType: 'Browser Extension',
         },
         {
-          name: 'METAMASK WALLET',
-          icon: 'metamask-caps.svg',
-          solana: { walletName: 'METAMASK WALLET' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'MetaMask',
-          icon: 'metamask-sus.svg',
-          solana: { walletName: 'sus metamask' as any },
+          name: 'METAMASK',
+          icon: 'metamask-alt.svg',
+          wagmi: { id: 'metamask-alt', type: 'injected' },
           isInjected: true,
           analyticsWalletType: 'Browser Extension',
         },
@@ -292,110 +125,8 @@ describe('multiplatform connectors', () => {
       // Act
       const result = deduplicateWalletConnectorMeta(walletConnectors)
 
-      // Assert
-      expect(result).toEqual(walletConnectors)
-    })
-
-    it('should preserve order of first occurrence when merging', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'MetaMask Wallet',
-          icon: 'metamask-wallet.svg',
-          wagmi: { id: 'metamask-wallet', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'MetaMask',
-          icon: 'metamask.svg',
-          solana: { walletName: 'MetaMask' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'MetaMask Wallet',
-        icon: 'metamask-wallet.svg',
-        wagmi: { id: 'metamask-wallet', type: 'injected' },
-        solana: { walletName: 'MetaMask' as any },
-        isInjected: true,
-        analyticsWalletType: 'Browser Extension',
-      })
-    })
-
-    it('should handle connectors with undefined properties on different platforms', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'MetaMask',
-          icon: undefined,
-          wagmi: { id: 'metamask', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'MetaMask Wallet',
-          icon: 'metamask.svg',
-          solana: { walletName: 'MetaMask' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'MetaMask',
-        icon: 'metamask.svg',
-        wagmi: { id: 'metamask', type: 'injected' },
-        solana: { walletName: 'MetaMask' as any },
-        isInjected: true,
-        analyticsWalletType: 'Browser Extension',
-      })
-    })
-
-    it('should handle special characters in wallet names on different platforms', () => {
-      // Arrange
-      const walletConnectors: WalletConnectorMeta[] = [
-        {
-          name: 'Wallet & Co.',
-          icon: 'wallet-co.svg',
-          wagmi: { id: 'wallet-co', type: 'injected' },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-        {
-          name: 'Wallet & Co. Wallet',
-          icon: 'wallet-co-wallet.svg',
-          solana: { walletName: 'Wallet & Co. Wallet' as any },
-          isInjected: true,
-          analyticsWalletType: 'Browser Extension',
-        },
-      ]
-
-      // Act
-      const result = deduplicateWalletConnectorMeta(walletConnectors)
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'Wallet & Co.',
-        icon: 'wallet-co.svg',
-        wagmi: { id: 'wallet-co', type: 'injected' },
-        solana: { walletName: 'Wallet & Co. Wallet' as any },
-        isInjected: true,
-        analyticsWalletType: 'Browser Extension',
-      })
+      // Assert - both remain because they are on the same platform
+      expect(result).toHaveLength(2)
     })
   })
 })

--- a/apps/web/src/features/wallet/connection/connectors/multiplatform.ts
+++ b/apps/web/src/features/wallet/connection/connectors/multiplatform.ts
@@ -4,7 +4,7 @@ import { logger } from 'utilities/src/logger/logger'
 const NORMALIZATION_RULES = [
   // Convert to lowercase
   (name: string) => name.toLowerCase(),
-  // Remove "Wallet" from the end of the `name`, for cases like "Phantom" being used as an eip6963/wagmi name while Solana utils use the `name` "Phantom Wallet"
+  // Remove "Wallet" from the end of the `name`
   (name: string) => name.replace(/ wallet$/, ''),
 ]
 
@@ -16,12 +16,6 @@ function normalizeWalletName(name: string) {
  * Merges wallet connectors into a single wallet connector, preferring the values from the first wallet connector.
  * @param walletConnectors - The wallet connectors to merge.
  * @returns A new wallet connector that represents the same wallet on multiple platforms.
- *
- * @example
- * const walletConnectorMeta1 = { name: 'Phantom', wagmi: { id: 'phantom', type: 'injected' }, isInjected: true  }
- * const walletConnectorMeta2 = { name: 'Phantom Wallet', solana: { walletName: 'Phantom Wallet' }, icon: 'https://icon.com', isInjected: true  }
- * const mergedWalletConnectorMeta = mergeWalletConnectorMeta(walletConnectorMeta1, walletConnectorMeta2)
- * // mergedWalletConnectorMeta = { name: 'Phantom', wagmi: { id: 'phantom', type: 'injected' }, solana: { walletName: 'Phantom Wallet' }, icon: 'https://icon.com', isInjected: true  }
  */
 function mergeWalletConnectorMeta(
   ...walletConnectors: [WalletConnectorMeta, WalletConnectorMeta, ...WalletConnectorMeta[]]
@@ -47,11 +41,11 @@ function mergeWalletConnectorMeta(
   return mergedWalletConnector
 }
 
-/** Checks if two wallet connector meta objects can be merged, based on whether one has a solana wallet name and the other has a wagmi connector id. */
+/** Checks if two wallet connector meta objects can be merged, based on whether they use different connector types. */
 function areConnectorsOnDifferentPlatforms(connector1: WalletConnectorMeta, connector2: WalletConnectorMeta): boolean {
   return (
-    Boolean(connector1.solana?.walletName) !== Boolean(connector2.solana?.walletName) &&
-    Boolean(connector1.wagmi?.id) !== Boolean(connector2.wagmi?.id)
+    Boolean(connector1.wagmi?.id) !== Boolean(connector2.wagmi?.id) ||
+    Boolean(connector1.customConnectorId) !== Boolean(connector2.customConnectorId)
   )
 }
 
@@ -86,7 +80,7 @@ export function deduplicateWalletConnectorMeta(walletConnectorMeta: WalletConnec
   const keyToConnectorsMap = new Map<string, WalletConnectorMeta[]>()
 
   for (const connector of walletConnectorMeta) {
-    // Use name as key, as solana wallet names do not have ids or rdns
+    // Use name as key for deduplication
     const key = normalizeWalletName(connector.name)
     const existing = keyToConnectorsMap.get(key) ?? []
     keyToConnectorsMap.set(key, [...existing, connector])

--- a/apps/web/src/features/wallet/connection/connectors/state.test.ts
+++ b/apps/web/src/features/wallet/connection/connectors/state.test.ts
@@ -201,15 +201,11 @@ describe('state', () => {
       const mockService = createMockConnectWalletService()
       const trackedService = wrapConnectWalletServiceWithStateTracking(mockService)
       const wagmiMeta = createMockWalletConnectorMeta({ wagmi: { id: 'metamask', type: 'injected' } })
-      const solanaMeta = createMockWalletConnectorMeta({ solana: { walletName: 'Phantom' as any } })
       const customMeta = createMockWalletConnectorMeta({ customConnectorId: 'uniswapWalletConnect' as any })
 
       // Act & Assert
       await trackedService.connect({ walletConnector: wagmiMeta })
       expect(mockService.connect).toHaveBeenCalledWith({ walletConnector: wagmiMeta })
-
-      await trackedService.connect({ walletConnector: solanaMeta })
-      expect(mockService.connect).toHaveBeenCalledWith({ walletConnector: solanaMeta })
 
       await trackedService.connect({ walletConnector: customMeta })
       expect(mockService.connect).toHaveBeenCalledWith({ walletConnector: customMeta })

--- a/apps/web/src/features/wallet/connection/services/ConnectWalletService.test.ts
+++ b/apps/web/src/features/wallet/connection/services/ConnectWalletService.test.ts
@@ -5,7 +5,6 @@ import {
 } from 'features/wallet/connection/services/ConnectWalletService'
 import type {
   CustomWalletConnectorMeta,
-  SolanaWalletConnectorMeta,
   WagmiWalletConnectorMeta,
 } from 'features/wallet/connection/types/WalletConnectorMeta'
 import { CONNECTION_PROVIDER_IDS } from 'uniswap/src/constants/web3'
@@ -29,30 +28,18 @@ const createMockWagmiWalletConnectorMeta = (overrides = {}): WagmiWalletConnecto
   ...overrides,
 })
 
-const createMockSolanaWalletConnectorMeta = (overrides = {}): SolanaWalletConnectorMeta => ({
-  name: 'Solana Wallet',
-  icon: 'solana-icon.svg',
-  solana: { walletName: 'Phantom' as any },
-  isInjected: true,
-  analyticsWalletType: 'Browser Extension',
-  ...overrides,
-})
-
 describe('ConnectWalletService', () => {
-  let mockConnectSolanaWallet: Mock
   let mockConnectWagmiWallet: Mock
   let mockConnectCustomWalletsMap: Record<CustomConnectorId, Mock>
   let connectWalletService: ConnectWalletService
 
   beforeEach(() => {
-    mockConnectSolanaWallet = vi.fn().mockResolvedValue(undefined)
     mockConnectWagmiWallet = vi.fn().mockResolvedValue(undefined)
     mockConnectCustomWalletsMap = {
       [CONNECTION_PROVIDER_IDS.UNISWAP_WALLET_CONNECT_CONNECTOR_ID]: vi.fn().mockResolvedValue(undefined),
     }
 
     connectWalletService = createConnectWalletService({
-      connectSolanaWallet: mockConnectSolanaWallet,
       connectWagmiWallet: mockConnectWagmiWallet,
       connectCustomWalletsMap: mockConnectCustomWalletsMap,
     })
@@ -75,7 +62,6 @@ describe('ConnectWalletService', () => {
         mockConnectCustomWalletsMap[CONNECTION_PROVIDER_IDS.UNISWAP_WALLET_CONNECT_CONNECTOR_ID],
       ).toHaveBeenCalledWith(expectedCustomConnector)
       expect(mockConnectWagmiWallet).not.toHaveBeenCalled()
-      expect(mockConnectSolanaWallet).not.toHaveBeenCalled()
     })
 
     it('should connect wagmi wallet when wagmiConnectorId is provided', async () => {
@@ -94,26 +80,6 @@ describe('ConnectWalletService', () => {
       expect(
         mockConnectCustomWalletsMap[CONNECTION_PROVIDER_IDS.UNISWAP_WALLET_CONNECT_CONNECTOR_ID],
       ).not.toHaveBeenCalled()
-      expect(mockConnectSolanaWallet).not.toHaveBeenCalled()
-    })
-
-    it('should connect solana wallet when solanaWalletName is provided', async () => {
-      // Arrange
-      const solanaWalletConnector = createMockSolanaWalletConnectorMeta()
-      const expectedSolanaConnector = {
-        ...solanaWalletConnector,
-        solana: { walletName: 'Phantom' },
-      }
-
-      // Act
-      await connectWalletService.connect({ walletConnector: solanaWalletConnector })
-
-      // Assert
-      expect(mockConnectSolanaWallet).toHaveBeenCalledWith(expectedSolanaConnector)
-      expect(
-        mockConnectCustomWalletsMap[CONNECTION_PROVIDER_IDS.UNISWAP_WALLET_CONNECT_CONNECTOR_ID],
-      ).not.toHaveBeenCalled()
-      expect(mockConnectWagmiWallet).not.toHaveBeenCalled()
     })
 
     it('should handle custom wallet connection errors gracefully', async () => {
@@ -137,18 +103,6 @@ describe('ConnectWalletService', () => {
       // Act & Assert
       await expect(connectWalletService.connect({ walletConnector: wagmiWalletConnector })).rejects.toThrow(
         'Wagmi wallet connection failed',
-      )
-    })
-
-    it('should handle solana wallet connection errors gracefully', async () => {
-      // Arrange
-      const error = new Error('Solana wallet connection failed')
-      mockConnectSolanaWallet.mockRejectedValue(error)
-      const solanaWalletConnector = createMockSolanaWalletConnectorMeta()
-
-      // Act & Assert
-      await expect(connectWalletService.connect({ walletConnector: solanaWalletConnector })).rejects.toThrow(
-        'Solana wallet connection failed',
       )
     })
 
@@ -190,7 +144,6 @@ describe('ConnectWalletService', () => {
     it('should create service with provided context', () => {
       // Arrange
       const context = {
-        connectSolanaWallet: mockConnectSolanaWallet,
         connectWagmiWallet: mockConnectWagmiWallet,
         connectCustomWalletsMap: mockConnectCustomWalletsMap,
       }

--- a/apps/web/src/features/wallet/connection/services/ConnectWalletService.ts
+++ b/apps/web/src/features/wallet/connection/services/ConnectWalletService.ts
@@ -1,7 +1,6 @@
 import type { CustomConnectorId } from 'features/wallet/connection/connectors/custom'
 import type {
   CustomWalletConnectorMeta,
-  SolanaWalletConnectorMeta,
   WagmiWalletConnectorMeta,
   WalletConnectorMeta,
 } from 'features/wallet/connection/types/WalletConnectorMeta'
@@ -11,17 +10,16 @@ export interface ConnectWalletService {
 }
 
 interface CreateConnectWalletServiceContext {
-  connectSolanaWallet?: (connector: SolanaWalletConnectorMeta) => Promise<void>
   connectWagmiWallet: (connector: WagmiWalletConnectorMeta) => Promise<void>
   connectCustomWalletsMap: Record<CustomConnectorId, (connector: CustomWalletConnectorMeta) => Promise<void>>
 }
 
 export function createConnectWalletService(ctx: CreateConnectWalletServiceContext): ConnectWalletService {
-  const { connectSolanaWallet, connectWagmiWallet, connectCustomWalletsMap } = ctx
+  const { connectWagmiWallet, connectCustomWalletsMap } = ctx
 
   return {
     connect: async (params: { walletConnector: WalletConnectorMeta }) => {
-      const { customConnectorId, wagmi, solana } = params.walletConnector
+      const { customConnectorId, wagmi } = params.walletConnector
       if (customConnectorId) {
         const connectCustomWallet = connectCustomWalletsMap[customConnectorId]
         await connectCustomWallet({ ...params.walletConnector, customConnectorId })
@@ -29,10 +27,6 @@ export function createConnectWalletService(ctx: CreateConnectWalletServiceContex
 
       if (wagmi?.id) {
         await connectWagmiWallet({ ...params.walletConnector, wagmi })
-      }
-
-      if (solana?.walletName && connectSolanaWallet) {
-        await connectSolanaWallet({ ...params.walletConnector, solana })
       }
     },
   }

--- a/apps/web/src/features/wallet/connection/types/WalletConnectorMeta.ts
+++ b/apps/web/src/features/wallet/connection/types/WalletConnectorMeta.ts
@@ -1,4 +1,3 @@
-import type { WalletName as SolanaWalletName } from "@solana/wallet-adapter-base"
 import type { CustomConnectorId } from "features/wallet/connection/connectors/custom"
 import type { Prettify } from "viem"
 
@@ -16,13 +15,11 @@ export type WalletConnectorMeta = {
   analyticsWalletType: string
 } & AtLeastOne<{
   wagmi?: WagmiConnectorDetails
-  solana?: SolanaConnectorDetails 
   /** The id of this connector, if this connector has custom logic (e.g. embedded wallet connector or uniswap wallet connect connector). */
   customConnectorId?: CustomConnectorId
 }>
 
 
-export type SolanaWalletConnectorMeta = Prettify<Extract<WalletConnectorMeta, { solana: SolanaConnectorDetails }>>
 export type WagmiWalletConnectorMeta = Prettify<Extract<WalletConnectorMeta, { wagmi: WagmiConnectorDetails }>>
 export type CustomWalletConnectorMeta = Prettify<Extract<WalletConnectorMeta, { customConnectorId: CustomConnectorId }>>
 
@@ -30,9 +27,4 @@ export type WagmiConnectorDetails = {
   /** The wagmi connector is of this connector, if this connector is linked to a wagmi connector. */
   id: string
   type: string // temporarily kept for backwards analytics compatibility
-}
-
-type SolanaConnectorDetails = {
-  /** The "@solana/wallet-adapter-base" `WalletName` of this connector, if this connector is linked to a solana wallet. */
-  walletName: SolanaWalletName
 }

--- a/apps/web/src/features/wallet/connection/utils.ts
+++ b/apps/web/src/features/wallet/connection/utils.ts
@@ -5,7 +5,7 @@ import { WalletConnectorMeta } from 'features/wallet/connection/types/WalletConn
  * Returns true if the meta object has any of its connector IDs matching the compareTo string.
  */
 export const isEqualWalletConnectorMetaId = (meta: WalletConnectorMeta, compareTo: string) => {
-  return meta.wagmi?.id === compareTo || meta.customConnectorId === compareTo || meta.solana?.walletName === compareTo
+  return meta.wagmi?.id === compareTo || meta.customConnectorId === compareTo
 }
 
 export function getConnectorWithId({
@@ -15,7 +15,7 @@ export function getConnectorWithId({
   connectors: WalletConnectorMeta[]
   id: string
 }): WalletConnectorMeta | undefined {
-  return connectors.find((c) => c.wagmi?.id === id || c.customConnectorId === id || c.solana?.walletName === id)
+  return connectors.find((c) => c.wagmi?.id === id || c.customConnectorId === id)
 }
 
 export function getConnectorWithIdWithThrow({

--- a/apps/web/vite/mockAssets.tsx
+++ b/apps/web/vite/mockAssets.tsx
@@ -56,7 +56,6 @@ vi.mock('ui/src/assets', () => ({
   WORLD_CHAIN_LOGO: 'world-chain-logo.png',
   ZORA_LOGO: 'zora-logo.png',
   ZKSYNC_LOGO: 'zksync-logo.png',
-  SOLANA_LOGO: 'solana-logo.png',
   SONEIUM_LOGO: 'soneium-logo.png',
   UNICHAIN_LOGO: 'unichain-logo.png',
   UNISWAP_LOGO: 'uniswap-logo.png',

--- a/packages/ui/src/assets/index.ts
+++ b/packages/ui/src/assets/index.ts
@@ -13,7 +13,6 @@ export const CITREA_LOGO = require('./logos/png/citrea.png')
 export const WORLD_CHAIN_LOGO = require('./logos/png/world-chain-logo.png')
 export const ZORA_LOGO = require('./logos/png/zora-logo.png')
 export const ZKSYNC_LOGO = require('./logos/png/zksync-logo.png')
-export const SOLANA_LOGO = require('./logos/png/solana-logo.png')
 export const SONEIUM_LOGO = require('./logos/png/soneium-logo.png')
 export const UNICHAIN_LOGO = require('./logos/png/unichain-logo.png')
 export const UNISWAP_LOGO = require('./logos/png/uniswap-logo.png')
@@ -67,9 +66,6 @@ export const FOR_CONNECTING_BACKGROUND_LIGHT = require('./backgrounds/for-connec
 
 export const CRYPTO_PURCHASE_BACKGROUND_LIGHT = require('./backgrounds/coins-background-light.png')
 export const CRYPTO_PURCHASE_BACKGROUND_DARK = require('./backgrounds/coins-background-dark.png')
-
-export const SOLANA_BANNER_LIGHT = require('./backgrounds/solana-banner-light.png')
-export const SOLANA_BANNER_DARK = require('./backgrounds/solana-banner-dark.png')
 
 export const SECURITY_SCREEN_BACKGROUND_DARK = {
   ios: require(`./backgrounds/ios/security-background-dark.png`),

--- a/packages/uniswap/src/features/telemetry/constants/trace/modal.ts
+++ b/packages/uniswap/src/features/telemetry/constants/trace/modal.ts
@@ -152,7 +152,6 @@ export const ModalName = {
   SmartWalletUpgradeModal: 'smart-wallet-upgrade-modal',
   SmartWalletUnavailableModal: 'smart-wallet-unavailable-modal',
   SmartWalletWarningModal: 'smart-wallet-warning-modal',
-  SolanaPromo: 'solana-promo-modal',
   StorageWarning: 'storage-warning-modal',
   Swap: 'swap-modal',
   SwapError: 'swap-error-modal',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11679,30 +11679,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/wallet-adapter-base@npm:0.9.27":
-  version: 0.9.27
-  resolution: "@solana/wallet-adapter-base@npm:0.9.27"
-  dependencies:
-    "@solana/wallet-standard-features": ^1.3.0
-    "@wallet-standard/base": ^1.1.0
-    "@wallet-standard/features": ^1.1.0
-    eventemitter3: ^5.0.1
-  peerDependencies:
-    "@solana/web3.js": ^1.98.0
-  checksum: 9a9108b3c28fbb9b78b5eba8b5c702b27df342e594fa5b1333f905ecfe15c44981a1808e531096fe80655c1763eadce8dd4dc51438e72f6c689241cbf8bf8f01
-  languageName: node
-  linkType: hard
-
-"@solana/wallet-standard-features@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@solana/wallet-standard-features@npm:1.3.0"
-  dependencies:
-    "@wallet-standard/base": ^1.1.0
-    "@wallet-standard/features": ^1.1.0
-  checksum: ee303ae145a734a0ef4592d3da4bcb888956dbb5dc69759cbec2050b3fa6ffe09ca4ae037d254ba438d687b8d7c70902037276197cfb52b7a2c3851be7d5edeb
-  languageName: node
-  linkType: hard
-
 "@sparkfabrik/react-native-idfa-aaid@npm:1.2.0":
   version: 1.2.0
   resolution: "@sparkfabrik/react-native-idfa-aaid@npm:1.2.0"
@@ -16868,7 +16844,6 @@ __metadata:
     "@reduxjs/toolkit": 1.9.3
     "@rive-app/canvas": 2.19.0
     "@rive-app/react-canvas": 4.13.0
-    "@solana/wallet-adapter-base": 0.9.27
     "@storybook/addon-essentials": 8.5.2
     "@storybook/addon-interactions": 8.5.2
     "@storybook/blocks": 8.5.2
@@ -17862,22 +17837,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 6fe731125c7af7867e93a43cf10447b7cba0d01d2faf9fe9752ab1ba188148c1fe5cf7b5c9013e2fd483464feb964a06da6998691396d3450a699ab2417a19dd
-  languageName: node
-  linkType: hard
-
-"@wallet-standard/base@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@wallet-standard/base@npm:1.1.0"
-  checksum: 4057188f615f1deeb0c8a39f04018d4575f87cb387749dab6bc2e8232a95400be51ea4235450829bb256aa21136621f47167383ef1767f0eb3109f1140c74d86
-  languageName: node
-  linkType: hard
-
-"@wallet-standard/features@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@wallet-standard/features@npm:1.1.0"
-  dependencies:
-    "@wallet-standard/base": ^1.1.0
-  checksum: c0c101ee0bd4c55619e39505d15158132bbd619f4dc611880a4b0c001e96806957bed35d7a51efdff0077cf5afb01e0dc46a32b01d9d8c27f807fc2b61e92159
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Removes all Solana-related code from the application to simplify the codebase and reduce maintenance overhead.

## Changes

### Type System
- Remove `SolanaWalletConnectorMeta` type and `SolanaConnectorDetails`
- Remove `solana` property from `WalletConnectorMeta`
- Remove `@solana/wallet-adapter-base` dependency from package.json

### Connection Logic
- Remove `connectSolanaWallet` parameter from `ConnectWalletService`
- Remove Solana wallet connection handling logic
- Simplify wallet connector matching (remove `solana?.walletName` checks)
- Update `areConnectorsOnDifferentPlatforms()` to only check Wagmi/Custom connectors

### UI & Assets
- Remove `SolanaPromo` modal renderer
- Remove Solana logo and banner assets (`SOLANA_LOGO`, `SOLANA_BANNER_LIGHT`, `SOLANA_BANNER_DARK`)
- Remove `solana-promo-modal` telemetry constant

### Tests
- Rewrite `ConnectWalletService.test.ts` without Solana test cases
- Simplify `multiplatform.test.ts` (removed 270+ lines of Solana-specific tests)
- Remove Solana connector from `state.test.ts`

## Impact
- **Code reduction:** 348 lines removed (381 deletions, 33 additions)
- **Simplified architecture:** Focus exclusively on EVM-based wallets (Wagmi) and custom connectors (WalletConnect)
- **Reduced dependencies:** One less npm package to maintain

## Test Plan
- [x] All modified tests pass
- [x] Lint passes
- [x] No TypeScript errors related to Solana
- [x] Existing wallet connection functionality (Wagmi, WalletConnect) unaffected