### PR TITLE
Fix OAuth error display for Twitter and Discord services

### DIFF
--- a/apps/web/src/pages/FirstSqueezer/FirstSqueezerContent.tsx
+++ b/apps/web/src/pages/FirstSqueezer/FirstSqueezerContent.tsx
@@ -71,10 +71,11 @@ export default function FirstSqueezerContent({ account }: FirstSqueezerContentPr
   // Get OAuth callback error from URL (if redirected from OAuth callback with error)
   const params = new URLSearchParams(window.location.search)
   const oauthCallbackError = params.get('oauth_error')
+  const oauthService = params.get('oauth_service') // 'twitter' or 'discord'
 
-  // Merge errors: callback error takes precedence over start error
-  const twitterError = oauthCallbackError || twitterOauthError
-  const discordError = oauthCallbackError || discordOauthError
+  // Merge errors: callback error takes precedence over start error, but only for the relevant service
+  const twitterError = (oauthService === 'twitter' ? oauthCallbackError : null) || twitterOauthError
+  const discordError = (oauthService === 'discord' ? oauthCallbackError : null) || discordOauthError
 
   const handleConnectWallet = () => {
     accountDrawer.open()

--- a/apps/web/src/pages/OAuthCallback/index.tsx
+++ b/apps/web/src/pages/OAuthCallback/index.tsx
@@ -8,9 +8,9 @@ import { useNavigate } from 'react-router'
  *
  * Query params expected:
  * - twitter=success&username=X  (success case - redirect to /first-squeezer)
- * - twitter=error&message=...   (error case - redirect to /first-squeezer?oauth_error=...)
+ * - twitter=error&message=...   (error case - redirect to /first-squeezer?oauth_error=...&oauth_service=twitter)
  * - discord=success&username=X  (success case - redirect to /first-squeezer)
- * - discord=error&message=...   (error case - redirect to /first-squeezer?oauth_error=...)
+ * - discord=error&message=...   (error case - redirect to /first-squeezer?oauth_error=...&oauth_service=discord)
  */
 export default function OAuthCallback() {
   const navigate = useNavigate()
@@ -24,14 +24,14 @@ export default function OAuthCallback() {
     // Handle Twitter error case
     if (twitterParam === 'error') {
       const errorMessage = message || 'Twitter verification failed'
-      navigate(`/first-squeezer?oauth_error=${encodeURIComponent(errorMessage)}`)
+      navigate(`/first-squeezer?oauth_error=${encodeURIComponent(errorMessage)}&oauth_service=twitter`)
       return
     }
 
     // Handle Discord error case
     if (discordParam === 'error') {
       const errorMessage = message || 'Discord verification failed'
-      navigate(`/first-squeezer?oauth_error=${encodeURIComponent(errorMessage)}`)
+      navigate(`/first-squeezer?oauth_error=${encodeURIComponent(errorMessage)}&oauth_service=discord`)
       return
     }
 


### PR DESCRIPTION
## Summary
- Fixed OAuth errors displaying on wrong service verification cards
- Added `oauth_service` parameter to distinguish between Twitter and Discord errors
- Updated error handling logic to only show errors for the relevant service

## Problem
OAuth errors were displayed on both Twitter and Discord verification cards because both services shared the same `oauth_error` URL parameter without identifying which service triggered the error. This caused Twitter follow errors to appear on the Discord verification card.

## Solution
1. **OAuthCallback** - Added `oauth_service=twitter` or `oauth_service=discord` parameter to error redirects
2. **FirstSqueezerContent** - Check `oauth_service` parameter before applying callback errors to each service
3. Updated documentation comments to reflect new parameter structure

## Test Plan
- [ ] Trigger Twitter OAuth error and verify it only appears on Twitter card
- [ ] Trigger Discord OAuth error and verify it only appears on Discord card
- [ ] Verify successful OAuth flows still work correctly
- [ ] Check that error messages are cleared when navigating away and back