### PR TITLE
Fix Twitter follow button to use intent URL

### DIFF
--- a/apps/web/src/pages/FirstSqueezer/TwitterFollowModal.tsx
+++ b/apps/web/src/pages/FirstSqueezer/TwitterFollowModal.tsx
@@ -56,7 +56,7 @@ export function TwitterFollowModal({ isOpen, onDismiss, onConfirm }: TwitterFoll
   }
 
   const handleNotYet = () => {
-    window.open('https://x.com/JuiceSwap_com', '_blank', 'noopener,noreferrer')
+    window.open('https://x.com/intent/follow?screen_name=JuiceSwap_com', '_blank', 'noopener,noreferrer')
     setHasOpenedFollow(true)
   }
 


### PR DESCRIPTION
## Summary
- Changed "Not yet" button to open Twitter follow intent URL
- Provides better UX by directly prompting users to follow

## Problem
When users clicked "Not yet" in the Twitter follow modal, it opened the @JuiceSwap_com profile page, requiring users to manually click the follow button. This added unnecessary friction to the user flow.

## Solution
Updated the URL from `https://x.com/JuiceSwap_com` to `https://x.com/intent/follow?screen_name=JuiceSwap_com`, which opens Twitter's native follow dialog and directly prompts users to follow the account.

## Test Plan
- [ ] Click "Not yet" button and verify Twitter follow dialog opens
- [ ] Verify follow action works correctly
- [ ] Test on different browsers