### PR TITLE
Update Citrea explorer URLs to new Citreascan domain

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/NFTs/NFTItem.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/NFTs/NFTItem.tsx
@@ -21,7 +21,7 @@ export function NFT({
   const onPress = () => {
     if (asset.asset_contract.address && asset.tokenId) {
       window.open(
-        `https://explorer.testnet.citrea.xyz/token/${asset.asset_contract.address}/instance/${asset.tokenId}`,
+        `https://testnet.citreascan.com/token/${asset.asset_contract.address}/instance/${asset.tokenId}`,
         '_blank',
         'noopener,noreferrer',
       )

--- a/apps/web/src/pages/FirstSqueezer/NFTClaimSection.tsx
+++ b/apps/web/src/pages/FirstSqueezer/NFTClaimSection.tsx
@@ -98,7 +98,7 @@ export function NFTClaimSection({ isEligible, walletAddress, nftMinted, nftTxHas
   const handleViewTransaction = () => {
     if (displayTxHash) {
       // Open Citrea testnet explorer
-      window.open(`https://explorer.testnet.citrea.xyz/tx/${displayTxHash}`, '_blank', 'noopener,noreferrer')
+      window.open(`https://testnet.citreascan.com/tx/${displayTxHash}`, '_blank', 'noopener,noreferrer')
     }
   }
 

--- a/docs/api/bapps-campaign-api-specification.md
+++ b/docs/api/bapps-campaign-api-specification.md
@@ -207,7 +207,7 @@ You'll need to connect to Citrea Testnet to verify transactions:
 
 - **RPC Endpoint**: `https://rpc.testnet.juiceswap.com`
 - **Chain ID**: 5115
-- **Explorer API**: `https://explorer.testnet.citrea.xyz/api`
+- **Explorer API**: `https://testnet.citreascan.com/api`
 
 ### Swap Detection
 

--- a/packages/uniswap/src/features/chains/evm/info/citrea.ts
+++ b/packages/uniswap/src/features/chains/evm/info/citrea.ts
@@ -42,8 +42,8 @@ const citreaTestnet = defineChain({
   blockExplorers: {
     default: {
       name: 'Citrea Testnet Explorer',
-      url: 'https://explorer.testnet.citrea.xyz',
-      apiUrl: 'https://explorer.testnet.citrea.xyz/api',
+      url: 'https://testnet.citreascan.com',
+      apiUrl: 'https://testnet.citreascan.com/api',
     },
   },
   contracts: {},
@@ -67,8 +67,8 @@ export const CITREA_TESTNET_CHAIN_INFO = {
   elementName: ElementName.ChainCitreaTestnet,
   explorer: {
     name: 'Citrea Testnet Explorer',
-    url: 'https://explorer.testnet.citrea.xyz/',
-    apiURL: 'https://explorer.testnet.citrea.xyz/api',
+    url: 'https://testnet.citreascan.com/',
+    apiURL: 'https://testnet.citreascan.com/api',
   },
   interfaceName: 'citrea_testnet',
   label: 'Citrea Testnet',
@@ -78,7 +78,7 @@ export const CITREA_TESTNET_CHAIN_INFO = {
     symbol: 'cBTC',
     decimals: 18,
     address: DEFAULT_NATIVE_ADDRESS_LEGACY,
-    explorerLink: 'https://explorer.testnet.citrea.xyz/',
+    explorerLink: 'https://testnet.citreascan.com/',
     logo: CITREA_LOGO,
   },
   networkLayer: NetworkLayer.L2, // Citrea is a Bitcoin rollup (L2)


### PR DESCRIPTION
## Summary
- Updated all Citrea testnet explorer URLs from `explorer.testnet.citrea.xyz` to `testnet.citreascan.com`
- Updated chain configuration in `citrea.ts`
- Updated transaction viewer links in NFT claim section
- Updated NFT token instance links
- Updated API documentation

## Changes
- Chain explorer configuration (blockExplorers, explorer, nativeCurrency.explorerLink)
- Transaction viewer URLs for NFT claims
- NFT token instance viewer URLs
- API documentation references

## Test plan
- [ ] Verify explorer links work correctly in chain configuration
- [ ] Test NFT transaction viewer opens correct URL
- [ ] Test NFT token instance links navigate properly
- [ ] Confirm all URLs resolve to valid Citreascan pages