### PR TITLE
Add campaign end date for Bapps campaign

### DIFF
--- a/apps/web/src/services/bappsCampaign/hooks.ts
+++ b/apps/web/src/services/bappsCampaign/hooks.ts
@@ -222,7 +222,7 @@ function useUrlCampaignOverride(): boolean {
 function useIsCampaignTimeActive(): boolean {
   const hasUrlOverride = useUrlCampaignOverride()
 
-  // Campaign start time: September 25, 2025 at 00:00 UTC
+  // Campaign time window: September 26, 2025 12:00 UTC to September 30, 2025 23:59:59 UTC
   return useMemo(() => {
     // URL Override has priority - if active, campaign is always on
     if (hasUrlOverride) {
@@ -231,8 +231,9 @@ function useIsCampaignTimeActive(): boolean {
 
     // Normal time-based logic
     const campaignStartTime = new Date('2025-09-26T12:00:00.000Z').getTime()
+    const campaignEndTime = new Date('2025-09-30T23:59:59.999Z').getTime()
     const now = Date.now()
-    return now >= campaignStartTime
+    return now >= campaignStartTime && now <= campaignEndTime
   }, [hasUrlOverride])
 }
 


### PR DESCRIPTION
## Summary
Set the Bapps campaign to automatically deactivate after September 30, 2025 at 23:59:59 UTC.

## Changes
- Added `campaignEndTime` check to `useIsCampaignTimeActive()` hook
- Campaign will now only be active during the specified time window

## Campaign Window
- **Start:** September 26, 2025 12:00 UTC
- **End:** September 30, 2025 23:59:59 UTC
- **Duration:** 4 days and 12 hours

## Impact
After September 30, 2025, the following components will automatically hide:
- BAppsCard on landing page
- CitreaBAppsBanner
- Navigation tab for ₿apps
- CitreaCampaignProgress widget
- Swap tracking for campaign tasks

## Testing
- [x] Verified date logic with manual testing
- [x] Pre-commit hooks passed (typecheck, lint, format)
- [x] URL override `?campaign=true` still works for testing

## Note
The campaign can still be manually activated for testing purposes using the `?campaign=true` URL parameter.