### PR TITLE
Fix CITREA_LOGO test mock and migrate tests to Vitest

### DIFF
--- a/apps/web/src/pages/Bapps/Bapps.test.tsx
+++ b/apps/web/src/pages/Bapps/Bapps.test.tsx
@@ -1,37 +1,49 @@
 import { render } from '@testing-library/react'
 import Bapps from 'pages/Bapps'
 import { MemoryRouter } from 'react-router'
+import { vi } from 'vitest'
 
 // Mock hooks
-jest.mock('hooks/useAccount', () => ({
+vi.mock('hooks/useAccount', () => ({
   useAccount: () => ({
     address: undefined,
     isConnected: false,
   }),
 }))
 
-jest.mock('@web3-react/core', () => ({
+vi.mock('@web3-react/core', () => ({
   useWeb3React: () => ({
     connector: {
-      deactivate: jest.fn(),
-      resetState: jest.fn(),
+      deactivate: vi.fn(),
+      resetState: vi.fn(),
     },
   }),
 }))
 
-jest.mock('components/AccountDrawer/MiniPortfolio/hooks', () => ({
+vi.mock('components/AccountDrawer/MiniPortfolio/hooks', () => ({
   useAccountDrawer: () => ({
-    open: jest.fn(),
+    open: vi.fn(),
     isOpen: false,
   }),
 }))
 
 // Mock telemetry
-jest.mock('uniswap/src/features/telemetry/Trace', () => {
-  return function MockTrace({ children }: { children: React.ReactNode }) {
-    return <div data-testid="trace">{children}</div>
+vi.mock('uniswap/src/features/telemetry/Trace', () => {
+  return {
+    default: function MockTrace({ children }: { children: React.ReactNode }) {
+      return <div data-testid="trace">{children}</div>
+    },
   }
 })
+
+// Mock campaign progress query
+vi.mock('uniswap/src/data/apiClients/ponderApi/PonderApi', () => ({
+  useCampaignProgressQuery: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  }),
+}))
 
 describe('Bapps Page', () => {
   it('renders the page title and description', () => {

--- a/apps/web/vite/mockAssets.tsx
+++ b/apps/web/vite/mockAssets.tsx
@@ -53,6 +53,7 @@ vi.mock('ui/src/assets', () => ({
   BLAST_LOGO: 'blast-logo.png',
   AVALANCHE_LOGO: 'avalanche-logo.png',
   CELO_LOGO: 'celo-logo.png',
+  CITREA_LOGO: 'citrea-logo.png',
   WORLD_CHAIN_LOGO: 'world-chain-logo.png',
   ZORA_LOGO: 'zora-logo.png',
   ZKSYNC_LOGO: 'zksync-logo.png',


### PR DESCRIPTION
## Summary
Fixes test infrastructure issues that were blocking test execution.

## Changes

### 1. Add CITREA_LOGO to Test Mocks
- Added `CITREA_LOGO: 'citrea-logo.png'` to `vite/mockAssets.tsx`
- Fixes error: `No "CITREA_LOGO" export is defined on the "ui/src/assets" mock`

### 2. Migrate Bapps Tests to Vitest
- Changed `jest.mock()` to `vi.mock()` 
- Changed `jest.fn()` to `vi.fn()`
- Added `import { vi } from 'vitest'`
- Added mock for `useCampaignProgressQuery` to prevent QueryClient errors

## Testing
- [x] Pre-commit hooks passed (typecheck, lint, format)
- [x] Tests no longer fail with mock errors (though Tamagui provider issues remain)

## Note
The Bapps tests still need Tamagui ThemeProvider setup, but the immediate mock errors are now fixed.