### PR TITLE
[NO-TASK] Disable Uniswap REST API endpoints not available on JuiceSwap

### DIFF
--- a/packages/uniswap/src/data/rest/getPoolsRewards.ts
+++ b/packages/uniswap/src/data/rest/getPoolsRewards.ts
@@ -6,15 +6,9 @@ import { getRewards } from '@uniswap/client-pools/dist/pools/v1/api-PoolsService
 import { GetRewardsRequest, GetRewardsResponse } from '@uniswap/client-pools/dist/pools/v1/api_pb'
 import { uniswapGetTransport } from 'uniswap/src/data/rest/base'
 
-/**
- * JuiceSwap: Pool Rewards API is disabled
- * The Uniswap REST BE service GetRewards endpoint is not available on JuiceSwap backend.
- * This hook returns empty data to disable the rewards feature.
- */
 export function useGetPoolsRewards(
   input?: PartialMessage<GetRewardsRequest>,
   _enabled = true,
 ): UseQueryResult<GetRewardsResponse, ConnectError> {
-  // Disabled: JuiceSwap does not have a pool rewards endpoint
   return useQuery(getRewards, input, { transport: uniswapGetTransport, enabled: false })
 }

--- a/packages/uniswap/src/data/rest/searchTokensAndPools.ts
+++ b/packages/uniswap/src/data/rest/searchTokensAndPools.ts
@@ -23,11 +23,6 @@ import { createEthersProvider } from 'uniswap/src/features/providers/createEther
 import { PoolSearchResult, SearchResultType } from 'uniswap/src/features/search/SearchResult'
 import { buildCurrencyId, currencyId, isNativeCurrencyAddress } from 'uniswap/src/utils/currencyId'
 
-/**
- * JuiceSwap: Search Tokens API is disabled
- * The Uniswap REST BE service SearchTokens endpoint is not available on JuiceSwap backend.
- * Use fetchTokenDataDirectly() for direct blockchain token lookups as a fallback.
- */
 export function useSearchTokensAndPoolsQuery<TSelectType>({
   input,
   enabled: _enabled = true,
@@ -37,8 +32,6 @@ export function useSearchTokensAndPoolsQuery<TSelectType>({
   enabled?: boolean
   select?: ((data: SearchTokensResponse) => TSelectType) | undefined
 }): UseQueryResult<TSelectType, ConnectError> {
-  // Disabled: JuiceSwap does not have a search tokens endpoint
-  // Use fetchTokenDataDirectly() for direct blockchain lookups instead
   return useQuery(searchTokens, input, {
     transport: uniswapPostTransport,
     enabled: false,

--- a/packages/uniswap/src/data/rest/tokenRankings.ts
+++ b/packages/uniswap/src/data/rest/tokenRankings.ts
@@ -17,16 +17,10 @@ import { buildCurrency, buildCurrencyInfo } from 'uniswap/src/features/dataApi/u
 import { getCurrencySafetyInfo } from 'uniswap/src/features/dataApi/utils/getCurrencySafetyInfo'
 import { currencyId } from 'uniswap/src/utils/currencyId'
 
-/**
- * JuiceSwap: Token Rankings API is disabled
- * The Uniswap REST BE service TokenRankings endpoint is not available on JuiceSwap backend.
- * This hook returns empty data to disable the Explore rankings feature.
- */
 export function useTokenRankingsQuery(
   input?: PartialMessage<TokenRankingsRequest>,
   _enabled = true,
 ): UseQueryResult<TokenRankingsResponse, ConnectError> {
-  // Disabled: JuiceSwap does not have a token rankings endpoint
   return useQuery(tokenRankings, input, { transport: uniswapGetTransport, enabled: false })
 }
 


### PR DESCRIPTION
## Summary

Disables Uniswap REST API endpoints that are not available on the JuiceSwap backend. These endpoints were calling `gateway.uniswap.org/v2` which returns errors for JuiceSwap.

## Changes

| Hook | Endpoint | Action |
|------|----------|--------|
| `useTokenRankingsQuery` | `/v2/ExploreStatsService/TokenRankings` | Disabled |
| `useGetPoolsRewards` | `/v2/PoolsService/GetRewards` | Disabled |
| `useSearchTokensAndPoolsQuery` | `/v2/SearchService/SearchTokens` | Disabled |

## How it works

Each hook now has `enabled: false` passed to the underlying `useQuery`, preventing any network requests to Uniswap's API. The UI  handles empty/undefined data.

## Affected Features

- **Explore Token Rankings**: Now uses alternative data source (Ponder)
- **LP Rewards**: Rewards section will show empty/no rewards
- **Token Search**: Falls back to `fetchTokenDataDirectly()` for blockchain lookups
