### PR TITLE
[NO-TASK] Replace Uniswap preconnect with JuiceSwap APIs

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -37,9 +37,8 @@
 
     <!-- CSP will be injected here -->
 
-    <!-- JuiceSwap API preconnects -->
     <link rel="preconnect" href="https://ponder.juiceswap.com/" crossorigin />
-    <link rel="preconnect" href="https://dev.api.juiceswap.com/" crossorigin />
+    <link rel="preconnect" href="https://api.juiceswap.com/" crossorigin />
     <link rel="preconnect" href="https://mainnet.infura.io/" crossorigin />
 
     <!-- Basel-Grotesk fonts not available in public/fonts


### PR DESCRIPTION
- Remove preconnect to interface.gateway.uniswap.org
- Add preconnect to ponder.juiceswap.com
- Add preconnect to dev.api.juiceswap.com