### PR TITLE
Implement ERC20 chain swap support (USDT_POLYGON ↔ JUSD_CITREA)

### DIFF
--- a/apps/web/src/state/routing/types.ts
+++ b/apps/web/src/state/routing/types.ts
@@ -21,6 +21,7 @@ import { Route as V3Route } from '@juiceswapxyz/v3-sdk'
 import { PermitTransferFromData } from '@uniswap/permit2-sdk'
 import { ZERO_PERCENT } from 'constants/misc'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { BridgeTrade } from 'uniswap/src/features/transactions/swap/types/trade'
 
 export enum TradeState {
   LOADING = 'loading',
@@ -933,6 +934,7 @@ export type SubmittableTrade =
   | V3DutchOrderTrade
   | LimitOrderTrade
   | PriorityOrderTrade
+  | BridgeTrade
 export type InterfaceTrade = SubmittableTrade | PreviewTrade
 
 export enum QuoteState {

--- a/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
+++ b/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
@@ -1,0 +1,110 @@
+import { getSigner } from 'state/sagas/transactions/utils'
+import { call } from 'typed-redux-saga'
+import {
+  buildErc20LockupTx,
+  claimErc20Swap,
+  getLdsBridgeManager,
+  LdsSwapStatus,
+} from 'uniswap/src/features/lds-bridge'
+import { Erc20ChainSwapDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { Erc20ChainSwapStep } from 'uniswap/src/features/transactions/swap/steps/erc20ChainSwap'
+import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
+import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
+
+const CONTRACTS = {
+  polygon: {
+    swap: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
+    token: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+  },
+  citrea: {
+    swap: '0xf2e019a371e5Fd32dB2fC564Ad9eAE9E433133cc',
+    token: '0xFdB0a83d94CD65151148a131167Eb499Cb85d015',
+  },
+}
+
+interface HandleErc20ChainSwapParams {
+  step: Erc20ChainSwapStep
+  setCurrentStep: SetCurrentStepFn
+  trade: Trade
+  account: AccountDetails
+  onTransactionHash?: (hash: string) => void
+  onSuccess?: () => void
+}
+
+export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
+  const { step, setCurrentStep, trade, account, onTransactionHash, onSuccess } = params
+  const isPolygonToCitrea = step.direction === Erc20ChainSwapDirection.PolygonToCitrea
+
+  const from = isPolygonToCitrea ? 'USDT_POLYGON' : 'JUSD_CITREA'
+  const to = isPolygonToCitrea ? 'JUSD_CITREA' : 'USDT_POLYGON'
+  const sourceChainId = isPolygonToCitrea ? UniverseChainId.Polygon : UniverseChainId.CitreaTestnet
+  const targetChainId = isPolygonToCitrea ? UniverseChainId.CitreaTestnet : UniverseChainId.Polygon
+  const sourceChain = isPolygonToCitrea ? 'polygon' : 'citrea'
+  const targetChain = isPolygonToCitrea ? 'citrea' : 'polygon'
+
+  const ldsBridge = getLdsBridgeManager()
+
+  // 1. Create swap (convert 6→8 decimals for API)
+  const inputAmount = trade.inputAmount.quotient.toString()
+  const userLockAmount = Number(inputAmount) * 100 // 6 → 8 decimals
+
+  const chainSwap = yield* call([ldsBridge, ldsBridge.createChainSwap], {
+    from,
+    to,
+    claimAddress: account.address,
+    userLockAmount,
+  })
+
+  setCurrentStep({ step, accepted: true })
+
+  // 2. Lock on source chain
+  const sourceSigner = yield* call(getSigner, account.address, sourceChain)
+
+  const lockResult = yield* call(buildErc20LockupTx, {
+    signer: sourceSigner,
+    contractAddress: CONTRACTS[sourceChain].swap,
+    tokenAddress: CONTRACTS[sourceChain].token,
+    preimageHash: chainSwap.preimageHash,
+    amount: BigInt(inputAmount), // 6 decimals for contract
+    claimAddress: chainSwap.lockupDetails.claimAddress!,
+    timelock: chainSwap.lockupDetails.timeoutBlockHeight,
+  })
+
+  if (onTransactionHash) {
+    onTransactionHash(lockResult.hash)
+  }
+
+  // 3. Wait for Boltz to lock on target chain
+  yield* call(
+    [ldsBridge, ldsBridge.waitForSwapUntilState],
+    chainSwap.id,
+    LdsSwapStatus.TransactionServerMempool,
+  )
+
+  yield* call(
+    [ldsBridge, ldsBridge.waitForSwapUntilState],
+    chainSwap.id,
+    LdsSwapStatus.TransactionConfirmed,
+  )
+
+  // 4. Claim on target chain (convert 8→6 decimals for contract)
+  const targetSigner = yield* call(getSigner, account.address, targetChain)
+  const claimAmount = BigInt(chainSwap.claimDetails.amount) / BigInt(100) // 8 → 6 decimals
+
+  yield* call(claimErc20Swap, {
+    signer: targetSigner,
+    contractAddress: CONTRACTS[targetChain].swap,
+    tokenAddress: CONTRACTS[targetChain].token,
+    preimage: chainSwap.preimage,
+    amount: claimAmount,
+    refundAddress: chainSwap.claimDetails.refundAddress!,
+    timelock: chainSwap.claimDetails.timeoutBlockHeight,
+  })
+
+  if (onSuccess) {
+    yield* call(onSuccess)
+  }
+}
+

--- a/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
+++ b/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
@@ -45,6 +45,7 @@ export const TokenLogo = memo(function _TokenLogo({
       cBTC: 'https://docs.juiceswap.com/media/icons/cbtc.png',
       cUSD: 'https://docs.juiceswap.com/media/icons/cusd.png',
       NUSD: 'https://docs.juiceswap.com/media/icons/nusd.png',
+      JUSD: 'https://docs.juiceswap.com/media/icons/jusd.png',
       TFC: 'https://docs.juiceswap.com/media/icons/tfc.png',
       USDC: 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png',
     }

--- a/packages/uniswap/src/components/CurrencyLogo/localTokenLogoMap.ts
+++ b/packages/uniswap/src/components/CurrencyLogo/localTokenLogoMap.ts
@@ -5,6 +5,7 @@ const TFC_ADDRESS = '0x14ADf6B87096Ef750a956756BA191fc6BE94e473'
 const cUSD_ADDRESS = '0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0'
 const NUSD_ADDRESS = '0x9B28B690550522608890C3C7e63c0b4A7eBab9AA'
 const USDC_ADDRESS = '0x36c16eaC6B0Ba6c50f494914ff015fCa95B7835F'
+const JUSD_ADDRESS = '0xFdB0a83d94CD65151148a131167Eb499Cb85d015'
 
 export const getLocalTokenLogoUrlByAddress = (tokenAddress: string | undefined): string | undefined => {
   switch (tokenAddress) {
@@ -19,6 +20,8 @@ export const getLocalTokenLogoUrlByAddress = (tokenAddress: string | undefined):
       return 'https://docs.juiceswap.com/media/icons/nusd.png'
     case USDC_ADDRESS.toLowerCase():
       return 'https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png'
+    case JUSD_ADDRESS.toLowerCase():
+      return 'https://docs.juiceswap.com/media/icons/jusd.png'
 
     default:
       return undefined

--- a/packages/uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge.ts
@@ -1,4 +1,10 @@
+import { ZERO_ADDRESS } from 'uniswap/src/constants/misc'
 import { ChainId, QuoteRequest } from 'uniswap/src/data/tradingApi/__generated__'
+
+export enum Erc20ChainSwapDirection {
+  PolygonToCitrea = 'PolygonToCitrea',
+  CitreaToPolygon = 'CitreaToPolygon',
+}
 
 export const isBitcoinBridgeQuote = (params: QuoteRequest): boolean => {
   const isOneSideCitrea = params.tokenOutChainId === ChainId._5115 || params.tokenInChainId === ChainId._5115
@@ -14,4 +20,22 @@ export const isLnBitcoinBridgeQuote = (params: QuoteRequest): boolean => {
     params.tokenOutChainId === ChainId._21_000_001 || params.tokenInChainId === ChainId._21_000_001
 
   return isOneSideCitrea && isOneSideLightning
+}
+
+export const isErc20ChainSwapQuote = (params: QuoteRequest): boolean => {
+  const { tokenInChainId, tokenOutChainId, tokenIn, tokenOut } = params
+
+  // Polygon (137) ↔ Citrea (5115)
+  const isPolygonToCitrea = tokenInChainId === ChainId._137 && tokenOutChainId === ChainId._5115
+  const isCitreaToPolygon = tokenInChainId === ChainId._5115 && tokenOutChainId === ChainId._137
+
+  if (!isPolygonToCitrea && !isCitreaToPolygon) {
+    return false
+  }
+
+  // Both must be ERC20 (not native)
+  const isInputNative = !tokenIn || tokenIn === ZERO_ADDRESS
+  const isOutputNative = !tokenOut || tokenOut === ZERO_ADDRESS
+
+  return !isInputNative && !isOutputNative
 }

--- a/packages/uniswap/src/data/apiClients/tradingApi/utils/swappableTokens.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/utils/swappableTokens.ts
@@ -5,6 +5,10 @@ import { ChainId, GetSwappableTokensResponse, SafetyLevel } from 'uniswap/src/da
 
 const USE_SWAPPABLE_TOKENS_MAPPING = process.env.USE_SWAPPABLE_TOKENS_MAPPING === 'true'
 
+// Token addresses for ERC20 chain swaps
+const JUSD_CITREA = '0xFdB0a83d94CD65151148a131167Eb499Cb85d015'
+const USDT_POLYGON = '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
+
 const swappableTokensData: Partial<Record<ChainId, Record<string, GetSwappableTokensResponse['tokens']>>> = {
   [ChainId._5115]: {
     '0x0000000000000000000000000000000000000000': [
@@ -35,6 +39,42 @@ const swappableTokensData: Partial<Record<ChainId, Record<string, GetSwappableTo
         },
         symbol: 'lnBTC',
         decimals: 18,
+      },
+    ],
+    // JUSD (Citrea) → USDT (Polygon)
+    [JUSD_CITREA]: [
+      {
+        address: USDT_POLYGON,
+        chainId: ChainId._137,
+        name: 'Tether USD',
+        project: {
+          logo: {
+            url: 'https://assets.coingecko.com/coins/images/325/large/Tether.png',
+          },
+          safetyLevel: SafetyLevel.VERIFIED,
+          isSpam: false,
+        },
+        symbol: 'USDT',
+        decimals: 6,
+      },
+    ],
+  },
+  // USDT (Polygon) → JUSD (Citrea)
+  [ChainId._137]: {
+    [USDT_POLYGON]: [
+      {
+        address: JUSD_CITREA,
+        chainId: ChainId._5115,
+        name: 'JuiceSwap USD',
+        project: {
+          logo: {
+            url: 'https://docs.juiceswap.com/media/icons/jusd.png',
+          },
+          safetyLevel: SafetyLevel.VERIFIED,
+          isSpam: false,
+        },
+        symbol: 'JUSD',
+        decimals: 6,
       },
     ],
   },

--- a/packages/uniswap/src/features/chains/evm/info/citrea.ts
+++ b/packages/uniswap/src/features/chains/evm/info/citrea.ts
@@ -12,13 +12,14 @@ import {
 } from 'uniswap/src/features/chains/types'
 import { Platform } from 'uniswap/src/features/platforms/types/Platform'
 import { ElementName } from 'uniswap/src/features/telemetry/constants'
-import { buildCUSD, buildUSDC } from 'uniswap/src/features/tokens/stablecoin'
+import { buildCUSD, buildJUSD, buildUSDC } from 'uniswap/src/features/tokens/stablecoin'
 import { defineChain } from 'viem'
 
 const testnetTokens = buildChainTokens({
   stables: {
     USDC: buildUSDC('0x36c16eaC6B0Ba6c50f494914ff015fCa95B7835F', UniverseChainId.CitreaTestnet),
     CUSD: buildCUSD('0x2fFC18aC99D367b70dd922771dF8c2074af4aCE0', UniverseChainId.CitreaTestnet),
+    JUSD: buildJUSD('0xFdB0a83d94CD65151148a131167Eb499Cb85d015', UniverseChainId.CitreaTestnet),
   },
 })
 

--- a/packages/uniswap/src/features/tokens/hardcodedTokens.ts
+++ b/packages/uniswap/src/features/tokens/hardcodedTokens.ts
@@ -63,12 +63,38 @@ const citreaNusdCurrency = {
   logoUrl: 'https://docs.juiceswap.com/media/icons/nusd.png',
 }
 
+const citreaJusdCurrency = {
+  currency: buildCurrency({
+    chainId: UniverseChainId.CitreaTestnet,
+    address: '0xFdB0a83d94CD65151148a131167Eb499Cb85d015',
+    decimals: 6,
+    symbol: 'JUSD',
+    name: 'JuiceSwap USD',
+  }) as Currency,
+  currencyId: `${UniverseChainId.CitreaTestnet}-0xFdB0a83d94CD65151148a131167Eb499Cb85d015`,
+  logoUrl: 'https://docs.juiceswap.com/media/icons/jusd.png',
+}
+
+// Polygon USDT for ERC20 chain swaps
+const polygonUsdtCurrency = {
+  currency: buildCurrency({
+    chainId: UniverseChainId.Polygon,
+    address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    decimals: 6,
+    symbol: 'USDT',
+    name: 'Tether USD',
+  }) as Currency,
+  currencyId: `${UniverseChainId.Polygon}-0xc2132D05D31c914a87C6611C10748AEb04B58e8F`,
+  logoUrl: 'https://assets.coingecko.com/coins/images/325/large/Tether.png',
+}
+
 export const suggestedCitreaTokens: CurrencyInfo[] = [
   citreaNativeCurrency,
   citreaWrappedNativeCurrency,
   citreaUsdcCurrency,
   citreaCusdCurrency,
   citreaNusdCurrency,
+  citreaJusdCurrency,
 ]
 
 export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
@@ -109,6 +135,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
   citreaUsdcCurrency,
   citreaCusdCurrency,
   citreaNusdCurrency,
+  citreaJusdCurrency,
   {
     currency: buildCurrency({
       chainId: UniverseChainId.CitreaTestnet,
@@ -120,6 +147,7 @@ export const hardcodedCommonBaseCurrencies: CurrencyInfo[] = [
     currencyId: `${UniverseChainId.CitreaTestnet}-0x14ADf6B87096Ef750a956756BA191fc6BE94e473`,
     logoUrl: 'https://docs.juiceswap.com/media/icons/tfc.png',
   },
+  polygonUsdtCurrency,
 ]
 
 /**

--- a/packages/uniswap/src/features/tokens/stablecoin.ts
+++ b/packages/uniswap/src/features/tokens/stablecoin.ts
@@ -33,3 +33,10 @@ export const buildCUSD = createTokenFactory({
   name: 'Citrus Dollar',
   symbol: 'cUSD',
 })
+
+/** Builds a metadata object representing JUSD with default values. */
+export const buildJUSD = createTokenFactory({
+  decimals: 6,
+  name: 'JuiceSwap USD',
+  symbol: 'JUSD',
+})

--- a/packages/uniswap/src/features/transactions/steps/types.ts
+++ b/packages/uniswap/src/features/transactions/steps/types.ts
@@ -7,6 +7,7 @@ import type { SignTypedDataStepFields } from 'uniswap/src/features/transactions/
 import { WrapTransactionStep } from 'uniswap/src/features/transactions/steps/wrap'
 import type { BitcoinBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/bitcoinBridge'
 import type { ClassicSwapSteps } from 'uniswap/src/features/transactions/swap/steps/classicSteps'
+import type { Erc20ChainSwapStep } from 'uniswap/src/features/transactions/swap/steps/erc20ChainSwap'
 import type { LightningBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/lightningBridge'
 import type { UniswapXSwapSteps } from 'uniswap/src/features/transactions/swap/steps/uniswapxSteps'
 import type { ValidatedTransactionRequest } from 'uniswap/src/features/transactions/types/transactionRequests'
@@ -32,6 +33,7 @@ export enum TransactionStepType {
   BitcoinBridgeBitcoinToCitreaStep = 'BitcoinBridgeBitcoinToCitreaStep',
   LightningBridgeSubmarineStep = 'LightningBridgeSubmarineStep',
   LightningBridgeReverseStep = 'LightningBridgeReverseStep',
+  Erc20ChainSwapStep = 'Erc20ChainSwapStep',
 }
 
 // TODO: add v4 lp flow
@@ -46,6 +48,7 @@ export type TransactionStep =
   | WrapTransactionStep
   | BitcoinBridgeTransactionStep
   | LightningBridgeTransactionStep
+  | Erc20ChainSwapStep
 export type OnChainTransactionStep = TransactionStep & OnChainTransactionFields
 export type OnChainTransactionStepBatched = TransactionStep & OnChainTransactionFieldsBatched
 export type SignatureTransactionStep = TransactionStep & SignTypedDataStepFields

--- a/packages/uniswap/src/features/transactions/swap/steps/erc20ChainSwap.ts
+++ b/packages/uniswap/src/features/transactions/swap/steps/erc20ChainSwap.ts
@@ -1,0 +1,16 @@
+import { Erc20ChainSwapDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+import { TransactionStepType } from 'uniswap/src/features/transactions/steps/types'
+
+export interface Erc20ChainSwapStep {
+  type: TransactionStepType.Erc20ChainSwapStep
+  direction: Erc20ChainSwapDirection
+}
+
+export const createErc20ChainSwapTransactionStep = (
+  direction: Erc20ChainSwapDirection,
+): Erc20ChainSwapStep => {
+  return {
+    type: TransactionStepType.Erc20ChainSwapStep,
+    direction,
+  }
+}

--- a/packages/uniswap/src/features/transactions/swap/utils/routing.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/routing.ts
@@ -33,6 +33,12 @@ export function isLightningBridge<T extends { routing: Routing }>(obj: T): obj i
   return obj.routing === Routing.LN_BRIDGE
 }
 
+export function isErc20ChainSwap<T extends { routing: Routing }>(
+  obj: T,
+): obj is T & { routing: Routing.ERC20_CHAIN_SWAP } {
+  return obj.routing === Routing.ERC20_CHAIN_SWAP
+}
+
 export function isWrap<T extends { routing: Routing }>(obj: T): obj is T & { routing: Routing.WRAP | Routing.UNWRAP } {
   return obj.routing === Routing.WRAP || obj.routing === Routing.UNWRAP
 }

--- a/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
@@ -129,6 +129,21 @@ export function transformTradingApiResponseToTrade(params: TradingApiResponseToT
     case Routing.LN_BRIDGE: {
       return new LightningBridgeTrade({ quote: data as BridgeQuoteResponse, currencyIn, currencyOut, tradeType })
     }
+    case Routing.ERC20_CHAIN_SWAP: {
+      const fixedCurrencyIn =
+        currencyIn.symbol === 'USDT' && currencyIn.decimals !== 6 && !currencyIn.isNative
+          ? new Token(currencyIn.chainId, currencyIn.address, 6, currencyIn.symbol, currencyIn.name)
+          : currencyIn
+
+      const fixedCurrencyOut =
+        currencyOut.symbol === 'JUSD' && currencyOut.decimals !== 6 && !currencyOut.isNative
+          ? new Token(currencyOut.chainId, currencyOut.address, 6, currencyOut.symbol, currencyOut.name)
+          : currencyOut.symbol === 'USDT' && currencyOut.decimals !== 6 && !currencyOut.isNative
+            ? new Token(currencyOut.chainId, currencyOut.address, 6, currencyOut.symbol, currencyOut.name)
+            : currencyOut
+
+      return new BridgeTrade({ quote: data as BridgeQuoteResponse, currencyIn: fixedCurrencyIn, currencyOut: fixedCurrencyOut, tradeType })
+    }
     case Routing.WRAP: {
       return new WrapTrade({ quote: data, currencyIn, currencyOut, tradeType })
     }


### PR DESCRIPTION
## Summary
Implements ERC20 Chain Swap functionality to enable cross-chain swaps between USDT on Polygon and JUSD on Citrea Testnet using the Boltz Protocol.

## Changes
- **Token Definitions**: Added JUSD token to Citrea Testnet and USDT (Polygon) to hardcoded tokens
- **Quote Detection & Handler**: Implemented ERC20 chain swap detection and quote generation
- **EVM Transactions**: Added `buildErc20LockupTx` and `claimErc20Swap` functions
- **Transaction Steps**: Added `Erc20ChainSwapStep` type and factory
- **Saga Handler**: Implemented Redux Saga for swap execution flow
- **Trade Types**: Updated `BridgeTrade` to use dynamic routing and added to `SubmittableTrade` union

## Technical Details
- **Decimals**: Tokens use 6 decimals, Boltz API uses 8 decimals
- **Flow**: User locks on source chain → Boltz locks on target → User claims on target


## Related
Closes #352