### PR TITLE
Add Launchpad navigation tab

### DIFF
--- a/apps/web/src/components/NavBar/Tabs/TabsContent.tsx
+++ b/apps/web/src/components/NavBar/Tabs/TabsContent.tsx
@@ -69,6 +69,12 @@ export const useTabsContent = (): TabsSection[] => {
         },
       ],
     },
+    {
+      title: t('common.launchpad'),
+      href: '/launchpad',
+      isActive: pathname.startsWith('/launchpad'),
+      icon: <Text fontSize={16}>🚀</Text>,
+    },
   ]
 
   // Collect conditional tabs

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -375,6 +375,7 @@
   "common.invalidRecipient.error": "Invalid recipient",
   "common.iOSAndroid": "iOS and Android",
   "common.language": "Language",
+  "common.launchpad": "Launchpad",
   "common.learnMoreSwap": "Learn more about swaps",
   "common.legalAndPrivacy": "Legal & Privacy",
   "common.less": "Less",


### PR DESCRIPTION
## Summary
- Add new "Launchpad" tab to main navigation bar
- Tab displays rocket emoji (🚀) icon
- Links to `/launchpad` route (already exists)
- Always visible (not feature-flagged like bApps or First Squeezer tabs)

## Changes
- `apps/web/src/components/NavBar/Tabs/TabsContent.tsx` - Added Launchpad tab entry
- `packages/uniswap/src/i18n/locales/source/en-US.json` - Added translation key

## Test plan
- [x] Dev server runs without errors
- [ ] Verify Launchpad tab appears in navigation
- [ ] Verify tab links to /launchpad correctly
- [ ] Verify tab highlighting works when on /launchpad routes