### PR TITLE
Improve fee description text in Launchpad

### DIFF
--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -504,7 +504,7 @@ export default function TokenDetail() {
 
           <Flex gap="$spacing8">
             <Text variant="body3" color="$neutral2">
-              • 1% fee on all trades
+              • 1% of all trade volume flows to JUICE governance token holders
             </Text>
             <Text variant="body3" color="$neutral2">
               • ~79.31% sold on bonding curve

--- a/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
+++ b/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
@@ -568,7 +568,7 @@ export function BuySellPanel({
       </ActionButton>
 
       <Text variant="body4" color="$neutral3" textAlign="center">
-        1% fee on all trades. Slippage tolerance: 1%
+        1% of all trade volume flows to JUICE governance token holders. Slippage tolerance: 1%
       </Text>
     </PanelContainer>
   )


### PR DESCRIPTION
## Summary
- Update fee text to clarify that 1% of trade volume flows to JUICE governance token holders
- Changes in BuySellPanel.tsx and TokenDetail.tsx

## Test plan
- [ ] Verify text displays correctly in Launchpad BuySellPanel
- [ ] Verify text displays correctly in TokenDetail page