### PR TITLE
fix(launchpad): set JUSD as input currency when navigating to swap

### DIFF
--- a/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
+++ b/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
@@ -477,7 +477,7 @@ export function BuySellPanel({
         <Text variant="body2" color="$neutral2" textAlign="center">
           Trade on the main DEX instead
         </Text>
-        <TradeOnSwapButton onPress={() => navigate(`/swap?outputCurrency=${tokenAddress}`)}>
+        <TradeOnSwapButton onPress={() => navigate(`/swap?inputCurrency=JUSD&outputCurrency=${tokenAddress}`)}>
           <Text variant="buttonLabel2" color="$white">
             Trade on Swap
           </Text>


### PR DESCRIPTION
## Summary
- When clicking "Trade on Swap" on a graduated launchpad token, the swap page now opens with JUSD pre-selected as the input currency
- Uses the symbol "JUSD" in the URL for cleaner, more readable URLs instead of the full contract address

## Test plan
- [ ] Navigate to a graduated launchpad token page
- [ ] Click "Trade on Swap" button
- [ ] Verify URL shows `inputCurrency=JUSD` instead of the full address
- [ ] Verify JUSD is correctly selected as input currency on the swap page