### PR TITLE
fix(wallet): remove src from ESLint ignorePatterns

### DIFF
--- a/packages/wallet/.eslintrc.js
+++ b/packages/wallet/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   extends: ['@uniswap/eslint-config/native'],
-  ignorePatterns: ['src', 'node_modules', '.turbo', '.eslintrc.js', 'codegen.ts'],
+  ignorePatterns: ['node_modules', '.turbo', '.eslintrc.js', 'codegen.ts'],
   parserOptions: {
     project: 'tsconfig.json',
     tsconfigRootDir: __dirname,

--- a/packages/wallet/src/features/transactions/swap/swapSaga.ts
+++ b/packages/wallet/src/features/transactions/swap/swapSaga.ts
@@ -180,7 +180,7 @@ export function* approveAndSwap(params: SwapParams) {
         submitViaPrivateRpc,
         userSubmissionTimestampMs,
         includesDelegation: swapTxContext.includesDelegation,
-        isSmartWalletTransaction: swapTxContext.txRequests[0]?.to === account.address,
+        isSmartWalletTransaction: swapTxContext.txRequests[0].to === account.address,
       }
       const executeTransactionParams: ExecuteTransactionParams = {
         txId,


### PR DESCRIPTION
Close #401 
## Changes
- Removed `'src'` from `ignorePatterns` in `packages/wallet/.eslintrc.js`
- Fixed linting error in `swapSaga.ts` (removed unnecessary optional chaining on line 183)


## Testing
- [x] ESLint now successfully lints source files in `packages/wallet/src/`
- [x] All linting errors resolved

## Impact
- All code in `packages/wallet/src/` will now be properly linted
- Code quality checks are now enforced for the wallet package
- Prevents future code quality issues from going undetected