### PR TITLE
fix: remove redundant empty earnings message in position page

### DIFF
--- a/apps/web/src/pages/Positions/PositionPage.tsx
+++ b/apps/web/src/pages/Positions/PositionPage.tsx
@@ -1039,12 +1039,6 @@ const EarningsSection = ({
             ) : (
               feeRows.length > 0 && <LiquidityPositionAmountRows rows={feeRows} />
             )}
-
-            {(!totalEarningsFiatValue || totalEarningsFiatValue.equalTo(0)) && (
-              <Text variant="body3" color="$neutral3">
-                {t('pool.earnings.empty')}
-              </Text>
-            )}
           </>
         )}
       </Flex>


### PR DESCRIPTION
## Summary
- Removes redundant "pool.earnings.empty" message from the earnings section in PositionPage

## Rationale
The empty state message was appearing when totalEarningsFiatValue is zero, but the earnings section already handles empty states appropriately through the fee rows display logic, making this message redundant.

## Test plan
- [ ] Open a position page with zero earnings
- [ ] Verify no redundant empty message appears
- [ ] Verify earnings section displays correctly with actual earnings