### PR TITLE
fix: update @juiceswapxyz/launchpad to 2.1.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -182,7 +182,7 @@
     "@graphql-codegen/typescript-resolvers": "3.2.1",
     "@juggle/resize-observer": "3.4.0",
     "@juicedollar/jusd": "1.1.0",
-    "@juiceswapxyz/launchpad": "2.1.0",
+    "@juiceswapxyz/launchpad": "2.1.2",
     "@juiceswapxyz/router-sdk": "0.1.5-beta.0",
     "@juiceswapxyz/sdk-core": "0.1.11-beta.0",
     "@juiceswapxyz/uniswapx-sdk": "0.1.3-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8797,7 +8797,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juicedollar/jusd@npm:1.1.0":
+"@juicedollar/jusd@npm:1.1.0, @juicedollar/jusd@npm:^1.1.0":
   version: 1.1.0
   resolution: "@juicedollar/jusd@npm:1.1.0"
   dependencies:
@@ -8814,16 +8814,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juiceswapxyz/launchpad@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@juiceswapxyz/launchpad@npm:2.1.0"
+"@juiceswapxyz/launchpad@npm:2.1.2":
+  version: 2.1.2
+  resolution: "@juiceswapxyz/launchpad@npm:2.1.2"
   dependencies:
+    "@juicedollar/jusd": ^1.1.0
+    "@juiceswapxyz/sdk-core": ^0.1.10-beta.0
     "@openzeppelin/contracts": ^5.4.0
     "@uniswap/v2-core": ^1.0.1
     "@uniswap/v2-periphery": ^1.1.0-beta.0
   peerDependencies:
     viem: ">=2.0.0"
-  checksum: 34199d983e4cbf8893f5773aa408d9ec1b2a4086d6eeb3484894f2ffa562674346fec4752b563e9632d05974c5f2994f957d3de0603921fb5a194dec040788da
+  checksum: 3d490df4b6e95b6e65305ca90c113ee4dedfed6918cb2b18264f79097273045fb0544ce0f6134df3e5350ba461825093252d5c146b9e06d28261b779402409fd
   languageName: node
   linkType: hard
 
@@ -8855,6 +8857,23 @@ __metadata:
     tiny-invariant: ^1.1.0
     toformat: ^2.0.0
   checksum: a82d957014ddafc8e307883efb2cd89f743247d14d8425ed491ad14ddfc3416bb94554c9a66e47d6d19ae2bdc42786059a0aaf590ebadd9a027cc362b264e4e1
+  languageName: node
+  linkType: hard
+
+"@juiceswapxyz/sdk-core@npm:^0.1.10-beta.0":
+  version: 0.1.10-beta.0
+  resolution: "@juiceswapxyz/sdk-core@npm:0.1.10-beta.0"
+  dependencies:
+    "@ethersproject/address": ^5.0.2
+    "@ethersproject/bytes": ^5.7.0
+    "@ethersproject/keccak256": 5.7.0
+    "@ethersproject/strings": 5.7.0
+    big.js: ^5.2.2
+    decimal.js-light: ^2.5.0
+    jsbi: ^3.1.4
+    tiny-invariant: ^1.1.0
+    toformat: ^2.0.0
+  checksum: d52c22d6510c23393161bfe30977341e1ee8c63d856e0de0f9545b9f24ea47398ff7b96f992fa84afb595365c1b2c86c1c0bbb6c7b69e6ad94394018d66e4709
   languageName: node
   linkType: hard
 
@@ -17903,7 +17922,7 @@ __metadata:
     "@graphql-codegen/typescript-resolvers": 3.2.1
     "@juggle/resize-observer": 3.4.0
     "@juicedollar/jusd": 1.1.0
-    "@juiceswapxyz/launchpad": 2.1.0
+    "@juiceswapxyz/launchpad": 2.1.2
     "@juiceswapxyz/router-sdk": 0.1.5-beta.0
     "@juiceswapxyz/sdk-core": 0.1.11-beta.0
     "@juiceswapxyz/uniswapx-sdk": 0.1.3-beta.0


### PR DESCRIPTION
## Summary
- Updates `@juiceswapxyz/launchpad` from 2.1.0 to 2.1.2
- Fixes incorrect JUSD address that was causing buy transactions to fail

## Changes
| | Old (2.1.0) | New (2.1.2) |
|---|---|---|
| **JUSD** | `0xFdB0a83d94CD65151148a131167Eb499Cb85d015` | `0x6a850a548fdd050e8961223ec8FfCDfacEa57E39` |
| **Factory** | `0xA72CbB319C62B7CA5988183c027533A1E7E33459` | `0xCf5b581064F27a0cFABbbD3E538aFf3b358665c4` |

## Test plan
- [ ] Verify new tokens can be created via `/launchpad/create`
- [ ] Verify buy/sell works on newly created tokens
- [ ] Note: Tokens created with old factory (2.1.0) will not work