### PR TITLE
fix: block token created with wrong baseAsset

### DIFF
--- a/apps/web/src/constants/launchpad.ts
+++ b/apps/web/src/constants/launchpad.ts
@@ -27,3 +27,10 @@ export {
  * Default slippage for launchpad trades (1%)
  */
 export const DEFAULT_LAUNCHPAD_SLIPPAGE_BPS = 100
+
+/**
+ * Tokens to hide from launchpad (e.g. created with wrong baseAsset)
+ */
+export const BLOCKED_LAUNCHPAD_TOKENS: string[] = [
+  '0xb65467c66bab289481278f90500061201d46d206', // Created with wrong JUSD address (old factory)
+]

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -1,4 +1,5 @@
 import { ToastRegularSimple } from 'components/Popups/ToastRegularSimple'
+import { BLOCKED_LAUNCHPAD_TOKENS } from 'constants/launchpad'
 import { useBondingCurveToken } from 'hooks/useBondingCurveToken'
 import { useGraduate } from 'hooks/useLaunchpadActions'
 import { useLaunchpadToken } from 'hooks/useLaunchpadTokens'
@@ -270,6 +271,26 @@ export default function TokenDetail() {
         <ContentWrapper>
           <Text variant="body1" color="$neutral2">
             Token not found
+          </Text>
+        </ContentWrapper>
+      </PageContainer>
+    )
+  }
+
+  // Check if token is blocked
+  const isBlocked = BLOCKED_LAUNCHPAD_TOKENS.some((a) => a.toLowerCase() === tokenAddress.toLowerCase())
+  if (isBlocked) {
+    return (
+      <PageContainer>
+        <ContentWrapper>
+          <BackButton onPress={handleBack}>
+            <BackArrow size="$icon.20" color="$neutral2" />
+            <Text variant="body2" color="$neutral2">
+              Back to Launchpad
+            </Text>
+          </BackButton>
+          <Text variant="body1" color="$neutral2" marginTop="$spacing24">
+            This token is no longer available.
           </Text>
         </ContentWrapper>
       </PageContainer>


### PR DESCRIPTION
## Summary
Hides token `0xb65467c66bab289481278f90500061201d46d206` from the launchpad.

This token was created with the old factory (v2.1.0) which used the wrong JUSD address (`0xFdB0...`). Buy/sell transactions will always fail on this token.

## Changes
- **constants/launchpad.ts**: Add `BLOCKED_LAUNCHPAD_TOKENS` list
- **hooks/useLaunchpadTokens.ts**: Filter out blocked tokens from listing
- **pages/Launchpad/TokenDetail.tsx**: Show "no longer available" for blocked tokens

## Test plan
- [ ] Verify token does not appear in `/launchpad` listing
- [ ] Verify `/launchpad/0xb65467c66bab289481278f90500061201d46d206` shows "no longer available"