### PR TITLE
Fix trading API URL env var not being loaded

### DIFF
--- a/packages/uniswap/src/constants/urls.ts
+++ b/packages/uniswap/src/constants/urls.ts
@@ -46,7 +46,7 @@ export const uniswapUrls = {
   graphQLUrl: config.graphqlUrlOverride || `${getJuiceSwapApiBaseUrl()}/v1/graphql`,
 
   // Trading API (JuiceSwap)
-  tradingApiUrl: config.tradingApiUrlOverride || 'https://dev.api.juiceswap.com',
+  tradingApiUrl: process.env.REACT_APP_TRADING_API_URL_OVERRIDE || config.tradingApiUrlOverride || 'https://dev.api.juiceswap.com',
 
   // Disabled services (kept for backwards compatibility)
   unitagsApiUrl: config.unitagsApiUrlOverride || '',


### PR DESCRIPTION
## Summary
- Fix `REACT_APP_TRADING_API_URL_OVERRIDE` env var not being loaded in Vite
- `tradingApiUrl` now checks `process.env` directly, like `getJuiceSwapApiBaseUrl()` does
- This allows local API testing to work correctly

## Problem
The `config.tradingApiUrlOverride` was showing as `undefined` in the browser console even when the env var was set. This caused all Trading API requests (LP create, claim, etc.) to always go to `dev.api.juiceswap.com` instead of the configured override URL.

## Solution
Added `process.env.REACT_APP_TRADING_API_URL_OVERRIDE` as the first fallback, consistent with how other API URLs are configured.

## Test plan
- [x] Set `REACT_APP_TRADING_API_URL_OVERRIDE=http://localhost:3000` in `.env.local`
- [x] Verify LP claim requests go to localhost instead of dev API

🤖 Generated with [Claude Code](https://claude.ai/code)