### PR TITLE
fix: use mainnet by default for asset bubble direct links

### DIFF
--- a/packages/uniswap/src/features/chains/logos.tsx
+++ b/packages/uniswap/src/features/chains/logos.tsx
@@ -29,6 +29,7 @@ const BLOCK_EXPLORER_LOGOS_LIGHT: Record<UniverseChainId, GeneratedIcon> = {
   [UniverseChainId.Bnb]: EtherscanLogoLight,
   [UniverseChainId.Celo]: BlockExplorer,
   [UniverseChainId.CitreaTestnet]: BlockExplorer,
+  [UniverseChainId.CitreaMainnet]: BlockExplorer,
   [UniverseChainId.Optimism]: OpEtherscanLogoLight,
   [UniverseChainId.Polygon]: PolygonscanLogoLight,
   [UniverseChainId.Sepolia]: EtherscanLogoLight,


### PR DESCRIPTION
## Summary
- Fix asset bubble direct links to use mainnet by default (testnet only when enabled in settings)
- Make `chain=citrea` URL parameter resolve dynamically based on testnet mode
- Update `cBTC` symbol inference to respect testnet mode setting
- Add L0 bridged token support (WBTC.e, USDC.e, USDT.e) for CitreaMainnet

## Problem
The landing page asset bubbles were always directing users to testnet assets, even when testnet mode was disabled. This happened because:
1. `chain=citrea` alias was hardcoded to `citrea_testnet`
2. `getHomeChainForCurrency('cBTC')` always returned `CitreaTestnet`
3. L0 bridged tokens only checked for `CitreaTestnet` chain ID

## Test plan
- [ ] Click asset bubbles on landing page with testnet mode OFF → should go to mainnet
- [ ] Enable testnet mode in settings → bubbles should now go to testnet
- [ ] Verify WBTC.e, USDC.e, USDT.e swaps work on mainnet