### PR TITLE
fix: consistent chain filtering to prevent testnet/mainnet mixing (#433)

### DIFF
--- a/apps/web/src/components/Pools/PoolDetails/PoolDetailsTransactionsTable.tsx
+++ b/apps/web/src/components/Pools/PoolDetails/PoolDetailsTransactionsTable.tsx
@@ -19,7 +19,7 @@ import { ExternalLink } from 'theme/components/Links'
 import { Flex, Text, useMedia } from 'ui/src'
 import { WRAPPED_NATIVE_CURRENCY } from 'uniswap/src/constants/tokens'
 import { ProtocolVersion, Token } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
-import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { useAppFiatCurrency } from 'uniswap/src/features/fiatCurrency/hooks'
 import { useLocalizationContext } from 'uniswap/src/features/language/LocalizationContext'
 import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
@@ -73,7 +73,8 @@ export function PoolDetailsTransactionsTable({
   token1?: Token
   protocolVersion?: ProtocolVersion
 }) {
-  const chainId = useChainIdFromUrlParam() ?? UniverseChainId.Mainnet
+  const { defaultChainId } = useEnabledChains()
+  const chainId = useChainIdFromUrlParam() ?? defaultChainId
   const activeLocalCurrency = useAppFiatCurrency()
   const { convertFiatAmountFormatted, formatNumberOrString } = useLocalizationContext()
   const [filterModalIsOpen, toggleFilterModal] = useReducer((s) => !s, false)

--- a/apps/web/src/components/Tokens/TokenDetails/Skeleton.tsx
+++ b/apps/web/src/components/Tokens/TokenDetails/Skeleton.tsx
@@ -19,7 +19,7 @@ import { ClickableTamaguiStyle } from 'theme/components/styles'
 import { capitalize } from 'tsafe'
 import { Anchor, Flex, Text, TextProps, styled } from 'ui/src'
 import { getChainInfo } from 'uniswap/src/features/chains/chainInfo'
-import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
 import { useChainIdFromUrlParam } from 'utils/chainParams'
 
@@ -274,7 +274,8 @@ function LoadingStats() {
 
 /* Loading State: row component with loading bubbles */
 function TokenDetailsSkeleton() {
-  const { id: chainId, urlParam } = getChainInfo(useChainIdFromUrlParam() ?? UniverseChainId.Mainnet)
+  const { defaultChainId } = useEnabledChains()
+  const { id: chainId, urlParam } = getChainInfo(useChainIdFromUrlParam() ?? defaultChainId)
   const { tokenAddress } = useParams<{ tokenAddress?: string }>()
   const token = useCurrency({
     address: tokenAddress === NATIVE_CHAIN_ID ? 'ETH' : tokenAddress,

--- a/apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx
+++ b/apps/web/src/components/Tokens/TokenTable/NetworkFilter.tsx
@@ -43,7 +43,7 @@ const StyledDropdown = {
 export default function TableNetworkFilter({ showMultichainOption = true }: { showMultichainOption?: boolean }) {
   const [isMenuOpen, toggleMenu] = useState(false)
   const isSupportedChainCallback = useIsSupportedChainIdCallback()
-  const { isTestnetModeEnabled } = useEnabledChains()
+  const { isTestnetModeEnabled, defaultChainId } = useEnabledChains()
   const { chains: enabledChainIds } = useEnabledChains({ includeTestnets: true })
   const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
 
@@ -84,9 +84,7 @@ export default function TableNetworkFilter({ showMultichainOption = true }: { sh
                 <NetworkLogo chainId={null} />
               ) : (
                 <ChainLogo
-                  chainId={
-                    isCitreaOnlyEnabled ? UniverseChainId.CitreaTestnet : currentChainId ?? UniverseChainId.Mainnet
-                  }
+                  chainId={isCitreaOnlyEnabled ? UniverseChainId.CitreaTestnet : currentChainId ?? defaultChainId}
                   size={20}
                   testId={TestID.TokensNetworkFilterSelected}
                 />
@@ -141,6 +139,7 @@ const TableNetworkItem = memo(function TableNetworkItem({
   const navigate = useNavigate()
   const theme = useTheme()
   const { t } = useTranslation()
+  const { defaultChainId } = useEnabledChains()
   const exploreParams = useExploreParams()
   const urlChainId = useChainIdFromUrlParam()
   const currentChainInfo = urlChainId ? getChainInfo(urlChainId) : undefined
@@ -174,11 +173,7 @@ const TableNetworkItem = memo(function TableNetworkItem({
         }}
       >
         <NetworkLabel>
-          {isAllNetworks ? (
-            <NetworkLogo chainId={null} />
-          ) : (
-            <ChainLogo chainId={chainId ?? UniverseChainId.Mainnet} size={20} />
-          )}
+          {isAllNetworks ? <NetworkLogo chainId={null} /> : <ChainLogo chainId={chainId ?? defaultChainId} size={20} />}
           <ElementAfterText
             text={isAllNetworks ? t('transaction.network.all') : chainInfo.label}
             textProps={{ variant: 'body2', ...EllipsisTamaguiStyle }}

--- a/apps/web/src/connection/web3reactShim.ts
+++ b/apps/web/src/connection/web3reactShim.ts
@@ -1,19 +1,20 @@
 import { useAccount } from 'hooks/useAccount'
 import { useEthersProvider } from 'hooks/useEthersProvider'
 import { useMemo } from 'react'
-import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 
 // eslint-disable-next-line import/no-unused-modules -- shim is used via a build alias in craco.config.cjs
 export function useWeb3React() {
   const account = useAccount()
+  const { defaultChainId } = useEnabledChains()
   const provider = useEthersProvider({ chainId: account.chainId })
 
   return useMemo(
     () => ({
       account: account.address,
-      chainId: account.chainId ?? UniverseChainId.Mainnet,
+      chainId: account.chainId ?? defaultChainId,
       provider,
     }),
-    [account.address, account.chainId, provider],
+    [account.address, account.chainId, defaultChainId, provider],
   )
 }

--- a/apps/web/src/pages/Explore/tables/RecentTransactions.tsx
+++ b/apps/web/src/pages/Explore/tables/RecentTransactions.tsx
@@ -28,6 +28,7 @@ import {
   PoolTransactionType,
 } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
 import { getChainInfo } from 'uniswap/src/features/chains/chainInfo'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { fromGraphQLChain } from 'uniswap/src/features/chains/utils'
 import { useAppFiatCurrency } from 'uniswap/src/features/fiatCurrency/hooks'
@@ -57,7 +58,8 @@ const RecentTransactions = memo(function RecentTransactions() {
     TransactionType.REMOVE,
     TransactionType.ADD,
   ])
-  const chainInfo = getChainInfo(useChainIdFromUrlParam() ?? UniverseChainId.Mainnet)
+  const { defaultChainId } = useEnabledChains()
+  const chainInfo = getChainInfo(useChainIdFromUrlParam() ?? defaultChainId)
   const { t } = useTranslation()
 
   const { transactions, loading, loadMore, errorV2, errorV3 } = useAllTransactions(chainInfo.backendChain.chain, filter)

--- a/apps/web/src/pages/MigrateV2/MigrateV2Pair.tsx
+++ b/apps/web/src/pages/MigrateV2/MigrateV2Pair.tsx
@@ -50,7 +50,7 @@ import { Arrow } from 'ui/src/components/arrow/Arrow'
 import { iconSizes } from 'ui/src/theme'
 import Badge from 'uniswap/src/components/badge/Badge'
 import { WRAPPED_NATIVE_CURRENCY } from 'uniswap/src/constants/tokens'
-import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { useLocalizationContext } from 'uniswap/src/features/language/LocalizationContext'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import { InterfacePageName, LiquidityEventName } from 'uniswap/src/features/telemetry/constants'
@@ -237,6 +237,7 @@ function V2PairMigration({
 }) {
   const { t } = useTranslation()
   const account = useAccount()
+  const { defaultChainId } = useEnabledChains()
   const colors = useSporeColors()
   const v2FactoryAddress = account.chainId ? V2_FACTORY_ADDRESSES[account.chainId] : undefined
   const trace = useTrace()
@@ -540,7 +541,7 @@ function V2PairMigration({
           <ExternalLink
             key="migration-contract"
             href={getExplorerLink({
-              chainId: account.chainId ?? UniverseChainId.Mainnet,
+              chainId: account.chainId ?? defaultChainId,
               data: migrator?.address ?? '',
               type: ExplorerDataType.ADDRESS,
             })}

--- a/apps/web/src/pages/Positions/V2PositionPage.tsx
+++ b/apps/web/src/pages/Positions/V2PositionPage.tsx
@@ -23,8 +23,8 @@ import { Button, Circle, Flex, Main, Shine, Text, styled } from 'ui/src'
 import { ZERO_ADDRESS } from 'uniswap/src/constants/misc'
 import { useGetPositionQuery } from 'uniswap/src/data/rest/getPosition'
 import { getChainInfo } from 'uniswap/src/features/chains/chainInfo'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { useSupportedChainId } from 'uniswap/src/features/chains/hooks/useSupportedChainId'
-import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { FeatureFlags } from 'uniswap/src/features/gating/flags'
 import { useFeatureFlag } from 'uniswap/src/features/gating/hooks'
 import { useLocalizationContext } from 'uniswap/src/features/language/LocalizationContext'
@@ -85,8 +85,9 @@ function V2PositionPage() {
   const { pairAddress } = useParams<{ pairAddress: string }>()
   const chainId = useChainIdFromUrlParam()
   const account = useAccount()
+  const { defaultChainId } = useEnabledChains()
   const supportedAccountChainId = useSupportedChainId(account.chainId)
-  const chainInfo = getChainInfo(chainId ?? UniverseChainId.Mainnet)
+  const chainInfo = getChainInfo(chainId ?? defaultChainId)
   const isMigrateV2Enabled = useFeatureFlag(FeatureFlags.MigrateV2)
 
   const {

--- a/apps/web/src/pages/Positions/index.tsx
+++ b/apps/web/src/pages/Positions/index.tsx
@@ -207,13 +207,14 @@ export default function Pool() {
   const savedPositions = useRequestPositionsForSavedPairs()
 
   // Get hardcoded positions for the current wallet (all hardcoded positions are V3)
+  // Filter by chainFilter if set, otherwise filter by currentModeChains to prevent testnet/mainnet mixing
   const hardcodedPositions = useMemo(() => {
     return getHardcodedPositionsForWallet(account.address).filter((position) => {
-      const matchesChain = !chainFilter || position.chainId === chainFilter
+      const matchesChain = chainFilter ? position.chainId === chainFilter : currentModeChains.includes(position.chainId)
       const matchesStatus = statusFilter.includes(position.status)
       return matchesChain && matchesStatus
     })
-  }, [account.address, chainFilter, statusFilter])
+  }, [account.address, chainFilter, currentModeChains, statusFilter])
 
   const isLoadingPositions = !!account.address && (isLoading || !data)
   const combinedPositions = useMemo(() => {

--- a/apps/web/src/pages/Swap/index.tsx
+++ b/apps/web/src/pages/Swap/index.tsx
@@ -5,6 +5,7 @@ import { popupRegistry } from 'components/Popups/registry'
 import { PopupType } from 'components/Popups/types'
 import { CitreaCampaignProgress } from 'components/swap/CitreaCampaignProgress'
 import { PageWrapper } from 'components/swap/styled'
+import { useAccount } from 'hooks/useAccount'
 import { useBAppsSwapTracking } from 'hooks/useBAppsSwapTracking'
 import { useCrossChainSwapsEnabled } from 'hooks/useCrossChainSwapsEnabled'
 import { useModalState } from 'hooks/useModalState'
@@ -249,6 +250,7 @@ function UniversalSwapFlow({
 }) {
   const [currentTab, setCurrentTab] = useState(SwapTab.Swap)
   const { pathname } = useLocation()
+  const account = useAccount()
   // Store onSubmitSwap callback ref for access in swapCallback
   const onSubmitSwapRef = useRef<
     ((txHash?: string, inputToken?: string, outputToken?: string) => Promise<void> | void) | undefined
@@ -302,16 +304,16 @@ function UniversalSwapFlow({
       resetDisableOneClickSwap()
 
       // Store transaction details for blockchain confirmation tracking
-      if (txHash && inputToken && outputToken) {
+      if (txHash && inputToken && outputToken && account.chainId) {
         setCurrentTransaction({
           txHash,
-          chainId: 5115, // Citrea Testnet
+          chainId: account.chainId,
           inputToken,
           outputToken,
         })
       }
     },
-    [resetDisableOneClickSwap],
+    [resetDisableOneClickSwap, account.chainId],
   )
 
   // Store the callback in ref for access in swapCallback

--- a/apps/web/src/pages/TokenDetails/index.tsx
+++ b/apps/web/src/pages/TokenDetails/index.tsx
@@ -19,6 +19,7 @@ import { useSporeColors } from 'ui/src'
 import { nativeOnChain } from 'uniswap/src/constants/tokens'
 import { useTokenWebQuery } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
 import { getChainInfo } from 'uniswap/src/features/chains/chainInfo'
+import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { fromGraphQLChain } from 'uniswap/src/features/chains/utils'
 import { usePortfolioBalances } from 'uniswap/src/features/dataApi/balances/balances'
@@ -50,7 +51,8 @@ function useTDPCurrency({
   isNative: boolean
 }) {
   const { chainId } = useAccount()
-  const appChainId = chainId ?? UniverseChainId.Mainnet
+  const { defaultChainId } = useEnabledChains()
+  const appChainId = chainId ?? defaultChainId
 
   const queryCurrency = useMemo(() => {
     if (isNative) {
@@ -123,7 +125,8 @@ function useCreateTDPContext(): PendingTDPContext | LoadedTDPContext {
     throw new Error('Invalid token details route: token address URL param is undefined')
   }
 
-  const currencyChainInfo = getChainInfo(useChainIdFromUrlParam() ?? UniverseChainId.Mainnet)
+  const { defaultChainId } = useEnabledChains()
+  const currencyChainInfo = getChainInfo(useChainIdFromUrlParam() ?? defaultChainId)
 
   const isNative = tokenAddress === NATIVE_CHAIN_ID
 


### PR DESCRIPTION
* fix: consistent chain filtering to prevent testnet/mainnet mixing

- Replace hardcoded chainId 5115 (CitreaTestnet) in Explore page with dynamic defaultChainId
- Replace hardcoded chainId 5115 in Swap page with account.chainId
- Replace UniverseChainId.Mainnet fallback with defaultChainId in:
  - TokenDetails page
  - MigrateV2Pair page
  - web3reactShim hook
  - RecentTransactions table
- Add chainId parameter to useLaunchpadToken and useRecentLaunchpadTrades hooks
- Filter hardcoded positions by currentModeChains to prevent cross-mode display

* fix: additional Mainnet fallback fixes found during consistency review

- Fix TokenDetails/index.tsx useCreateTDPContext Mainnet fallback
- Fix PoolDetailsTransactionsTable.tsx Mainnet fallback
- Fix Skeleton.tsx Mainnet fallback
- Fix V2PositionPage.tsx Mainnet fallback
- Fix NetworkFilter.tsx Mainnet fallback in ChainLogo

* fix: replace remaining Mainnet fallback in TableNetworkItem