### PR TITLE
fix: use Citrea mainnet config for ERC20 chain swaps

### DIFF
--- a/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
+++ b/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
@@ -61,7 +61,7 @@ async function waitForNetwork(targetChainId: number, timeout = 60000): Promise<v
 const USDC_ETHEREUM_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 const USDT_ETHEREUM_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
 const USDT_POLYGON_ADDRESS = '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'
-const JUSD_CITREA_TESTNET = ADDRESS[5115]!.juiceDollar
+const JUSD_CITREA_MAINNET = ADDRESS[4114]!.juiceDollar
 
 // Swap contract addresses (same contract handles multiple tokens on each chain)
 const SWAP_CONTRACTS = {
@@ -75,7 +75,7 @@ const TOKEN_CONFIGS: Record<string, { address: string; decimals: number; chainId
   USDT_ETH: { address: USDT_ETHEREUM_ADDRESS, decimals: 6, chainId: UniverseChainId.Mainnet },
   USDC_ETH: { address: USDC_ETHEREUM_ADDRESS, decimals: 6, chainId: UniverseChainId.Mainnet },
   USDT_POLYGON: { address: USDT_POLYGON_ADDRESS, decimals: 6, chainId: UniverseChainId.Polygon },
-  JUSD_CITREA: { address: JUSD_CITREA_TESTNET, decimals: 18, chainId: UniverseChainId.CitreaTestnet },
+  JUSD_CITREA: { address: JUSD_CITREA_MAINNET, decimals: 18, chainId: UniverseChainId.CitreaMainnet },
 }
 
 const BOLTZ_DECIMALS = 8 // Boltz uses 8 decimals internally
@@ -152,7 +152,7 @@ export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
     ? UniverseChainId.Polygon
     : isEthereumToCitrea
       ? UniverseChainId.Mainnet
-      : UniverseChainId.CitreaTestnet
+      : UniverseChainId.CitreaMainnet
 
   const ldsBridge = getLdsBridgeManager()
 

--- a/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
@@ -695,7 +695,7 @@ export async function fetchSwap({ ...params }: CreateSwapRequest): Promise<Creat
   return {
     requestId: Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15),
     swap: {
-      chainId: tokenInChainId ?? ChainId._5115,
+      chainId: tokenInChainId ?? ChainId._4114,
       data: response.data,
       from: connectedWallet ?? '',
       to: response.to,


### PR DESCRIPTION
## Summary

- Fix ERC20 chain swap handler to use Citrea mainnet (4114) instead of testnet (5115)
- This fixes JUSD→USDC swaps failing due to token address mismatch between quote API and swap handler

## Problem

The ERC20 chain swap handler was incorrectly configured:
- `JUSD_CITREA` used testnet address from `ADDRESS[5115]`
- `TOKEN_CONFIGS.JUSD_CITREA.chainId` was set to `CitreaTestnet`
- `sourceChainId` fallback used `CitreaTestnet`
- `TradingApiClient` fallback used `ChainId._5115`

Meanwhile, the quote system (`swappableTokens.ts`, `isBitcoinBridge.ts`) uses mainnet (`ChainId._4114`).

This mismatch caused:
- USDC→JUSD to work (JUSD address not needed for Ethereum lockup)
- JUSD→USDC to fail (wrong JUSD address used for Citrea lockup)

## Changes

| File | Change |
|------|--------|
| `erc20ChainSwap.ts` | `ADDRESS[5115]` → `ADDRESS[4114]` |
| `erc20ChainSwap.ts` | `CitreaTestnet` → `CitreaMainnet` |
| `TradingApiClient.ts` | Fallback `ChainId._5115` → `ChainId._4114` |

## Test plan

- [ ] Test USDC→JUSD swap (Ethereum→Citrea)
- [ ] Test JUSD→USDC swap (Citrea→Ethereum) - this was broken before
- [ ] Test USDT→JUSD and JUSD→USDT swaps