### PR TITLE
fix: add chainId parameter to explore queries for mainnet/testnet separation

### DIFF
--- a/apps/web/src/state/explore/index.tsx
+++ b/apps/web/src/state/explore/index.tsx
@@ -55,6 +55,7 @@ export function ExploreContextProvider({
     isLoading: exploreStatsLoading,
     error: exploreStatsError,
   } = useExploreStatsQuery<ExploreStatsResponse>({
+    chainId: isSupportedChain ? chainId : undefined,
     enabled: isSupportedChain,
   })
 

--- a/packages/uniswap/src/data/apiClients/ponderApi/PonderApi.ts
+++ b/packages/uniswap/src/data/apiClients/ponderApi/PonderApi.ts
@@ -5,6 +5,7 @@ import {
   DailyGrowthResponse,
   HourlyCompletionStatsResponse,
 } from 'uniswap/src/data/apiClients/ponderApi/types'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 
 const ponderApiUrl = process.env.REACT_APP_PONDER_JUICESWAP_URL || 'https://ponder.juiceswap.com'
 const ponderFallbackApiUrl = process.env.REACT_APP_PONDER_FALLBACK_JUICESWAP_URL || 'https://dev.ponder.juiceswap.com'
@@ -13,29 +14,38 @@ const ponderApiClient = createApiClientWithFallback(ponderApiUrl, ponderFallback
 
 export const createPonderApiClient = (): ReturnType<typeof createApiClientWithFallback> => ponderApiClient
 
-export const useDailyGrowthQuery = (days: number): UseQueryResult<DailyGrowthResponse, Error> => {
+export const useDailyGrowthQuery = (
+  days: number,
+  chainId: UniverseChainId = UniverseChainId.CitreaTestnet,
+): UseQueryResult<DailyGrowthResponse, Error> => {
   return useTanstackQuery<DailyGrowthResponse, Error>({
-    queryKey: ['dailyGrowth', days],
+    queryKey: ['dailyGrowth', days, chainId],
     queryFn: () =>
-      ponderApiClient.get<DailyGrowthResponse>('/campaign/daily-growth', { params: { days, chainId: 5115 } }),
+      ponderApiClient.get<DailyGrowthResponse>('/campaign/daily-growth', { params: { days, chainId } }),
   })
 }
 
-export const useHourlyCompletionStatsQuery = (hours: number): UseQueryResult<HourlyCompletionStatsResponse, Error> => {
+export const useHourlyCompletionStatsQuery = (
+  hours: number,
+  chainId: UniverseChainId = UniverseChainId.CitreaTestnet,
+): UseQueryResult<HourlyCompletionStatsResponse, Error> => {
   return useTanstackQuery<HourlyCompletionStatsResponse, Error>({
-    queryKey: ['hourlyCompletionStats', hours],
+    queryKey: ['hourlyCompletionStats', hours, chainId],
     queryFn: () =>
       ponderApiClient.get<HourlyCompletionStatsResponse>('/campaign/hourly-completion-stats', {
-        params: { hours, chainId: 5115 },
+        params: { hours, chainId },
       }),
   })
 }
 
-export const useCampaignProgressQuery = (walletAddress: string): UseQueryResult<CampaignProgressResponse, Error> => {
+export const useCampaignProgressQuery = (
+  walletAddress: string,
+  chainId: UniverseChainId = UniverseChainId.CitreaTestnet,
+): UseQueryResult<CampaignProgressResponse, Error> => {
   return useTanstackQuery<CampaignProgressResponse, Error>({
-    queryKey: ['campaignProgress', walletAddress],
+    queryKey: ['campaignProgress', walletAddress, chainId],
     queryFn: () =>
-      ponderApiClient.get<CampaignProgressResponse>('/campaign/progress', { params: { walletAddress, chainId: 5115 } }),
+      ponderApiClient.get<CampaignProgressResponse>('/campaign/progress', { params: { walletAddress, chainId } }),
     enabled: !!walletAddress,
   })
 }

--- a/packages/uniswap/src/data/rest/exploreStats.ts
+++ b/packages/uniswap/src/data/rest/exploreStats.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query'
 import { createPonderApiClient } from 'uniswap/src/data/apiClients/ponderApi/PonderApi'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 
 type ExploreStatsResponse = {
   stats: {
@@ -9,8 +10,10 @@ type ExploreStatsResponse = {
 
 const PonderApiClient = createPonderApiClient()
 
-const fetchExploreStats = (): Promise<ExploreStatsResponse> => {
-  return PonderApiClient.get<ExploreStatsResponse>(`/exploreStats`)
+const fetchExploreStats = (chainId?: number): Promise<ExploreStatsResponse> => {
+  return PonderApiClient.get<ExploreStatsResponse>(`/exploreStats`, {
+    params: chainId ? { chainId } : undefined,
+  })
 }
 
 /**
@@ -18,15 +21,17 @@ const fetchExploreStats = (): Promise<ExploreStatsResponse> => {
  * This included top tokens and top pools data
  */
 export function useExploreStatsQuery<TSelectType>({
+  chainId,
   enabled,
   select,
 }: {
+  chainId?: UniverseChainId
   enabled?: boolean
   select?: ((data: ExploreStatsResponse) => TSelectType) | undefined
 }): UseQueryResult<TSelectType, Error> {
   return useQuery({
-    queryKey: ['exploreStats'],
-    queryFn: () => fetchExploreStats(),
+    queryKey: ['exploreStats', chainId],
+    queryFn: () => fetchExploreStats(chainId),
     enabled,
     select,
   })


### PR DESCRIPTION
## Summary
- Add `chainId` parameter to `useExploreStatsQuery` for proper chain filtering on /explore page
- Pass `chainId` from `ExploreContext` to the exploreStats query
- Add optional `chainId` parameter to campaign queries (`useDailyGrowthQuery`, `useHourlyCompletionStatsQuery`, `useCampaignProgressQuery`)
- Include `chainId` in query keys for correct caching per chain

## Problem
The /explore page was not properly separating mainnet and testnet data because:
1. `exploreStats` query had no chainId parameter
2. Campaign queries were hardcoded to chainId 5115 (testnet)

## Changes
- `packages/uniswap/src/data/rest/exploreStats.ts` - Added chainId parameter
- `apps/web/src/state/explore/index.tsx` - Pass chainId to query
- `packages/uniswap/src/data/apiClients/ponderApi/PonderApi.ts` - Added optional chainId to campaign queries

## Test plan
- [ ] Verify /explore page shows correct data when switching between mainnet/testnet
- [ ] Verify campaign queries work with different chainIds
- [ ] Check query caching works correctly per chain

## Note
Requires corresponding Ponder API update to support `chainId` query parameter on `/exploreStats` endpoint.