### PR TITLE
fix: pass chainId to TopPools for correct mainnet/testnet pool display

### DIFF
--- a/apps/web/src/pages/Positions/TopPools.tsx
+++ b/apps/web/src/pages/Positions/TopPools.tsx
@@ -6,7 +6,6 @@ import { ExternalArrowLink } from 'components/Liquidity/ExternalArrowLink'
 import { HARDCODED_CITREA_POOLS } from 'constants/hardcodedPools'
 import { TopPoolsSection } from 'pages/Positions/TopPoolsSection'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 import { useTopPools } from 'state/explore/topPools'
 import { PoolStat } from 'state/explore/types'
 import { Flex, useMedia } from 'ui/src'
@@ -14,14 +13,17 @@ import { Chain } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/t
 import { useExploreStatsQuery } from 'uniswap/src/data/rest/exploreStats'
 import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
-import { selectIsCitreaOnlyEnabled } from 'uniswap/src/features/settings/selectors'
 
 export function TopPools({ chainId }: { chainId: UniverseChainId | null }) {
   const { t } = useTranslation()
   const media = useMedia()
   const isBelowXlScreen = !media.xl
-  const isCitreaOnlyEnabled = useSelector(selectIsCitreaOnlyEnabled)
   const { isTestnetModeEnabled } = useEnabledChains()
+
+  // Determine the effective chainId for the API call
+  // Use CitreaMainnet as default when no chain is selected and not in testnet mode
+  const effectiveChainId =
+    chainId ?? (isTestnetModeEnabled ? UniverseChainId.CitreaTestnet : UniverseChainId.CitreaMainnet)
 
   // Call hooks before any conditional returns
   const {
@@ -29,6 +31,7 @@ export function TopPools({ chainId }: { chainId: UniverseChainId | null }) {
     isLoading: exploreStatsLoading,
     error: exploreStatsError,
   } = useExploreStatsQuery<ExploreStatsResponse>({
+    chainId: effectiveChainId,
     enabled: true,
   })
 
@@ -37,9 +40,9 @@ export function TopPools({ chainId }: { chainId: UniverseChainId | null }) {
     sortState: { sortDirection: OrderDirection.Desc, sortBy: PoolSortFields.TVL },
   })
 
-  // If testnet mode is enabled, Citrea Only is enabled, or Citrea testnet is selected, show hardcoded pools
-  // This prevents mainnet/testnet mixing since the API doesn't support testnet chains
-  if (isTestnetModeEnabled || isCitreaOnlyEnabled || chainId === UniverseChainId.CitreaTestnet) {
+  // If testnet mode is enabled or Citrea testnet is selected, show hardcoded pools
+  // Mainnet uses real API data
+  if (isTestnetModeEnabled || chainId === UniverseChainId.CitreaTestnet) {
     if (!isBelowXlScreen) {
       return null
     }


### PR DESCRIPTION
## Summary
- Fix bug where testnet pools were shown on `/positions` page even when user is on mainnet
- Pass `chainId` to `useExploreStatsQuery` based on user's network mode
- Remove incorrect `isCitreaOnlyEnabled` condition from testnet check

## Root Cause
The `TopPools` component was not passing `chainId` to the API query, causing the backend to use its default (which was testnet), resulting in testnet pools being displayed to mainnet users.

## Changes
- Add `effectiveChainId` calculation based on `chainId` prop and `isTestnetModeEnabled`
- Pass `chainId: effectiveChainId` to `useExploreStatsQuery`
- Remove `isCitreaOnlyEnabled` from testnet condition (it's unrelated to network selection)
- Clean up unused imports (`useSelector`, `selectIsCitreaOnlyEnabled`)

## Test plan
- [ ] Open `/positions` in mainnet mode → should show mainnet pools from API
- [ ] Open `/positions` in testnet mode → should show hardcoded testnet pools
- [ ] Verify "Top pools by TVL" section displays correct pools for each network

## Related
- Companion PR: https://github.com/JuiceSwapxyz/ponder/pull/102 (backend default chainId → mainnet)