### PR TITLE
fix: pass chainId to remaining useExploreStatsQuery calls

### DIFF
--- a/apps/web/src/appGraphql/data/useAllTransactions.ts
+++ b/apps/web/src/appGraphql/data/useAllTransactions.ts
@@ -8,14 +8,17 @@ import {
   useV4TransactionsQuery,
 } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
 import { useExploreStatsQuery } from 'uniswap/src/data/rest/exploreStats'
+import { fromGraphQLChain } from 'uniswap/src/features/chains/utils'
 import i18n from 'uniswap/src/i18n'
 
-const useV3Transactions = () => {
+const useV3Transactions = (chain: Chain) => {
+  const chainId = fromGraphQLChain(chain)
   const {
     data,
     isLoading: loadingV3,
     error: errorV3,
   } = useExploreStatsQuery<{ stats: { transactionStats: unknown[] } }>({
+    chainId: chainId ?? undefined,
     enabled: true,
   })
 
@@ -69,7 +72,7 @@ export function useAllTransactions(
     skip: true,
   })
 
-  const { data: dataV3, loading: loadingV3, error: errorV3 } = useV3Transactions()
+  const { data: dataV3, loading: loadingV3, error: errorV3 } = useV3Transactions(chain)
 
   const {
     data: dataV2,

--- a/packages/uniswap/src/features/search/SearchModal/SearchModalNoQueryList.tsx
+++ b/packages/uniswap/src/features/search/SearchModal/SearchModalNoQueryList.tsx
@@ -99,6 +99,7 @@ function useSectionsForNoQuerySearch({
     error: topPoolsError,
     refetch: refetchPools,
   } = useExploreStatsQuery<PoolStats[] | undefined>({
+    chainId: chainFilter ?? undefined,
     enabled: isWeb && (activeTab === SearchTab.All || activeTab === SearchTab.Pools),
   })
 


### PR DESCRIPTION
## Summary
Fix remaining places where `useExploreStatsQuery` was called without `chainId`, causing testnet data to appear on mainnet.

## Changes
- **useAllTransactions.ts**: Pass `chain` parameter to `useV3Transactions` hook and convert to `chainId` using `fromGraphQLChain`
- **SearchModalNoQueryList.tsx**: Pass `chainFilter` to `useExploreStatsQuery` for trending pools

## Related
Follow-up to PR #448 which fixed the same issue in `TopPools.tsx`

## Test plan
- [ ] Open Explore page on mainnet → transactions should be from mainnet
- [ ] Open Search modal on mainnet → trending pools should be from mainnet
- [ ] Switch to testnet → data should update to testnet