### PR TITLE
fix(chains): add missing CITREA_MAINNET case to fromGraphQLChain

### DIFF
--- a/packages/uniswap/src/features/chains/utils.ts
+++ b/packages/uniswap/src/features/chains/utils.ts
@@ -97,6 +97,8 @@ export function fromGraphQLChain(chain: Chain | string | undefined): UniverseCha
       return UniverseChainId.Zksync
     case Chain.Zora:
       return UniverseChainId.Zora
+    case 'CITREA_MAINNET':
+      return UniverseChainId.CitreaMainnet
     case 'CITREA_TESTNET':
       return UniverseChainId.CitreaTestnet
   }


### PR DESCRIPTION
## Summary
Add missing `'CITREA_MAINNET'` case to `fromGraphQLChain` function.

## Problem
The `fromGraphQLChain` function had a case for `'CITREA_TESTNET'` but was missing the `'CITREA_MAINNET'` case. This meant:

```typescript
fromGraphQLChain('CITREA_MAINNET')  // returned null ❌
fromGraphQLChain('CITREA_TESTNET')  // returned UniverseChainId.CitreaTestnet ✅
```

When `useAllTransactions` was called with Citrea Mainnet chain, `fromGraphQLChain` returned `null`, which got converted to `undefined`, causing the API to use its default chainId instead of explicitly requesting mainnet data.

## Solution
Add the missing case:
```typescript
case 'CITREA_MAINNET':
  return UniverseChainId.CitreaMainnet
```

Now `fromGraphQLChain` correctly handles both Citrea chains symmetrically with `toGraphQLChain`.

## Test plan
- [ ] Verify transactions on /explore page show correct chain data
- [ ] Verify `fromGraphQLChain('CITREA_MAINNET')` returns `UniverseChainId.CitreaMainnet`