### PR TITLE
Update Citrea RPC and explorer URLs to citreascan.com

### DIFF
--- a/apps/web/e2e/scripts/erc20-chain-swap-test.ts
+++ b/apps/web/e2e/scripts/erc20-chain-swap-test.ts
@@ -56,7 +56,7 @@ const CONFIG = {
 
   // Target Chain: Citrea Testnet
   citrea: {
-    rpcUrl: 'https://rpc.testnet.citrea.xyz',
+    rpcUrl: 'https://rpc.testnet.citreascan.com',
     chainId: 5115,
     jusd: ADDRESS[5115]!.juiceDollar,
     erc20Swap: '0xf2e019a371e5Fd32dB2fC564Ad9eAE9E433133cc',

--- a/apps/web/src/pages/Juice/sections/TechDetails.tsx
+++ b/apps/web/src/pages/Juice/sections/TechDetails.tsx
@@ -34,7 +34,7 @@ const AddressLink = styled(Flex, {
   },
 })
 
-const EXPLORER_BASE = 'https://explorer.testnet.citrea.xyz/address/'
+const EXPLORER_BASE = 'https://testnet.citreascan.com/address/'
 
 function ContractAddress({ address, name: _name }: { address: string; name: string }) {
   const handleClick = () => {

--- a/apps/web/src/pages/Jusd/sections/TechDetails.tsx
+++ b/apps/web/src/pages/Jusd/sections/TechDetails.tsx
@@ -35,7 +35,7 @@ const AddressLink = styled(Flex, {
 })
 
 // TODO: Move explorer URL to chain config (getChainInfo) - currently hardcoded for testnet
-const EXPLORER_BASE = 'https://explorer.testnet.citrea.xyz/address/'
+const EXPLORER_BASE = 'https://testnet.citreascan.com/address/'
 
 function ContractAddress({ address }: { address: string }) {
   const handleClick = () => {


### PR DESCRIPTION
## Summary
- Update RPC URLs from citrea.xyz to citreascan.com
- Update explorer URLs to new citreascan.com domain

## Changes
| Old URL | New URL |
|---------|---------|
| `https://rpc.citrea.xyz` | `https://rpc.citreascan.com` |
| `https://rpc.testnet.citrea.xyz` | `https://rpc.testnet.citreascan.com` |
| `https://explorer.mainnet.citrea.xyz` | `https://citreascan.com` |
| `https://explorer.testnet.citrea.xyz` | `https://testnet.citreascan.com` |

## Test plan
- [ ] Verify RPC connections work with new URLs
- [ ] Verify explorer links resolve correctly