### PR TITLE
feat: register preimage with ponder_claim after swap creation

### DIFF
--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -12,6 +12,7 @@ import {
   fetchSubmarineTransactionsBySwapId,
   fetchSwapCurrentStatus,
   helpMeClaim,
+  registerPreimage,
 } from 'uniswap/src/features/lds-bridge/api/client'
 import { fetchBlockTipHeight } from 'uniswap/src/features/lds-bridge/api/mempool'
 import { createLdsSocketClient } from 'uniswap/src/features/lds-bridge/api/socket'
@@ -109,6 +110,17 @@ class LdsBridgeManager extends SwapEventEmitter {
     }
 
     await this.storageManager.setSwap(reverseInvoiceResponse.id, reverseSwap)
+
+    // Register preimage with ponder_claim for automatic claiming
+    registerPreimage({
+      preimageHash: reverseSwap.preimageHash,
+      preimage: reverseSwap.preimage,
+      swapId: reverseInvoiceResponse.id,
+    }).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error('Failed to register preimage:', error)
+    })
+
     this._subscribeToSwapUpdates(reverseInvoiceResponse.id)
     await this._notifySwapChanges()
     await this.waitForSwapUntilState(reverseInvoiceResponse.id, LdsSwapStatus.SwapCreated)
@@ -215,6 +227,17 @@ class LdsBridgeManager extends SwapEventEmitter {
     }
 
     await this.storageManager.setSwap(chainSwapResponse.id, chainSwap)
+
+    // Register preimage with ponder_claim for automatic claiming
+    registerPreimage({
+      preimageHash: chainSwap.preimageHash,
+      preimage: chainSwap.preimage,
+      swapId: chainSwapResponse.id,
+    }).catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error('Failed to register preimage:', error)
+    })
+
     this._subscribeToSwapUpdates(chainSwapResponse.id)
     await this.waitForSwapUntilState(chainSwapResponse.id, LdsSwapStatus.SwapCreated)
     await this._notifySwapChanges()

--- a/packages/uniswap/src/features/lds-bridge/api/client.ts
+++ b/packages/uniswap/src/features/lds-bridge/api/client.ts
@@ -15,6 +15,8 @@ import type {
   LightningBridgeSubmarineGetResponse,
   LightningBridgeSubmarineLockResponse,
   LockupCheckResponse,
+  RegisterPreimageRequest,
+  RegisterPreimageResponse,
 } from 'uniswap/src/features/lds-bridge/lds-types/api'
 import { LdsSwapStatus } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
 
@@ -34,6 +36,8 @@ export type {
   LightningBridgeSubmarineGetResponse,
   LightningBridgeSubmarineLockResponse,
   LockupCheckResponse,
+  RegisterPreimageRequest,
+  RegisterPreimageResponse,
 }
 
 const LdsApiClient = createApiClient({
@@ -64,6 +68,12 @@ export async function createReverseSwap(params: CreateReverseSwapRequest): Promi
 
 export async function helpMeClaim(params: HelpMeClaimRequest): Promise<HelpMeClaimResponse> {
   return await LdsApiClient.post<HelpMeClaimResponse>('/claim/help-me-claim', {
+    body: JSON.stringify(params),
+  })
+}
+
+export async function registerPreimage(params: RegisterPreimageRequest): Promise<RegisterPreimageResponse> {
+  return await LdsApiClient.post<RegisterPreimageResponse>('/claim/register-preimage', {
     body: JSON.stringify(params),
   })
 }

--- a/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
@@ -214,3 +214,13 @@ export interface ClaimChainSwapResponse {
 }
 
 export type ChainPairsResponse = Record<string, Record<string, ChainPairInfo>>
+
+export interface RegisterPreimageRequest {
+  preimageHash: string
+  preimage: string
+  swapId?: string
+}
+
+export interface RegisterPreimageResponse {
+  success: boolean
+}


### PR DESCRIPTION
## Summary
- Register preimage with ponder_claim immediately after swap creation
- Enables auto-claim even if user closes browser before lockup confirmation

## Changes
- Add `registerPreimage()` API function
- Add `RegisterPreimageRequest` and `RegisterPreimageResponse` types
- Call `registerPreimage()` in `createChainSwap()` and `createReverseSwap()`

## Dependencies
- Requires ponder_claim PR: https://github.com/LightningDotSpace/ponder-claim/pull/13

## Test plan
- [ ] Create a chain swap (BTC → cBTC)
- [ ] Verify preimage registration request is sent
- [ ] Close browser before lockup confirmation
- [ ] Verify auto-claim happens via ponder_claim