### PR TITLE
fix(ui): make pending button clickable when loading

### DIFF
--- a/apps/web/src/components/Web3Status/index.tsx
+++ b/apps/web/src/components/Web3Status/index.tsx
@@ -3,22 +3,20 @@ import PortfolioDrawer from 'components/AccountDrawer'
 import { usePendingActivity } from 'components/AccountDrawer/MiniPortfolio/Activity/hooks'
 import { useAccountDrawer } from 'components/AccountDrawer/MiniPortfolio/hooks'
 import StatusIcon from 'components/Identicon/StatusIcon'
-import { RecentlyConnectedModal } from 'components/Web3Status/RecentlyConnectedModal'
 import { useAccountIdentifier } from 'components/Web3Status/useAccountIdentifier'
 import { useShowPendingAfterDelay } from 'components/Web3Status/useShowPendingAfterDelay'
 import { useAccount } from 'hooks/useAccount'
-import { useModalState } from 'hooks/useModalState'
 import { atom, useAtom } from 'jotai'
 import styled from 'lib/styled-components'
 import { Portal } from 'nft/components/common/Portal'
 import { RefObject, forwardRef, useCallback, useEffect, useRef } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useAppSelector } from 'state/hooks'
-import { AnimatePresence, Button, ButtonProps, Flex, Popover, Text } from 'ui/src'
+import { AnimatePresence, Button, ButtonProps, Flex, Text } from 'ui/src'
 import { Unitag } from 'ui/src/components/icons/Unitag'
 import { breakpoints } from 'ui/src/theme'
 import Trace from 'uniswap/src/features/telemetry/Trace'
-import { ElementName, InterfaceEventName, ModalName } from 'uniswap/src/features/telemetry/constants'
+import { ElementName, InterfaceEventName } from 'uniswap/src/features/telemetry/constants'
 import { sendAnalyticsEvent } from 'uniswap/src/features/telemetry/send'
 import { TestID } from 'uniswap/src/test/fixtures/testIDs'
 import { isIFramed } from 'utils/isIFramed'
@@ -190,21 +188,9 @@ function Web3StatusInner() {
 }
 
 export default function Web3Status() {
-  const { isOpen: recentlyConnectedModalIsOpen } = useModalState(ModalName.RecentlyConnectedModal)
   return (
     <PrefetchBalancesWrapper>
-      <Popover
-        placement="bottom"
-        stayInFrame
-        allowFlip
-        open={recentlyConnectedModalIsOpen}
-        offset={{ mainAxis: 8, crossAxis: -4 }}
-      >
-        <Popover.Trigger>
-          <Web3StatusInner />
-        </Popover.Trigger>
-        <RecentlyConnectedModal />
-      </Popover>
+      <Web3StatusInner />
       <Portal>
         <PortfolioDrawer />
       </Portal>

--- a/packages/ui/src/components/buttons/Button/Button.tsx
+++ b/packages/ui/src/components/buttons/Button/Button.tsx
@@ -57,6 +57,7 @@ const ButtonComponent = forwardRef<TamaguiElement, ButtonProps>(function Button(
       custom-background-color={customBackgroundColor}
       dd-action-name={props['dd-action-name'] ?? (typeof children === 'string' ? children : undefined)}
       {...props}
+      hasOnDisabledPress={Boolean(onDisabledPress)}
       onPress={handleOnPress}
     >
       <ThemedIcon

--- a/packages/ui/src/components/buttons/Button/components/CustomButtonFrame/CustomButtonFrame.tsx
+++ b/packages/ui/src/components/buttons/Button/components/CustomButtonFrame/CustomButtonFrame.tsx
@@ -80,14 +80,14 @@ const CustomButtonFrameWithoutCustomProps = styled(XStack, {
 
         // TODO(WEB-6347): change name back to `disabled`
         // @ts-expect-error we know isDisabled will be ButtonVariantProps['isDisabled']
-        if (props.isDisabled && !props.onDisabledPress) {
+        if (props.isDisabled && !props.hasOnDisabledPress) {
           return {
             backgroundColor: '$surface2',
           }
         }
 
         // @ts-expect-error we know this will potentially be on `props`
-        if (props.onDisabledPress) {
+        if (props.hasOnDisabledPress) {
           return {
             backgroundColor: '$surface2',
             pressStyle: withCommonPressStyle({}),
@@ -191,8 +191,8 @@ const CustomButtonFrameWithoutCustomProps = styled(XStack, {
     // TODO(WEB-6347): change variant name back to `disabled`
     isDisabled: (untypedIsDisabled, { props }) => {
       // @ts-expect-error we know this will potentially be on `props`
-      if (props.onDisabledPress) {
-        // `onDisabledPress` takes priority over `isDisabled` here; we still want to show the button as being interactive on hover, click, focus, etc.
+      if (props.hasOnDisabledPress) {
+        // `hasOnDisabledPress` takes priority over `isDisabled` here; we still want to show the button as being interactive on hover, click, focus, etc.
         return {}
       }
 
@@ -217,6 +217,10 @@ const CustomButtonFrameWithoutCustomProps = styled(XStack, {
       tertiary: {},
       'text-only': {},
     },
+    hasOnDisabledPress: {
+      true: {},
+      false: {},
+    },
   } as const,
   defaultVariants: {
     variant: 'default',
@@ -231,7 +235,6 @@ CustomButtonFrameWithoutCustomProps.displayName = 'CustomButtonFrameWithoutCusto
 
 type CustomProps = {
   'primary-color'?: string
-  onDisabledPress?: () => void
 }
 
 type CustomButtonWithExtraProps = typeof CustomButtonFrameWithoutCustomProps & {


### PR DESCRIPTION
## Summary

- Fix: "X Pending" button in header was not clickable
- Root cause: `onDisabledPress` was destructured in Button.tsx but never passed to CustomButtonFrame, causing the variant functions to not detect it and incorrectly apply `pointerEvents: none`
- Also removed unused Popover wrapper from Web3Status that was blocking clicks

## Changes

1. **packages/ui/src/components/buttons/Button/Button.tsx**
   - Pass `hasOnDisabledPress={Boolean(onDisabledPress)}` to CustomButtonFrame

2. **packages/ui/src/components/buttons/Button/components/CustomButtonFrame/CustomButtonFrame.tsx**
   - Add `hasOnDisabledPress` as a proper Tamagui variant
   - Update variant functions to check `hasOnDisabledPress` instead of `onDisabledPress`

3. **apps/web/src/components/Web3Status/index.tsx**
   - Remove unused Popover wrapper (RecentlyConnectedModal renders null anyway)

## Test plan

- [x] Click on "X Pending" button when transactions are pending
- [x] Verify account drawer opens
- [x] Verify normal button state still works (when not loading)
- [x] TypeCheck passes
- [x] Lint passes