### PR TITLE
fix: allow source chain for cross-chain swaps to Citrea

### DIFF
--- a/apps/web/src/state/swap/hooks.tsx
+++ b/apps/web/src/state/swap/hooks.tsx
@@ -502,9 +502,16 @@ export function useInitialCurrencyState(): {
   const isNonEvmChain =
     parsedCurrencyState.chainId === UniverseChainId.Bitcoin ||
     parsedCurrencyState.chainId === UniverseChainId.LightningNetwork
+  // For cross-chain swaps to Citrea, allow the source chain even if not in enabled chains
+  const isCrossChainToCitrea =
+    parsedCurrencyState.chainId &&
+    parsedCurrencyState.outputChainId &&
+    ALWAYS_ENABLED_CHAIN_IDS.includes(parsedCurrencyState.outputChainId)
   const supportedChainId: UniverseChainId = isNonEvmChain
     ? (parsedCurrencyState.chainId as UniverseChainId)
-    : evmSupportedChainId ?? UniverseChainId.Mainnet
+    : isCrossChainToCitrea
+      ? (parsedCurrencyState.chainId as UniverseChainId)
+      : evmSupportedChainId ?? UniverseChainId.Mainnet
   const supportedChainInfo = getChainInfo(supportedChainId)
   const isChainExplicitlySpecified = !!parsedCurrencyState.chainId
   const isSupportedChainCompatible =


### PR DESCRIPTION
## Summary
- Allows source chain selection for cross-chain swaps when the target chain is Citrea
- Fixes issue where source chains were incorrectly restricted for cross-chain swaps to always-enabled chains

## Test plan
- [ ] Test cross-chain swap from non-enabled chain to Citrea
- [ ] Verify source chain selector works correctly