### PR TITLE
fix(activity): show loading state while local activities are being processed

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
@@ -78,9 +78,9 @@ function combineActivities(localMap: ActivityMap = {}, remoteMap: ActivityMap = 
 
 export function useAllActivities(account: string) {
   const { formatNumberOrString } = useLocalizationContext()
-  const { activities, loading } = useAssetActivity()
+  const { activities, loading: remoteLoading } = useAssetActivity()
 
-  const localMap = useLocalActivities(account)
+  const { data: localMap, isLoading: localLoading } = useLocalActivities(account)
   const remoteMap = useMemo(
     () => parseRemoteActivities(activities, account, formatNumberOrString),
     [account, activities, formatNumberOrString],
@@ -107,6 +107,9 @@ export function useAllActivities(account: string) {
   }, [account, localMap, remoteMap, updateCancelledTx])
 
   const combinedActivities = useMemo(() => combineActivities(localMap, remoteMap ?? {}), [localMap, remoteMap])
+
+  // Combine both loading states - show loading until both sources are ready
+  const loading = remoteLoading || localLoading
 
   return { loading, activities: combinedActivities }
 }

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLocal.test.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLocal.test.ts
@@ -343,13 +343,13 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[mockHash('0xswap_exact_input')]).toBeDefined()
+        expect(result.current.data[mockHash('0xswap_exact_input')]).toBeDefined()
       })
     })
 
-    expect(result.current[mockHash('0xswap_exact_input', TransactionStatus.Pending)]?.title).toEqual('Swapping')
-    expect(result.current[mockHash('0xswap_exact_input', TransactionStatus.Success)]?.title).toEqual('Swapped')
-    expect(result.current[mockHash('0xswap_exact_input', TransactionStatus.Failed)]?.title).toEqual('Swap failed')
+    expect(result.current.data[mockHash('0xswap_exact_input', TransactionStatus.Pending)]?.title).toEqual('Swapping')
+    expect(result.current.data[mockHash('0xswap_exact_input', TransactionStatus.Success)]?.title).toEqual('Swapped')
+    expect(result.current.data[mockHash('0xswap_exact_input', TransactionStatus.Failed)]?.title).toEqual('Swap failed')
   })
 
   it('Adapts Swap exact input to Activity type', async () => {
@@ -358,11 +358,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [MockUSDC_MAINNET, MockDAI],
       title: 'Swapped',
@@ -379,11 +379,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [MockUSDC_MAINNET, MockDAI],
       title: 'Swapped',
@@ -400,11 +400,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [MockDAI],
       title: 'Approved',
@@ -421,11 +421,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [MockUSDT],
       title: 'Revoked approval',
@@ -443,11 +443,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [native, native.wrapped],
       title: 'Wrapped',
@@ -466,11 +466,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [native.wrapped, native],
       title: 'Unwrapped',
@@ -487,11 +487,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [MockUSDC_MAINNET, MockDAI],
       title: 'Collected fees',
@@ -508,11 +508,11 @@ describe('parseLocalActivity', () => {
 
     await act(async () => {
       await waitFor(() => {
-        expect(result.current[hash]).toBeDefined()
+        expect(result.current.data[hash]).toBeDefined()
       })
     })
 
-    expect(result.current[hash]).toMatchObject({
+    expect(result.current.data[hash]).toMatchObject({
       chainId: mockChainId,
       currencies: [MockUSDC_MAINNET, MockDAI],
       title: 'Migrated liquidity',

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLocal.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLocal.ts
@@ -639,13 +639,13 @@ export async function signatureToActivity(
   }
 }
 
-export function useLocalActivities(account: string): ActivityMap {
+export function useLocalActivities(account: string): { data: ActivityMap; isLoading: boolean } {
   const allTransactions = useMultichainTransactions(account)
   const allSignatures = useAllSignatures()
   const { formatNumberOrString } = useLocalizationContext()
   const { chains } = useEnabledChains()
 
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: [ReactQueryCacheKey.LocalActivities, account, allTransactions, allSignatures],
     queryFn: async () => {
       const transactions = Object.values(allTransactions)
@@ -669,5 +669,5 @@ export function useLocalActivities(account: string): ActivityMap {
     },
   })
 
-  return data ?? {}
+  return { data: data ?? {}, isLoading }
 }


### PR DESCRIPTION
## Summary
- Fixed race condition where Activity Tab showed "No activity yet" despite pending transactions existing
- `useLocalActivities` now returns `{ data, isLoading }` to expose its loading state
- `useAllActivities` combines both remote and local loading states: `loading = remoteLoading || localLoading`

## Problem
The pending counter showed "2 Pending" but clicking on it displayed "No activity yet" in the Activity Tab. This happened because:
1. Remote GraphQL query completed quickly (often with empty results) → `loading = false`
2. Local activities were still processing (fetching token info via GraphQL) → returned `{}`
3. `combineActivities({}, {})` returned empty array
4. "No activity yet" was displayed prematurely

## Solution
Expose the `isLoading` state from `useLocalActivities` and combine it with the remote loading state. The skeleton loading will now be shown until **both** data sources are ready.

## Test plan
- [ ] Open Activity Tab with pending transactions
- [ ] Verify skeleton loading is shown until data loads
- [ ] Verify pending transactions appear after loading completes
- [ ] Run `yarn typecheck` ✅
- [ ] Run `yarn lint` ✅
- [ ] Run `yarn build:production` ✅