### PR TITLE
fix: improve ERC20 chain swap network switching (#477)

### DIFF
--- a/apps/web/src/hooks/useSwitchChain.ts
+++ b/apps/web/src/hooks/useSwitchChain.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
 import { endSwitchingChain, startSwitchingChain } from 'state/wallets/reducer'
 import { useIsSupportedChainIdCallback } from 'uniswap/src/features/chains/hooks/useSupportedChainId'
+import { ERC20_CHAIN_SWAP_SOURCE_CHAINS } from 'uniswap/src/features/chains/utils'
 import { EVMUniverseChainId } from 'uniswap/src/features/chains/types'
 import { useSwitchChain as useSwitchChainWagmi } from 'wagmi'
 
@@ -15,7 +16,9 @@ export function useSwitchChain() {
   return useCallback(
     (chainId: EVMUniverseChainId) => {
       const isSupportedChain = isSupportedChainCallback(chainId)
-      if (!isSupportedChain) {
+      const isCrossChainSwapSource = ERC20_CHAIN_SWAP_SOURCE_CHAINS.includes(chainId)
+
+      if (!isSupportedChain && !isCrossChainSwapSource) {
         throw new Error(`Chain ${chainId} not supported for connector (${account.connector?.name})`)
       }
       if (account.chainId === chainId) {

--- a/apps/web/src/state/sagas/transactions/swapSaga.ts
+++ b/apps/web/src/state/sagas/transactions/swapSaga.ts
@@ -230,19 +230,18 @@ async function handleSwitchChains(
 ): Promise<{ chainSwitchFailed: boolean }> {
   const { selectChain, startChainId, swapTxContext } = params
 
+  // For ERC20 chain swaps, skip chain switching here entirely
+  // The chain switch will be handled in erc20ChainSwap.ts with proper non-blocking logic
+  if (isErc20ChainSwap(swapTxContext)) {
+    return { chainSwitchFailed: false }
+  }
+
   const swapChainId = swapTxContext.trade.inputAmount.currency.chainId
   if (swapChainId === startChainId) {
     return { chainSwitchFailed: false }
   }
 
   const chainSwitched = await selectChain(swapChainId)
-
-  // For ERC20 chain swaps, if chain switch fails, allow it to proceed anyway
-  // The chain switch will happen during transaction execution
-  if (!chainSwitched && isErc20ChainSwap(swapTxContext)) {
-    // Allow ERC20 chain swaps to proceed - chain will switch during transaction execution
-    return { chainSwitchFailed: false }
-  }
 
   return { chainSwitchFailed: !chainSwitched }
 }

--- a/packages/uniswap/src/features/chains/utils.ts
+++ b/packages/uniswap/src/features/chains/utils.ts
@@ -195,6 +195,19 @@ export function filterChainIdsByFeatureFlag(featureFlaggedChainIds: {
 // JuiceSwap only supports Citrea chains
 export const ALWAYS_ENABLED_CHAIN_IDS = [UniverseChainId.CitreaMainnet, UniverseChainId.CitreaTestnet]
 
+// Chains that can be switched to for ERC20 cross-chain swaps
+// These are NOT shown in the UI chain selector but CAN be switched to
+//
+// To add a new cross-chain swap source (e.g., Arbitrum → Citrea):
+// 1. Add chain to this array (e.g., UniverseChainId.ArbitrumOne)
+// 2. Add direction to Erc20ChainSwapDirection enum in isBitcoinBridge.ts
+// 3. Update direction detection in TradingApiClient.ts getErc20ChainSwapQuote()
+// 4. Handle new direction in erc20ChainSwap.ts handleErc20ChainSwap()
+export const ERC20_CHAIN_SWAP_SOURCE_CHAINS: UniverseChainId[] = [
+  UniverseChainId.Polygon, // USDT_POLYGON -> JUSD
+  UniverseChainId.Mainnet, // USDT_ETH/USDC_ETH -> JUSD
+]
+
 export function getEnabledChains({
   platform,
   /**


### PR DESCRIPTION
* fix: improve ERC20 chain swap network switching

- Skip blocking chain switch in swapSaga for ERC20 swaps
- Move chain switch to erc20ChainSwap.ts (before server swap creation)
- Use non-blocking selectChain with waitForNetwork polling
- Add logging for debugging chain switch issues
- Reduce timeout from 30s to 15s for faster feedback

* allow chain switching to Polygon/Mainnet for ERC20 cross-chain swaps

* improve ERC20 chain swap network switching

---------