### PR TITLE
fix: re-enable trading on Ethereum mainnet

### DIFF
--- a/packages/uniswap/src/features/transactions/swap/hooks/useTrade/useTradeServiceQueryOptions.ts
+++ b/packages/uniswap/src/features/transactions/swap/hooks/useTrade/useTradeServiceQueryOptions.ts
@@ -27,7 +27,7 @@ export function createTradeServiceQueryOptions(ctx: {
         }
         return ctx.tradeService.getTrade(params)
       },
-      enabled: !!params && !params.skip && !!validatedInput && params.otherCurrency?.chainId !== 1, // TODO: re-enable
+      enabled: !!params && !params.skip && !!validatedInput,
     })
   }
 }


### PR DESCRIPTION
## Summary
- Removes the chainId !== 1 condition that was blocking trades on Ethereum mainnet
- Addresses the TODO comment to re-enable this functionality

## Test plan
- [ ] Verify that swaps work correctly on Ethereum mainnet (chainId 1)
- [ ] Verify that swaps continue to work on other supported chains
- [ ] Test both single-chain and cross-chain swap scenarios