### PR TITLE
feat: Display Lightning bridge swaps in Activity drawer

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/ActivityRow.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/ActivityRow.tsx
@@ -1,4 +1,5 @@
 import { useOpenOffchainActivityModal } from 'components/AccountDrawer/MiniPortfolio/Activity/OffchainActivityModal'
+import { LDS_ACTIVITY_PREFIX } from 'components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge'
 import { useTimeSince } from 'components/AccountDrawer/MiniPortfolio/Activity/parseRemote'
 import { Activity } from 'components/AccountDrawer/MiniPortfolio/Activity/types'
 import { PortfolioLogo } from 'components/AccountDrawer/MiniPortfolio/PortfolioLogo'
@@ -9,6 +10,7 @@ import Column from 'components/deprecated/Column'
 import Row from 'components/deprecated/Row'
 import styled from 'lib/styled-components'
 import { useCallback } from 'react'
+import { useNavigate } from 'react-router'
 import { SignatureType } from 'state/signatures/types'
 import { ThemedText } from 'theme/components'
 import { EllipsisStyle } from 'theme/components/styles'
@@ -87,10 +89,16 @@ export function ActivityRow({ activity }: { activity: Activity }) {
   const isBridge = type === TransactionType.Bridging
 
   const openOffchainActivityModal = useOpenOffchainActivityModal()
+  const navigate = useNavigate()
 
   const explorerUrl = getExplorerLink({ chainId, data: hash, type: ExplorerDataType.TRANSACTION })
 
   const onClick = useCallback(() => {
+    if (hash.startsWith(LDS_ACTIVITY_PREFIX)) {
+      navigate('/bridge-swaps')
+      return
+    }
+
     if (offchainOrderDetails) {
       openOffchainActivityModal(offchainOrderDetails, {
         inputLogo: activity.logos?.[0],
@@ -98,13 +106,13 @@ export function ActivityRow({ activity }: { activity: Activity }) {
       })
       return
     }
-    // Do not allow FOR activity to be opened until confirmed on chain
+
     if (activity.status === TransactionStatus.Pending && !isHash(hash)) {
       return
     }
 
     window.open(explorerUrl, '_blank')
-  }, [activity.logos, activity.status, explorerUrl, hash, offchainOrderDetails, openOffchainActivityModal])
+  }, [activity.logos, activity.status, explorerUrl, hash, navigate, offchainOrderDetails, openOffchainActivityModal])
 
   return (
     <Trace

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.ts
@@ -1,0 +1,66 @@
+import { Activity, ActivityMap } from 'components/AccountDrawer/MiniPortfolio/Activity/types'
+import { TransactionType } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { SomeSwap } from 'uniswap/src/features/lds-bridge/lds-types/storage'
+import { LdsSwapStatus } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
+import { TransactionStatus } from 'uniswap/src/features/transactions/types/transactionDetails'
+
+export const LDS_ACTIVITY_PREFIX = 'lds-'
+
+function ldsStatusToTransactionStatus(status?: LdsSwapStatus): TransactionStatus {
+  if (!status) {
+    return TransactionStatus.Pending
+  }
+
+  if (status === LdsSwapStatus.InvoiceSettled || status === LdsSwapStatus.TransactionClaimed) {
+    return TransactionStatus.Success
+  }
+
+  if (
+    status === LdsSwapStatus.SwapExpired ||
+    status === LdsSwapStatus.SwapRefunded ||
+    status === LdsSwapStatus.InvoiceFailedToPay ||
+    status === LdsSwapStatus.TransactionFailed
+  ) {
+    return TransactionStatus.Failed
+  }
+
+  return TransactionStatus.Pending
+}
+
+export function swapToActivity(swap: SomeSwap & { id: string }): Activity {
+  const status = ldsStatusToTransactionStatus(swap.status)
+
+  const sourceChain = swap.assetSend === 'cBTC' ? UniverseChainId.CitreaMainnet : UniverseChainId.LightningNetwork
+  const destChain = swap.assetReceive === 'BTC' ? UniverseChainId.LightningNetwork : UniverseChainId.CitreaMainnet
+
+  const descriptor = `${swap.sendAmount} ${swap.assetSend} → ${swap.receiveAmount} ${swap.assetReceive}`
+
+  const titleMap: Partial<Record<TransactionStatus, string>> = {
+    [TransactionStatus.Pending]: 'Bridge pending',
+    [TransactionStatus.Success]: 'Bridged',
+    [TransactionStatus.Failed]: 'Bridge failed',
+  }
+
+  return {
+    hash: `${LDS_ACTIVITY_PREFIX}${swap.id}`,
+    chainId: sourceChain,
+    outputChainId: destChain,
+    status,
+    timestamp: swap.date / 1000,
+    title: titleMap[status] || 'Bridge',
+    descriptor,
+    from: swap.claimAddress,
+    type: TransactionType.Bridging,
+  }
+}
+
+export function swapsToActivityMap(swaps: Record<string, SomeSwap>): ActivityMap {
+  const activityMap: ActivityMap = {}
+
+  for (const [id, swap] of Object.entries(swaps)) {
+    activityMap[`${LDS_ACTIVITY_PREFIX}${id}`] = swapToActivity({ ...swap, id })
+  }
+
+  return activityMap
+}


### PR DESCRIPTION
## Summary
Adds Lightning bridge swaps (submarine, reverse, chain) to the Activity section in the account drawer, providing a unified timeline view of all user transactions.

## Changes
- **New file:** `parseLdsBridge.ts` - converts LDS swap data to Activity format
- **Modified:** `hooks.ts` - loads bridge swaps and merges with existing activities
- **Modified:** `ActivityRow.tsx` - handles navigation to Bridge Swaps page on click

## Implementation Details
- Bridge activities use `lds-{swapId}` prefix to distinguish from blockchain tx hashes
- Status mapping: LDS statuses → TransactionStatus (Pending/Success/Failed)
- Clicking a bridge activity navigates to `/bridge-swaps` instead of block explorer
- Automatically subscribes to swap status updates via LdsBridgeManager

## Testing
- All LDS bridge swaps (Submarine, Reverse, and Chain) now appear in Activity drawer:
 -- Submarine swaps: cBTC → lnBTC
 -- Reverse swaps: lnBTC → cBTC
 -- Chain swaps: cBTC ↔ BTC (both directions)
- Activities show correct status, timestamp, and amount
- Clicking navigates to Bridge Swaps page
- Pending/completed/failed states display correctly
