### PR TITLE
Fix: use full logo for single currency in drawer

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/PortfolioLogo.tsx
@@ -45,7 +45,10 @@ function getLogo(
   if (accountAddress) {
     return <Identicon account={accountAddress} size={size} />
   }
-  if (currencies && currencies.length) {
+  if (currencies?.length === 1) {
+    return <CurrencyLogo currency={currencies[0]} size={size} />
+  }
+  if (currencies?.length) {
     return <DoubleCurrencyLogo currencies={currencies} size={size} customIcon={customIcon} />
   }
   if (images && images.length >= 2) {


### PR DESCRIPTION
Single currencies now use CurrencyLogo instead of DoubleCurrencyLogo/SplitLogo, preventing the 19px width clip in the drawer tokens tab.