### PR TITLE
Remove fees FAQ entry from landing page

### DIFF
--- a/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
+++ b/apps/web/src/pages/Landing/sections/NewsletterEtc.tsx
@@ -191,11 +191,6 @@ function FAQList() {
       question: t('faq.supportedChains.question'),
       answer: t('faq.supportedChains.answer'),
     },
-    {
-      id: 'faq-fees',
-      question: t('faq.fees.question'),
-      answer: t('faq.fees.answer'),
-    },
   ]
 
   return (

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -2502,8 +2502,6 @@
   "faq.whatIsJuice.answer": "JUICE is the governance and equity token of the JuiceDollar protocol. It represents your stake in the ecosystem — you can earn protocol fees, participate in governance, and benefit from the protocol's growth. Visit the JUICE page to learn more.",
   "faq.supportedChains.question": "What chains does JuiceSwap support?",
   "faq.supportedChains.answer": "JuiceSwap currently operates on Citrea, a Bitcoin Layer 2 network. This allows you to swap tokens with the security of Bitcoin while benefiting from lower fees and faster transactions.",
-  "faq.fees.question": "What are the fees on JuiceSwap?",
-  "faq.fees.answer": "JuiceSwap charges a small swap fee that goes to liquidity providers and the protocol. The exact fee depends on the pool you're trading in. JUICE token investments and redemptions have a 2% fee that benefits existing JUICE holders.",
   "juice.hero.title": "Governance & Equity Token of the Juice Ecosystem",
   "juice.hero.tagline": "Governance & Equity Token of JuiceDollar",
   "juice.hero.description": "Own a piece of the protocol. Earn fees. Shape the future. JUICE represents your stake in the JUICE ecosystem — like owning shares in a decentralized bank.",


### PR DESCRIPTION
## Summary
- Removes the FAQ entry about swap fees from the landing page
- Removes corresponding translation keys from en-US.json

## Test plan
- [ ] Verify landing page FAQ section renders correctly without the fees entry