### PR TITLE
fix(bridge-swaps): convert satoshi amounts to BTC for display

### DIFF
--- a/apps/web/src/pages/BridgeSwaps/RefundableSwapsSection.tsx
+++ b/apps/web/src/pages/BridgeSwaps/RefundableSwapsSection.tsx
@@ -1,4 +1,5 @@
 import { AddressInput, RefundButton, RefundableSection, RefundableSwapCard } from 'pages/BridgeSwaps/styles'
+import { formatSatoshiAmount } from 'pages/BridgeSwaps/utils'
 import { useCallback, useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { refundSwap } from 'state/sagas/transactions/bridgeRefundSaga'
@@ -49,7 +50,7 @@ function RefundableSwapCardItem({
     <RefundableSwapCard>
       <Flex gap="$spacing4">
         <Text variant="body2" color="$neutral1" fontWeight="600">
-          {swap.sendAmount.toLocaleString()} {swap.assetSend} → {swap.receiveAmount.toLocaleString()}{' '}
+          {formatSatoshiAmount(swap.sendAmount)} {swap.assetSend} → {formatSatoshiAmount(swap.receiveAmount)}{' '}
           {swap.assetReceive}
         </Text>
         <Text variant="body4" color="$neutral2">

--- a/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
+++ b/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
@@ -1,3 +1,4 @@
+import { formatSatoshiAmount } from 'pages/BridgeSwaps/utils'
 import { useState } from 'react'
 import { Flex, Text, styled } from 'ui/src'
 import { AlertTriangleFilled } from 'ui/src/components/icons/AlertTriangleFilled'
@@ -216,13 +217,13 @@ export function SwapCard({ swap, onRefresh: _onRefresh }: SwapCardProps): JSX.El
           </Flex>
           <SwapAmounts>
             <Text variant="body2" color="$neutral1">
-              {swap.sendAmount.toLocaleString()} {swap.assetSend}
+              {formatSatoshiAmount(swap.sendAmount)} {swap.assetSend}
             </Text>
             <Text variant="body2" color="$neutral2">
               →
             </Text>
             <Text variant="body2" color="$neutral1">
-              {swap.receiveAmount.toLocaleString()} {swap.assetReceive}
+              {formatSatoshiAmount(swap.receiveAmount)} {swap.assetReceive}
             </Text>
           </SwapAmounts>
           <Text variant="body3" color="$neutral2">

--- a/apps/web/src/pages/BridgeSwaps/utils.ts
+++ b/apps/web/src/pages/BridgeSwaps/utils.ts
@@ -1,0 +1,12 @@
+const SATOSHI_DIVISOR = 100_000_000
+
+export function formatSatoshiAmount(satoshis: number): string {
+  const btcAmount = satoshis / SATOSHI_DIVISOR
+  // Remove trailing zeros but keep at least reasonable precision
+  if (btcAmount === 0) {
+    return '0'
+  }
+  // Use up to 8 decimal places, but remove trailing zeros
+  const formatted = btcAmount.toFixed(8)
+  return formatted.replace(/\.?0+$/, '')
+}


### PR DESCRIPTION
## Summary
- Fix decimal display on bridge-swaps page where amounts were shown in satoshis instead of BTC
- Add `formatSatoshiAmount` utility function to convert satoshis to human-readable BTC values
- Apply formatting to both `SwapCard` and `RefundableSwapsSection` components

## Changes
| Before | After |
|--------|-------|
| `10000000 BTC` | `0.1 BTC` |
| `9950000 cBTC` | `0.0995 cBTC` |

## Test plan
- [x] Navigate to `/bridge-swaps` page
- [ ] Verify amounts display correctly with proper decimal places
- [ ] Check refundable swaps section shows correct amounts