### PR TITLE
feat: swap and bridge toasts → /bridge-swaps and Citreascan

### DIFF
--- a/apps/web/src/components/Popups/PopupContent.tsx
+++ b/apps/web/src/components/Popups/PopupContent.tsx
@@ -232,21 +232,12 @@ export function BridgingPopupContent({ hash, onClose }: { hash: string; onClose:
     return null
   }
 
-  const onClick = () =>
-    window.open(
-      getExplorerLink({ chainId: activity.chainId, data: activity.hash, type: ExplorerDataType.TRANSACTION }),
-      '_blank',
-    )
+  const onClick = () => {
+    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+    onClose()
+  }
 
-  const explorerUrlUnavailable = isPendingTx(transaction) && transaction.batchInfo
-
-  return (
-    <ActivityPopupContent
-      activity={activity}
-      onClick={explorerUrlUnavailable ? undefined : onClick}
-      onClose={onClose}
-    />
-  )
+  return <ActivityPopupContent activity={activity} onClick={onClick} onClose={onClose} />
 }
 
 export function LightningBridgePopupContent({
@@ -298,6 +289,11 @@ export function LightningBridgePopupContent({
 
   const isPending = status === LdsBridgeStatus.Pending
 
+  const onClick = () => {
+    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+    onClose()
+  }
+
   return (
     <Flex
       row
@@ -315,7 +311,7 @@ export function LightningBridgePopupContent({
         width: '100%',
       }}
     >
-      <TouchableArea onPress={noop} flex={1}>
+      <TouchableArea onPress={onClick} flex={1}>
         <Flex row gap="$gap12" height={68} py="$spacing12" px="$spacing16">
           <Flex justifyContent="center">
             <PortfolioLogo chainId={UniverseChainId.Mainnet} images={[bitcoinLogo]} size={32} />
@@ -402,6 +398,11 @@ export function BitcoinBridgePopupContent({
 
   const isPending = status === LdsBridgeStatus.Pending
 
+  const onClick = () => {
+    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+    onClose()
+  }
+
   return (
     <Flex
       row
@@ -419,7 +420,7 @@ export function BitcoinBridgePopupContent({
         width: '100%',
       }}
     >
-      <TouchableArea onPress={noop} flex={1}>
+      <TouchableArea onPress={onClick} flex={1}>
         <Flex row gap="$gap12" height={68} py="$spacing12" px="$spacing16">
           <Flex justifyContent="center">
             <PortfolioLogo chainId={UniverseChainId.Mainnet} images={[bitcoinLogo]} size={32} />

--- a/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
+++ b/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
@@ -79,6 +79,10 @@ function WebUniswapProviderInner({ children }: PropsWithChildren) {
     [navigate, closeSearchModal],
   )
 
+  const navigateToBridgesSwaps = useCallback(() => {
+    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+  }, [])
+
   const navigateToSendFlow = useCallback(
     ({ chainId, currencyAddress }: { chainId: UniverseChainId; currencyAddress?: Address }) => {
       const chainUrlParam = getChainInfo(chainId).urlParam
@@ -183,6 +187,7 @@ function WebUniswapProviderInner({ children }: PropsWithChildren) {
       navigateToNftCollection={navigateToNftCollection}
       navigateToNftDetails={navigateToNftDetails}
       navigateToPoolDetails={navigateToPoolDetails}
+      navigateToBridgesSwaps={navigateToBridgesSwaps}
       handleShareToken={handleShareToken}
       onConnectWallet={accountDrawer.open}
       getCanSignPermits={getCanSignPermits}

--- a/packages/uniswap/src/contexts/UniswapContext.tsx
+++ b/packages/uniswap/src/contexts/UniswapContext.tsx
@@ -33,6 +33,7 @@ interface UniswapContextValue {
   navigateToNftDetails: (args: NavigateToNftItemArgs) => void
   navigateToNftCollection: (args: { collectionAddress: Address; chainId: UniverseChainId }) => void
   navigateToPoolDetails: (args: { poolId: Address; chainId: UniverseChainId }) => void
+  navigateToBridgesSwaps?: () => void
   handleShareToken: (args: { currencyId: string }) => void
   onSwapChainsChanged: (args: {
     chainId: UniverseChainId
@@ -73,6 +74,7 @@ export function UniswapProvider({
   navigateToNftDetails,
   navigateToNftCollection,
   navigateToPoolDetails,
+  navigateToBridgesSwaps,
   handleShareToken,
   onSwapChainsChanged,
   signer,
@@ -104,6 +106,7 @@ export function UniswapProvider({
       navigateToNftCollection,
       navigateToNftDetails,
       navigateToPoolDetails,
+      navigateToBridgesSwaps,
       handleShareToken,
       onSwapChainsChanged: ({
         chainId,
@@ -145,6 +148,7 @@ export function UniswapProvider({
       navigateToNftCollection,
       navigateToNftDetails,
       navigateToPoolDetails,
+      navigateToBridgesSwaps,
       handleShareToken,
       signer,
       useProviderHook,

--- a/packages/uniswap/src/features/notifications/types.ts
+++ b/packages/uniswap/src/features/notifications/types.ts
@@ -202,6 +202,7 @@ export interface ChangeAssetVisibilityNotification extends AppNotificationBase {
 export interface SwapPendingNotification extends AppNotificationBase {
   type: AppNotificationType.SwapPending
   wrapType: WrapType
+  isBridge?: boolean
 }
 
 export interface TransferCurrencyPendingNotification extends AppNotificationBase {

--- a/packages/uniswap/src/features/transactions/swap/components/UnichainInstantBalanceModal/constants.ts
+++ b/packages/uniswap/src/features/transactions/swap/components/UnichainInstantBalanceModal/constants.ts
@@ -16,4 +16,4 @@ export const CHAIN_TO_UNIVERSAL_ROUTER_ADDRESS: Partial<Record<UniverseChainId, 
   ],
 }
 
-export const FLASHBLOCKS_UI_SKIP_ROUTES: TradeRouting[] = [Routing.WRAP, Routing.UNWRAP, Routing.BRIDGE]
+export const FLASHBLOCKS_UI_SKIP_ROUTES: TradeRouting[] = [Routing.WRAP, Routing.UNWRAP, Routing.BRIDGE, Routing.BITCOIN_BRIDGE, Routing.LN_BRIDGE, Routing.ERC20_CHAIN_SWAP]

--- a/packages/wallet/src/features/notifications/components/BridgeNotification.tsx
+++ b/packages/wallet/src/features/notifications/components/BridgeNotification.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { Flex, Text } from 'ui/src'
 import { iconSizes } from 'ui/src/theme'
 import { BridgeIcon, SplitLogo } from 'uniswap/src/components/CurrencyLogo/SplitLogo'
+import { useUniswapContext } from 'uniswap/src/contexts/UniswapContext'
 import { useLocalizationContext } from 'uniswap/src/features/language/LocalizationContext'
 import { BridgeTxNotification } from 'uniswap/src/features/notifications/types'
 import { useCurrencyInfo } from 'uniswap/src/features/tokens/useCurrencyInfo'
@@ -16,7 +17,8 @@ import { useCreateSwapFormState } from 'wallet/src/features/transactions/hooks/u
 export function BridgeNotification({ notification }: { notification: BridgeTxNotification }): JSX.Element {
   const { t } = useTranslation()
   const formatter = useLocalizationContext()
-  const { navigateToAccountActivityList, navigateToSwapFlow } = useWalletNavigation()
+  const { navigateToSwapFlow } = useWalletNavigation()
+  const { navigateToBridgesSwaps } = useUniswapContext()
 
   const {
     chainId,
@@ -92,7 +94,7 @@ export function BridgeNotification({ notification }: { notification: BridgeTxNot
       hideDelay={hideDelay}
       title={title}
       contentOverride={contentOverride}
-      onPress={navigateToAccountActivityList}
+      onPress={navigateToBridgesSwaps}
     />
   )
 }

--- a/packages/wallet/src/features/notifications/components/SwapPendingNotification.tsx
+++ b/packages/wallet/src/features/notifications/components/SwapPendingNotification.tsx
@@ -1,6 +1,7 @@
 import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import { SpinningLoader } from 'ui/src'
+import { useUniswapContext } from 'uniswap/src/contexts/UniswapContext'
 import { SwapPendingNotification as SwapPendingNotificationType } from 'uniswap/src/features/notifications/types'
 import { WrapType } from 'uniswap/src/features/transactions/types/wrap'
 import { ONE_SECOND_MS } from 'utilities/src/time/time'
@@ -12,6 +13,7 @@ export const TRANSACTION_PENDING_NOTIFICATION_DELAY = 12 * ONE_SECOND_MS
 
 export function SwapPendingNotification({ notification }: { notification: SwapPendingNotificationType }): JSX.Element {
   const { t } = useTranslation()
+  const { navigateToBridgesSwaps } = useUniswapContext()
 
   const notificationText = getNotificationText(notification.wrapType, t)
 
@@ -21,6 +23,7 @@ export function SwapPendingNotification({ notification }: { notification: SwapPe
       hideDelay={TRANSACTION_PENDING_NOTIFICATION_DELAY}
       postCaptionElement={<SpinningLoader color="$accent1" />}
       title={notificationText}
+      onPress={notification.isBridge ? navigateToBridgesSwaps : undefined}
     />
   )
 }

--- a/packages/wallet/src/features/transactions/swap/executeSwapSaga.test.ts
+++ b/packages/wallet/src/features/transactions/swap/executeSwapSaga.test.ts
@@ -598,6 +598,7 @@ describe('executeSwapSaga', () => {
           pushNotification({
             type: AppNotificationType.SwapPending,
             wrapType: WrapType.NotApplicable,
+            isBridge: true,
           }),
         )
         .call(params.onSuccess)
@@ -651,6 +652,7 @@ describe('executeSwapSaga', () => {
           pushNotification({
             type: AppNotificationType.SwapPending,
             wrapType: WrapType.NotApplicable,
+            isBridge: true,
           }),
         )
         .call(params.onSuccess)

--- a/packages/wallet/src/features/transactions/swap/executeSwapSaga.ts
+++ b/packages/wallet/src/features/transactions/swap/executeSwapSaga.ts
@@ -13,7 +13,7 @@ import {
   SwapGasFeeEstimation,
   ValidatedSwapTxContext,
 } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
-import { isWrap } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { isBridge, isBitcoinBridge, isLightningBridge, isWrap } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { TransactionType } from 'uniswap/src/features/transactions/types/transactionDetails'
 import { isFinalizedTx } from 'uniswap/src/features/transactions/types/utils'
 import { WrapType } from 'uniswap/src/features/transactions/types/wrap'
@@ -325,7 +325,8 @@ export function createExecuteSwapSaga(
           !getIsFlashblocksEnabled(chainId) ||
           FLASHBLOCKS_UI_SKIP_ROUTES.includes(preSignedTransaction.swapTxContext.routing)
         ) {
-          yield* put(pushNotification({ type: AppNotificationType.SwapPending, wrapType: WrapType.NotApplicable }))
+          const isBridgeSwap = isBridge(preSignedTransaction.swapTxContext) || isBitcoinBridge(preSignedTransaction.swapTxContext) || isLightningBridge(preSignedTransaction.swapTxContext)
+          yield* put(pushNotification({ type: AppNotificationType.SwapPending, wrapType: WrapType.NotApplicable, isBridge: isBridgeSwap }))
         }
 
         swapResult = yield* executeTransactionStep({

--- a/packages/wallet/src/features/transactions/swap/swapSaga.ts
+++ b/packages/wallet/src/features/transactions/swap/swapSaga.ts
@@ -192,7 +192,7 @@ export function* approveAndSwap(params: SwapParams) {
         transactionOriginType: TransactionOriginType.Internal,
       }
       yield* call(executeTransaction, executeTransactionParams)
-      yield* put(pushNotification({ type: AppNotificationType.SwapPending, wrapType: WrapType.NotApplicable }))
+      yield* put(pushNotification({ type: AppNotificationType.SwapPending, wrapType: WrapType.NotApplicable, isBridge: true }))
 
       // Call onSuccess now if it wasn't called earlier in function due to transaction spacing
       if (swapTxHasDelayedSubmission) {


### PR DESCRIPTION
Bridge pending and completed toasts are clickable and open `/bridge-swaps` in a new tab (same pattern as swap toasts → Citreascan).

- Add `isBridge` to pending notification; include bridge routings in flashblocks skip list
- Add `navigateToBridgesSwaps` in Uniswap + web context (opens in new tab via `window.open`)
- BridgeNotification + web popups (Bridging, Lightning, Bitcoin) use it
- executeSwapSaga + swapSaga set `isBridge` for bridge routes