### PR TITLE
feat: Separate bridge swap activity by testnet/mainnet

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.ts
@@ -1,4 +1,5 @@
 import { Activity, ActivityMap } from 'components/AccountDrawer/MiniPortfolio/Activity/types'
+import { inferChainIdFromSwap } from 'components/AccountDrawer/MiniPortfolio/Activity/utils'
 import { TransactionType } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { SomeSwap } from 'uniswap/src/features/lds-bridge/lds-types/storage'
@@ -31,8 +32,14 @@ function ldsStatusToTransactionStatus(status?: LdsSwapStatus): TransactionStatus
 export function swapToActivity(swap: SomeSwap & { id: string }): Activity {
   const status = ldsStatusToTransactionStatus(swap.status)
 
-  const sourceChain = swap.assetSend === 'cBTC' ? UniverseChainId.CitreaMainnet : UniverseChainId.LightningNetwork
-  const destChain = swap.assetReceive === 'BTC' ? UniverseChainId.LightningNetwork : UniverseChainId.CitreaMainnet
+  const inferredChainId = swap.chainId ?? inferChainIdFromSwap(swap)
+  const sourceChain = inferredChainId
+    ? inferredChainId
+    : swap.assetSend === 'cBTC'
+      ? UniverseChainId.CitreaMainnet
+      : UniverseChainId.LightningNetwork
+  const destChain =
+    swap.assetReceive === 'BTC' ? UniverseChainId.LightningNetwork : inferredChainId ?? UniverseChainId.CitreaMainnet
 
   const descriptor = `${swap.sendAmount} ${swap.assetSend} → ${swap.receiveAmount} ${swap.assetReceive}`
 

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js'
 import { popupRegistry } from 'components/Popups/registry'
 import { BitcoinBridgeDirection, LdsBridgeStatus, PopupType } from 'components/Popups/types'
 import { call } from 'typed-redux-saga'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { LdsSwapStatus, btcToSat, getLdsBridgeManager } from 'uniswap/src/features/lds-bridge'
 import { BitcoinBridgeBitcoinToCitreaStep } from 'uniswap/src/features/transactions/swap/steps/bitcoinBridge'
 import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
@@ -24,12 +25,14 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
   const userLockAmount = btcToSat(new BigNumber(trade.inputAmount.toExact())).toNumber()
   const ldsBridge = getLdsBridgeManager()
   const claimAddress = account.address
+  const citreaChainId = trade.outputAmount.currency.chainId as UniverseChainId
 
   const chainSwapResponse = yield* call([ldsBridge, ldsBridge.createChainSwap], {
     from: 'BTC',
     to: 'cBTC',
     claimAddress,
     userLockAmount,
+    chainId: citreaChainId,
   })
   step.bip21 = chainSwapResponse.lockupDetails.bip21
   setCurrentStep({ step, accepted: true })

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeCitreaToBitcoin.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeCitreaToBitcoin.ts
@@ -45,16 +45,17 @@ export function* handleBitcoinBridgeCitreaToBitcoin(params: HandleBitcoinBridgeC
 
   const ldsBridge = getLdsBridgeManager()
   const userLockAmount = btcToSat(new BigNumber(trade.inputAmount.toExact())).toNumber()
+  const citreaChainId = trade.inputAmount.currency.chainId as UniverseChainId
 
   const chainSwap = yield* call([ldsBridge, ldsBridge.createChainSwap], {
     from: 'cBTC',
     to: 'BTC',
     claimAddress,
     userLockAmount,
+    chainId: citreaChainId,
   })
 
   // Ensure wallet is on Citrea before signing the lockup transaction
-  const citreaChainId = trade.inputAmount.currency.chainId as UniverseChainId
   yield* call(ensureCorrectChain, {
     targetChainId: citreaChainId,
     selectChain,

--- a/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
+++ b/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
@@ -35,7 +35,7 @@ const JUSD_CITREA_MAINNET = ADDRESS[4114]!.juiceDollar
 const JUSD_CITREA_TESTNET = ADDRESS[5115]!.juiceDollar
 
 // Swap contract addresses (same contract handles multiple tokens on each chain)
-const SWAP_CONTRACTS = {
+export const SWAP_CONTRACTS = {
   ethereum: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
   polygon: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
   citreaMainnet: '0x7397f25f230f7d5a83c18e1b68b32511bf35f860',
@@ -210,6 +210,7 @@ export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
     to,
     claimAddress: account.address,
     userLockAmount,
+    chainId: citreaChainId,
   }
 
   let chainSwap

--- a/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
@@ -3,6 +3,7 @@ import { popupRegistry } from 'components/Popups/registry'
 import { LdsBridgeStatus, PopupType } from 'components/Popups/types'
 import { call } from 'typed-redux-saga'
 import { LightningBridgeDirection } from 'uniswap/src/data/tradingApi/types'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { LdsSwapStatus, btcToSat, getLdsBridgeManager } from 'uniswap/src/features/lds-bridge'
 import { LightningBridgeReverseStep } from 'uniswap/src/features/transactions/swap/steps/lightningBridge'
 import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
@@ -24,11 +25,13 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
 
   const invoiceAmount = Number(btcToSat(new BigNumber(trade.inputAmount.toExact())))
   const claimAddress = account.address
+  const citreaChainId = trade.outputAmount.currency.chainId as UniverseChainId
 
   const ldsBridge = getLdsBridgeManager()
   const reverseSwap = yield* call([ldsBridge, ldsBridge.createReverseSwap], {
     invoiceAmount,
     claimAddress,
+    chainId: citreaChainId,
   })
 
   step.invoice = reverseSwap.invoice as string

--- a/apps/web/src/state/sagas/transactions/lightningBridgeSubmarine.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeSubmarine.ts
@@ -44,12 +44,13 @@ export function* handleLightningBridgeSubmarine(params: HandleLightningBridgeSub
   } = invoiceResponse
 
   const ldsBridge = getLdsBridgeManager()
+  const citreaChainId = trade.inputAmount.currency.chainId as UniverseChainId
   const submarineSwap = yield* call([ldsBridge, ldsBridge.createSubmarineSwap], {
     invoice,
+    chainId: citreaChainId,
   })
 
   // Ensure wallet is on Citrea before signing the lockup transaction
-  const citreaChainId = trade.inputAmount.currency.chainId as UniverseChainId
   yield* call(ensureCorrectChain, {
     targetChainId: citreaChainId,
     selectChain,

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from '@ethersproject/random'
 import { crypto } from 'bitcoinjs-lib'
 import { Buffer } from 'buffer'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import {
   createChainSwap,
   createReverseSwap,
@@ -72,14 +73,18 @@ class LdsBridgeManager extends SwapEventEmitter {
     return this.chainPairs
   }
 
-  createReverseSwap = async (params: { invoiceAmount: number; claimAddress: string }): Promise<ReverseSwap> => {
+  createReverseSwap = async (params: {
+    invoiceAmount: number
+    claimAddress: string
+    chainId?: UniverseChainId
+  }): Promise<ReverseSwap> => {
     const reversePairs = await this.getReversePairs()
     const pairHash = reversePairs.BTC?.cBTC?.hash
     if (!pairHash) {
       throw new Error('Pair hash not found')
     }
 
-    const { invoiceAmount, claimAddress } = params
+    const { invoiceAmount, claimAddress, chainId } = params
     const { preimageHash, preimage, keyIndex, mnemonic } = generateChainSwapKeys()
 
     const reverseInvoiceResponse = await createReverseSwap({
@@ -106,6 +111,7 @@ class LdsBridgeManager extends SwapEventEmitter {
       claimPrivateKeyIndex: keyIndex,
       mnemonic,
       keyIndex,
+      chainId,
       ...reverseInvoiceResponse,
     }
 
@@ -127,13 +133,13 @@ class LdsBridgeManager extends SwapEventEmitter {
     return reverseSwap
   }
 
-  createSubmarineSwap = async (params: { invoice: string }): Promise<SubmarineSwap> => {
+  createSubmarineSwap = async (params: { invoice: string; chainId?: UniverseChainId }): Promise<SubmarineSwap> => {
     const submarinePairs = await this.getSubmarinePairs()
     const pairHash = submarinePairs.cBTC?.BTC?.hash
     if (!pairHash) {
       throw new Error('Pair hash not found')
     }
-    const { invoice } = params
+    const { invoice, chainId } = params
     const { preimageHash, claimPublicKey, preimage, keyIndex, mnemonic } = generateChainSwapKeys()
     const lockupResponse = await createSubmarineSwap({
       from: 'cBTC',
@@ -158,6 +164,7 @@ class LdsBridgeManager extends SwapEventEmitter {
       refundPrivateKeyIndex: keyIndex,
       mnemonic,
       keyIndex,
+      chainId,
       ...lockupResponse,
     }
 
@@ -173,6 +180,7 @@ class LdsBridgeManager extends SwapEventEmitter {
     to: string
     claimAddress: string
     userLockAmount: number
+    chainId?: UniverseChainId
   }): Promise<ChainSwap> => {
     const chainPairs = await this.getChainPairs()
     const pairHash = chainPairs[params.from]?.[params.to]?.hash
@@ -180,7 +188,7 @@ class LdsBridgeManager extends SwapEventEmitter {
       throw new Error('Pair hash not found')
     }
 
-    const { from, to, claimAddress, userLockAmount } = params
+    const { from, to, claimAddress, userLockAmount, chainId } = params
     const {
       preimageHash: preimageHashFromKey,
       claimPublicKey: publicKey,
@@ -223,6 +231,7 @@ class LdsBridgeManager extends SwapEventEmitter {
       refundPrivateKeyIndex: keyIndex,
       mnemonic,
       keyIndex,
+      chainId,
       ...chainSwapResponse,
     }
 

--- a/packages/uniswap/src/features/lds-bridge/lds-types/storage.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/storage.ts
@@ -1,6 +1,7 @@
 import type { LightningBridgeSubmarineLockResponse } from 'uniswap/src/features/lds-bridge/lds-types/api'
 import { CreateChainSwapResponse, CreateReverseSwapResponse } from 'uniswap/src/features/lds-bridge/lds-types/api'
 import type { LdsSwapStatus } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
+import type { UniverseChainId } from 'uniswap/src/features/chains/types'
 
 export enum SwapType {
   Submarine = 'submarine',
@@ -20,6 +21,7 @@ export type SwapBase = {
   preimageHash: string
   mnemonic: string
   keyIndex: number
+  chainId?: UniverseChainId
   // Not set for submarine swaps; but set for interface compatibility
   claimTx?: string
 


### PR DESCRIPTION
## Summary
Bridge swaps in the Activity drawer are now scoped by network. When toggling Testnet/Mainnet, only bridge transactions for the selected network are shown, matching swap history behavior.

## Changes
- **Storage**: Optional `chainId` on LDS swap types; stored when creating chain/reverse/submarine swaps.
- **Sagas**: All bridge flows (ERC20, Bitcoin Citrea↔BTC, Lightning reverse/submarine) pass Citrea `chainId` into LDS when creating swaps.
- **Activity**: `useAllActivities` filters bridge activities with `keepActivitiesForChains(activityMap, chains)` so the list respects the current network.
- **Legacy ERC20**: Old swaps without `chainId` get it from contract addresses via `inferChainIdFromSwap` (uses `SWAP_CONTRACTS` from erc20ChainSwap so addresses stay in sync).

## Testing

- [x] Create bridge swaps on testnet and mainnet; switch network and confirm only the matching bridge items appear in the Activity tab.