### PR TITLE
feat: add bridge claim notifications and improve swap flow

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
@@ -13,7 +13,7 @@ import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import { useLocalizationContext } from 'uniswap/src/features/language/LocalizationContext'
 import { getLdsBridgeManager } from 'uniswap/src/features/lds-bridge/LdsBridgeManager'
 import { SomeSwap } from 'uniswap/src/features/lds-bridge/lds-types/storage'
-import { swapStatusFinal } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
+import { LdsSwapStatus, swapStatusFinal } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
 import { TransactionStatus } from 'uniswap/src/features/transactions/types/transactionDetails'
 import { logger } from 'utilities/src/logger/logger'
 
@@ -170,6 +170,10 @@ export function useOpenLimitOrders(account: string) {
   }
 }
 
+const statusNonFinalSwaps = (swap: SomeSwap) => swap.status && !swapStatusFinal.includes(swap.status)
+const swapsFinalNonClaimed = (swap: SomeSwap) =>
+  !swap.claimTx && swap.status === LdsSwapStatus.TransactionServerConfirmed
+
 export function usePendingBridgeActivities(): { bridgeSwaps: SomeSwap[]; loading: boolean } {
   const [bridgeSwaps, setBridgeSwaps] = useState<SomeSwap[]>([])
   const [loading, setLoading] = useState(true)
@@ -181,9 +185,8 @@ export function usePendingBridgeActivities(): { bridgeSwaps: SomeSwap[]; loading
       try {
         await ldsBridgeManager.suscribeAllPendingSwaps()
         const swaps = await ldsBridgeManager.getSwaps()
-        const pendingSwaps = Object.values(swaps).filter(
-          (swap) => swap.status && !swapStatusFinal.includes(swap.status),
-        )
+        const pendingSwaps = Object.values(swaps).filter(statusNonFinalSwaps).filter(swapsFinalNonClaimed)
+
         setBridgeSwaps(pendingSwaps)
         setLoading(false)
       } catch (error) {
@@ -193,7 +196,7 @@ export function usePendingBridgeActivities(): { bridgeSwaps: SomeSwap[]; loading
     }
 
     const handleSwapChange = (swaps: Record<string, SomeSwap>): void => {
-      const pendingSwaps = Object.values(swaps).filter((swap) => swap.status && !swapStatusFinal.includes(swap.status))
+      const pendingSwaps = Object.values(swaps).filter(statusNonFinalSwaps).filter(swapsFinalNonClaimed)
       setBridgeSwaps(pendingSwaps)
     }
 

--- a/apps/web/src/components/Popups/PopupItem.tsx
+++ b/apps/web/src/components/Popups/PopupItem.tsx
@@ -1,6 +1,9 @@
 import { MismatchToastItem } from 'components/Popups/MismatchToastItem'
 import {
   BitcoinBridgePopupContent,
+  ClaimCompletedPopupContent,
+  ClaimInProgressPopupContent,
+  Erc20ChainSwapPopupContent,
   FORTransactionPopupContent,
   FailedNetworkSwitchPopup,
   LightningBridgePopupContent,
@@ -85,6 +88,19 @@ export function PopupItem({ content, onClose }: { content: PopupContent; popKey:
     case PopupType.BitcoinBridge: {
       return <BitcoinBridgePopupContent direction={content.direction} status={content.status} onClose={onClose} />
     }
+    case PopupType.Erc20ChainSwap: {
+      return (
+        <Erc20ChainSwapPopupContent
+          fromChainId={content.fromChainId}
+          toChainId={content.toChainId}
+          fromAsset={content.fromAsset}
+          toAsset={content.toAsset}
+          status={content.status}
+          url={content.url}
+          onClose={onClose}
+        />
+      )
+    }
     case PopupType.RefundableSwaps: {
       return <RefundableSwapsPopupContent count={content.count} onClose={onClose} />
     }
@@ -93,6 +109,12 @@ export function PopupItem({ content, onClose }: { content: PopupContent; popKey:
     }
     case PopupType.RefundsCompleted: {
       return <RefundsCompletedPopupContent count={content.count} onClose={onClose} />
+    }
+    case PopupType.ClaimInProgress: {
+      return <ClaimInProgressPopupContent count={content.count} onClose={onClose} />
+    }
+    case PopupType.ClaimCompleted: {
+      return <ClaimCompletedPopupContent count={content.count} onClose={onClose} />
     }
     default:
       return null

--- a/apps/web/src/components/Popups/types.ts
+++ b/apps/web/src/components/Popups/types.ts
@@ -13,9 +13,12 @@ export enum PopupType {
   CampaignTaskCompleted = 'campaignTaskCompleted',
   LightningBridge = 'lightningBridge',
   BitcoinBridge = 'bitcoinBridge',
+  Erc20ChainSwap = 'erc20ChainSwap',
   RefundableSwaps = 'refundableSwaps',
   RefundsInProgress = 'refundsInProgress',
   RefundsCompleted = 'refundsCompleted',
+  ClaimInProgress = 'claimInProgress',
+  ClaimCompleted = 'claimCompleted',
 }
 
 export enum SwitchNetworkAction {
@@ -93,6 +96,16 @@ export type PopupContent =
       direction: BitcoinBridgeDirection
     }
   | {
+      type: PopupType.Erc20ChainSwap
+      id: string
+      status: LdsBridgeStatus
+      fromChainId: UniverseChainId
+      toChainId: UniverseChainId
+      fromAsset: string
+      toAsset: string
+      url?: string
+    }
+  | {
       type: PopupType.RefundableSwaps
       count: number
     }
@@ -102,5 +115,13 @@ export type PopupContent =
     }
   | {
       type: PopupType.RefundsCompleted
+      count: number
+    }
+  | {
+      type: PopupType.ClaimInProgress
+      count: number
+    }
+  | {
+      type: PopupType.ClaimCompleted
       count: number
     }

--- a/apps/web/src/state/sagas/root.ts
+++ b/apps/web/src/state/sagas/root.ts
@@ -1,5 +1,6 @@
 import { liquiditySaga } from 'state/sagas/liquidity/liquiditySaga'
 import { lpIncentivesClaimSaga } from 'state/sagas/lp_incentives/lpIncentivesSaga'
+import { watchClaimableSwaps } from 'state/sagas/transactions/bridgeClaimSaga'
 import { watchRefundSwap } from 'state/sagas/transactions/bridgeRefundSaga'
 import { bridgeResumeSaga } from 'state/sagas/transactions/bridgeResumeSaga'
 import { swapSaga } from 'state/sagas/transactions/swapSaga'
@@ -26,6 +27,9 @@ export function* rootWebSaga() {
 
   // Watch for refund actions
   yield* spawn(watchRefundSwap)
+
+  // Watch for claimable swaps
+  yield* spawn(watchClaimableSwaps)
 
   // Check and resume any pending bridges from previous session
   yield* call(bridgeResumeSaga)

--- a/apps/web/src/state/sagas/transactions/bridgeClaimSaga.ts
+++ b/apps/web/src/state/sagas/transactions/bridgeClaimSaga.ts
@@ -1,0 +1,138 @@
+import { popupRegistry } from 'components/Popups/registry'
+import { LdsBridgeStatus, PopupType } from 'components/Popups/types'
+import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
+import { call, delay, spawn } from 'typed-redux-saga'
+import { BitcoinBridgeDirection } from 'uniswap/src/data/tradingApi/types'
+import { getLdsBridgeManager } from 'uniswap/src/features/lds-bridge'
+import { ASSET_CHAIN_ID_MAP } from 'uniswap/src/features/lds-bridge/LdsBridgeManager'
+import { SomeSwap, SwapType } from 'uniswap/src/features/lds-bridge/lds-types/storage'
+import { LdsSwapStatus } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
+import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
+
+const POLLING_INTERVAL = 30000 // 30 seconds
+
+function* attemptClaimSwap(swap: SomeSwap) {
+  const { id: swapId } = swap
+
+  popupRegistry.addPopup(
+    {
+      type: PopupType.ClaimInProgress,
+      count: 1,
+    },
+    `claim-in-progress-${swapId}`,
+    DEFAULT_TXN_DISMISS_MS,
+  )
+
+  try {
+    const ldsBridgeManager = getLdsBridgeManager()
+    const claimedSwap = yield* call([ldsBridgeManager, ldsBridgeManager.autoClaimSwap], swapId)
+
+    popupRegistry.removePopup(`claim-in-progress-${swapId}`)
+
+    if (claimedSwap.claimTx) {
+      // Use Erc20ChainSwap notification for all Chain swaps
+      if (swap.type === SwapType.Chain) {
+        const fromChainId = ASSET_CHAIN_ID_MAP[swap.assetSend]
+        const toChainId = ASSET_CHAIN_ID_MAP[swap.assetReceive]
+
+        const explorerUrl = getExplorerLink({
+          chainId: toChainId,
+          data: claimedSwap.claimTx,
+          type: ExplorerDataType.TRANSACTION,
+        })
+
+        popupRegistry.addPopup(
+          {
+            type: PopupType.Erc20ChainSwap,
+            id: claimedSwap.claimTx,
+            fromChainId,
+            toChainId,
+            fromAsset: swap.assetSend,
+            toAsset: swap.assetReceive,
+            status: LdsBridgeStatus.Confirmed,
+            url: explorerUrl,
+          },
+          claimedSwap.claimTx,
+        )
+      } else {
+        // Reverse swap notification (traditional Bitcoin bridge)
+        popupRegistry.addPopup(
+          {
+            type: PopupType.ClaimCompleted,
+            count: 1,
+          },
+          `claim-completed-${swapId}`,
+          DEFAULT_TXN_DISMISS_MS,
+        )
+
+        const direction =
+          swap.assetReceive === 'cBTC' ? BitcoinBridgeDirection.BitcoinToCitrea : BitcoinBridgeDirection.CitreaToBitcoin
+
+        popupRegistry.addPopup(
+          {
+            type: PopupType.BitcoinBridge,
+            id: claimedSwap.claimTx,
+            status: LdsBridgeStatus.Confirmed,
+            direction,
+          },
+          claimedSwap.claimTx,
+        )
+      }
+    }
+  } catch (error) {
+    popupRegistry.removePopup(`claim-in-progress-${swapId}`)
+    // eslint-disable-next-line no-console
+    console.error(`Failed to claim swap ${swapId}:`, error)
+  }
+}
+
+function isSwapReadyForClaim(swap: SomeSwap): boolean {
+  // Only chain swaps and reverse swaps can be claimed
+  if (swap.type !== SwapType.Chain && swap.type !== SwapType.Reverse) {
+    return false
+  }
+
+  // Must have TransactionServerConfirmed status
+  if (swap.status !== LdsSwapStatus.TransactionServerConfirmed) {
+    return false
+  }
+
+  // Must not already be claimed
+  if (swap.claimTx) {
+    return false
+  }
+
+  return true
+}
+
+function* pollForClaimableSwaps() {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const ldsBridgeManager = getLdsBridgeManager()
+      const swaps = yield* call([ldsBridgeManager, ldsBridgeManager.getSwaps])
+
+      const claimableSwaps = Object.values(swaps).filter(isSwapReadyForClaim)
+
+      if (claimableSwaps.length > 0) {
+        // eslint-disable-next-line no-console
+        console.log(`Found ${claimableSwaps.length} swap(s) ready for claim`)
+
+        // Attempt to claim each swap sequentially
+        for (const swap of claimableSwaps) {
+          yield* call(attemptClaimSwap, swap)
+        }
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Error polling for claimable swaps:', error)
+    }
+
+    // Wait before next poll
+    yield* delay(POLLING_INTERVAL)
+  }
+}
+
+export function* watchClaimableSwaps() {
+  yield* spawn(pollForClaimableSwaps)
+}

--- a/apps/web/src/state/sagas/transactions/lightningBridgeSubmarine.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeSubmarine.ts
@@ -13,6 +13,7 @@ import {
   getLdsBridgeManager,
   pollForClaimablePreimage,
 } from 'uniswap/src/features/lds-bridge'
+import { ASSET_CHAIN_ID_MAP } from 'uniswap/src/features/lds-bridge/LdsBridgeManager'
 import { LightningBridgeSubmarineStep } from 'uniswap/src/features/transactions/swap/steps/lightningBridge'
 import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
 import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
@@ -87,7 +88,8 @@ export function* handleLightningBridgeSubmarine(params: HandleLightningBridgeSub
     yield* call(onSuccess)
   }
 
-  yield* call(pollForClaimablePreimage, preimageHash)
+  const chainId = ASSET_CHAIN_ID_MAP[submarineSwap.assetReceive]
+  yield* call(pollForClaimablePreimage, preimageHash, chainId)
 
   popupRegistry.addPopup(
     {

--- a/packages/uniswap/src/features/lds-bridge/api/client.ts
+++ b/packages/uniswap/src/features/lds-bridge/api/client.ts
@@ -78,12 +78,12 @@ export async function registerPreimage(params: RegisterPreimageRequest): Promise
   })
 }
 
-export async function getLockup(preimageHash: string): Promise<{ data: LockupCheckResponse }> {
+export async function getLockup(preimageHash: string, chainId: number): Promise<{ data: LockupCheckResponse }> {
   return await LdsApiClient.post<{ data: LockupCheckResponse }>(`/claim/graphql`, {
     body: JSON.stringify({
       operationName: 'LockupQuery',
       query: `query LockupQuery {
-          lockups(preimageHash: "0x${preimageHash}") {
+          lockups(id: "${chainId}:0x${preimageHash}") {
             amount
             claimAddress
             claimTxHash

--- a/packages/uniswap/src/features/lds-bridge/transactions/evm.ts
+++ b/packages/uniswap/src/features/lds-bridge/transactions/evm.ts
@@ -76,6 +76,18 @@ export async function buildErc20LockupTx(params: {
       currentAllowance: currentAllowance.toString(),
       requiredAmount: amount.toString(),
     })
+
+    // For USDT and similar tokens: reset allowance to 0 first if there's a non-zero allowance
+    // This prevents "execution reverted" errors on tokens that don't allow changing non-zero allowances
+    if (!currentAllowance.isZero()) {
+      // eslint-disable-next-line no-console
+      console.log('[ERC20 Lock] Resetting existing allowance to 0 (required for USDT and similar tokens)')
+      const resetTx = await tokenContract.approve(contractAddress, 0)
+      await resetTx.wait()
+      // eslint-disable-next-line no-console
+      console.log('[ERC20 Lock] Allowance reset confirmed')
+    }
+
     const approveTx = await tokenContract.approve(contractAddress, amount)
     await approveTx.wait()
     // eslint-disable-next-line no-console

--- a/packages/uniswap/src/features/lds-bridge/utils/polling.ts
+++ b/packages/uniswap/src/features/lds-bridge/utils/polling.ts
@@ -1,13 +1,13 @@
 import { getLockup } from 'uniswap/src/features/lds-bridge/api/client'
 import { RetryableError, retry } from 'uniswap/src/features/lds-bridge/utils/retry'
 
-export function pollForLockupConfirmation(preimageHash: string): {
+export function pollForLockupConfirmation(preimageHash: string, chainId: number): {
   promise: Promise<NonNullable<Awaited<ReturnType<typeof getLockup>>['data']['lockups']>>
   cancel: () => void
 } {
   return retry(
     async () => {
-      const response = await getLockup(preimageHash)
+      const response = await getLockup(preimageHash, chainId)
 
       if (!response.data.lockups) {
         throw new RetryableError('Lockup not found yet, retrying...')
@@ -24,13 +24,13 @@ export function pollForLockupConfirmation(preimageHash: string): {
   )
 }
 
-export function pollForClaimablePreimage(preimageHash: string): {
+export function pollForClaimablePreimage(preimageHash: string, chainId: number): {
   promise: Promise<NonNullable<NonNullable<Awaited<ReturnType<typeof getLockup>>['data']['lockups']>['preimage']>>
   cancel: () => void
 } {
   return retry(
     async () => {
-      const response = await getLockup(preimageHash)
+      const response = await getLockup(preimageHash, chainId)
 
       if (!response.data.lockups || !response.data.lockups.preimage) {
         throw new RetryableError('Claim not found yet, retrying...')


### PR DESCRIPTION
## Summary

- Adds comprehensive notification system for bridge claim operations
- Implements visual feedback for ERC20 chain swaps with split logo component
- Improves pending bridge activities filtering to include final but unclaimed swaps
- Adds dedicated saga for automatic claim polling
- Fixes USDT approval flow by resetting allowance before new approval

## Changes

### New Features
- **ERC20 Chain Swap Notifications**: New popup content with split token logos showing cross-chain swaps
- **Claim Progress Indicators**: "Claim in Progress" and "Claim Completed" popup notifications
- **Split Logo Component**: Visual representation of cross-chain token swaps with dual token/network display
- **Bridge Claim Saga**: Dedicated saga that polls for claimable swaps every 30 seconds and auto-claims them
- **ASSET_CHAIN_ID_MAP**: Centralized mapping for consistent chain ID resolution across bridge operations

### Improvements
- Pending bridge activities now correctly filter for both non-final swaps and final unclaimed swaps
- LdsBridgeManager notifies swap changes after claim transaction completion
- API client and polling utilities updated to use chainId parameter for more accurate lockup queries
- Popup content shows appropriate notifications based on swap type (Chain vs Reverse)

### Bug Fixes
- USDT approval flow now resets existing allowance to 0 before setting new allowance (prevents "execution reverted" errors)

## Test Plan

- [ ] Verify ERC20 chain swap notifications appear with correct token logos
- [ ] Confirm "Claim in Progress" popup displays during claim operations
- [ ] Test claim success popup shows with correct explorer link
- [ ] Validate pending bridge activities filter includes unclaimed swaps
- [ ] Test USDT approval flow on mainnet/testnet
- [ ] Verify automatic claim polling triggers for eligible swaps
- [ ] Check that notifications display correctly for both Chain and Reverse swaps