### PR TITLE
feat(bitcoin-bridge): add explorer links to popups and improve claim flow

### DIFF
--- a/apps/web/src/components/Popups/PopupContent.tsx
+++ b/apps/web/src/components/Popups/PopupContent.tsx
@@ -353,10 +353,12 @@ export function LightningBridgePopupContent({
 export function BitcoinBridgePopupContent({
   direction,
   status,
+  url,
   onClose,
 }: {
   direction: BitcoinBridgeDirection
   status: LdsBridgeStatus
+  url?: string
   onClose: () => void
 }) {
   const { t } = useTranslation()
@@ -399,8 +401,12 @@ export function BitcoinBridgePopupContent({
 
   const isPending = status === LdsBridgeStatus.Pending
 
-  const onClick = () => {
-    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+  const handlePress = () => {
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } else {
+      window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+    }
     onClose()
   }
 
@@ -416,12 +422,13 @@ export function BitcoinBridgePopupContent({
       py={2}
       px={0}
       animation="300ms"
+      cursor="pointer"
       $sm={{
         mx: 'auto',
         width: '100%',
       }}
     >
-      <TouchableArea onPress={onClick} flex={1}>
+      <TouchableArea onPress={handlePress} flex={1}>
         <Flex row gap="$gap12" height={68} py="$spacing12" px="$spacing16">
           <Flex justifyContent="center">
             <PortfolioLogo chainId={UniverseChainId.Mainnet} images={[bitcoinLogo]} size={32} />

--- a/apps/web/src/components/Popups/PopupItem.tsx
+++ b/apps/web/src/components/Popups/PopupItem.tsx
@@ -86,7 +86,14 @@ export function PopupItem({ content, onClose }: { content: PopupContent; popKey:
       return <LightningBridgePopupContent direction={content.direction} status={content.status} onClose={onClose} />
     }
     case PopupType.BitcoinBridge: {
-      return <BitcoinBridgePopupContent direction={content.direction} status={content.status} onClose={onClose} />
+      return (
+        <BitcoinBridgePopupContent
+          direction={content.direction}
+          status={content.status}
+          url={content.url}
+          onClose={onClose}
+        />
+      )
     }
     case PopupType.Erc20ChainSwap: {
       return (

--- a/apps/web/src/components/Popups/types.ts
+++ b/apps/web/src/components/Popups/types.ts
@@ -94,6 +94,7 @@ export type PopupContent =
       id: string
       status: LdsBridgeStatus
       direction: BitcoinBridgeDirection
+      url?: string
     }
   | {
       type: PopupType.Erc20ChainSwap

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
@@ -48,6 +48,7 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
       id: chainSwapResponse.id,
       status: LdsBridgeStatus.Pending,
       direction: BitcoinBridgeDirection.BitcoinToCitrea,
+      url: '/bridge-swaps',
     },
     chainSwapResponse.id,
   )
@@ -61,6 +62,7 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
       id: txHash!,
       status: LdsBridgeStatus.Confirmed,
       direction: BitcoinBridgeDirection.BitcoinToCitrea,
+      url: '/bridge-swaps',
     },
     txHash!,
   )

--- a/apps/web/src/state/sagas/transactions/bridgeClaimSaga.ts
+++ b/apps/web/src/state/sagas/transactions/bridgeClaimSaga.ts
@@ -74,6 +74,7 @@ function* attemptClaimSwap(swap: SomeSwap) {
             id: claimedSwap.claimTx,
             status: LdsBridgeStatus.Confirmed,
             direction,
+            url: '/bridge-swaps',
           },
           claimedSwap.claimTx,
         )

--- a/apps/web/src/state/sagas/transactions/bridgeRefundSaga.ts
+++ b/apps/web/src/state/sagas/transactions/bridgeRefundSaga.ts
@@ -93,6 +93,7 @@ function* refundSwapSaga(action: RefundSwapAction) {
         id: txId,
         status: LdsBridgeStatus.Confirmed,
         direction: BitcoinBridgeDirection.CitreaToBitcoin,
+        url: '/bridge-swaps',
       },
       txId,
     )

--- a/apps/web/src/state/sagas/transactions/bridgeResumeSaga.ts
+++ b/apps/web/src/state/sagas/transactions/bridgeResumeSaga.ts
@@ -14,6 +14,7 @@ const claimAndNotify = async (swapId: string) => {
       id: claimTx!,
       status: LdsBridgeStatus.Confirmed,
       direction: BitcoinBridgeDirection.BitcoinToCitrea,
+      url: '/bridge-swaps',
     },
     claimTx!,
   )

--- a/packages/uniswap/src/features/chains/nonEvm/bitcoin.ts
+++ b/packages/uniswap/src/features/chains/nonEvm/bitcoin.ts
@@ -40,8 +40,8 @@ const citreaTestnet = defineChain({
   },
   blockExplorers: {
     default: {
-      name: 'No Explorer',
-      url: 'https://no-explorer.com/',
+      name: 'Mempool.Space',
+      url: 'https://mempool.space/',
     },
   },
   contracts: {},
@@ -63,8 +63,8 @@ export const BITCOIN_CHAIN_INFO = {
   docs: 'https://no-docs.com/',
   elementName: ElementName.DocsLink,
   explorer: {
-    name: 'No Explorer',
-    url: 'https://no-explorer.com/',
+    name: 'Mempool.Space',
+    url: 'https://mempool.space/',
   },
   interfaceName: 'bitcoin',
   label: 'Bitcoin Network',

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -246,15 +246,17 @@ class LdsBridgeManager extends SwapEventEmitter {
     }
 
     await this.storageManager.setSwap(chainSwapResponse.id, chainSwap)
-    // Register preimage with ponder_claim for automatic claiming
-    registerPreimage({
-      preimageHash: chainSwap.preimageHash,
-      preimage: chainSwap.preimage,
-      swapId: chainSwapResponse.id,
-    }).catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error('Failed to register preimage:', error)
-    })
+
+    if (params.to !== 'BTC') {
+      registerPreimage({
+        preimageHash: chainSwap.preimageHash,
+        preimage: chainSwap.preimage,
+        swapId: chainSwapResponse.id,
+      }).catch((error) => {
+        // eslint-disable-next-line no-console
+        console.error('Failed to register preimage:', error)
+      })
+    }
 
     this._subscribeToSwapUpdates(chainSwapResponse.id)
     await this.waitForSwapUntilState(chainSwapResponse.id, LdsSwapStatus.SwapCreated)

--- a/packages/uniswap/src/features/lds-bridge/transactions/musig.ts
+++ b/packages/uniswap/src/features/lds-bridge/transactions/musig.ts
@@ -101,6 +101,7 @@ export const prepareRefundMusig = async (
  * @returns ClaimDetails object ready for transaction construction
  */
 export const buildClaimDetails = (params: {
+  cooperative: boolean
   tweakedKey: Buffer
   lockupTx: Transaction
   swapTree: ReturnType<typeof SwapTreeSerializer.deserializeSwapTree>
@@ -108,12 +109,12 @@ export const buildClaimDetails = (params: {
   musig: Musig
   preimage: Buffer
 }): ClaimDetails => {
-  const { tweakedKey, lockupTx, swapTree, claimKeyPair, musig, preimage } = params
+  const { cooperative, tweakedKey, lockupTx, swapTree, claimKeyPair, musig, preimage } = params
   const swapOutput = detectSwap(tweakedKey, lockupTx as unknown as Transaction)
 
   return {
     ...swapOutput,
-    cooperative: true,
+    cooperative,
     swapTree,
     keys: claimKeyPair,
     type: OutputType.Taproot,


### PR DESCRIPTION
## Summary
- Add optional URL prop to Bitcoin bridge popups for linking to block explorers
- Update Bitcoin chain info to use Mempool.Space explorer instead of placeholder
- Improve Citrea to Bitcoin bridge flow with proper explorer URL generation
- Switch to non-cooperative claims (cooperative claims temporarily disabled pending LDS zero conf support)
- Only register preimage with ponder_claim when destination is not BTC
- Add cooperative boolean parameter to musig claim details for better control

## Test plan
- [ ] Test Bitcoin to Citrea bridge flow and verify popup shows correct explorer link
- [ ] Test Citrea to Bitcoin bridge flow and verify non-cooperative claim works
- [ ] Verify popup URLs open correct explorer pages
- [ ] Verify claim/refund/resume flows all display proper notifications