### PR TITLE
fix(web): skip wagmi block number polling for non-EVM chains

### DIFF
--- a/apps/web/src/lib/hooks/useBlockNumber.tsx
+++ b/apps/web/src/lib/hooks/useBlockNumber.tsx
@@ -6,8 +6,8 @@ import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { atom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
 import { PropsWithChildren, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { ALL_EVM_CHAIN_IDS } from 'uniswap/src/features/chains/chainInfo'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { isEVMChain } from 'uniswap/src/features/platforms/utils/chains'
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { useBlockNumber as useWagmiBlockNumber } from 'wagmi'
 
@@ -69,9 +69,8 @@ export function BlockNumberProvider({ children }: PropsWithChildren) {
   // Use wagmi's useBlockNumber which properly polls via viem's transport
   // Only use wagmi for EVM chains - non-EVM chains (like Lightning Network) are not supported
   const windowVisible = useIsWindowVisible()
-  const isEvmChain = multicallChainId !== undefined && ALL_EVM_CHAIN_IDS.includes(multicallChainId)
   const { data: wagmiBlockNumber } = useWagmiBlockNumber({
-    chainId: isEvmChain ? (multicallChainId as number) : undefined,
+    chainId: multicallChainId && isEVMChain(multicallChainId) ? multicallChainId : undefined,
     watch: windowVisible,
   })
   // Update state when wagmi's block number changes

--- a/packages/uniswap/src/features/platforms/utils/chains.ts
+++ b/packages/uniswap/src/features/platforms/utils/chains.ts
@@ -6,10 +6,9 @@ export function chainIdToPlatform(chainId: UniverseChainId): Platform {
   return getChainInfo(chainId).platform
 }
 
-function createPlatformChecker<T extends Platform>(_platform: T) {
+function createPlatformChecker<T extends Platform>(platform: T) {
   return (chainId: UniverseChainId): chainId is UniverseChainIdByPlatform<T> => {
-    // All chains are now Platform.EVM, so this always returns true for EVM
-    return true
+    return getChainInfo(chainId).platform === platform
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix crash when navigating to swap page with non-EVM chain tokens (e.g., `/swap?inputCurrency=lnBTC&outputCurrency=cBTC`)
- Fix broken `isEVMChain` utility that always returned `true` (was checking nothing)
- Use the fixed utility in `BlockNumberProvider` for cleaner, more maintainable code

## Problem

The swap page was showing a blank/white screen when accessing URLs with Lightning Network tokens. The `BlockNumberProvider` was crashing because wagmi's `useBlockNumber` hook only supports EVM chains configured in the wagmi config, but Lightning Network is a non-EVM chain (`Platform.NonEvm`).

Additionally, the existing `isEVMChain` utility function was broken - it always returned `true` regardless of the actual chain platform, due to an outdated comment stating "All chains are now Platform.EVM".

## Solution

1. **Fixed `isEVMChain` utility** in `packages/uniswap/src/features/platforms/utils/chains.ts`:
   ```typescript
   // Before (broken - always returns true)
   function createPlatformChecker<T extends Platform>(_platform: T) {
     return (chainId: UniverseChainId): chainId is UniverseChainIdByPlatform<T> => {
       return true  // Bug: checks nothing!
     }
   }

   // After (fixed - actually checks the platform)
   function createPlatformChecker<T extends Platform>(platform: T) {
     return (chainId: UniverseChainId): chainId is UniverseChainIdByPlatform<T> => {
       return getChainInfo(chainId).platform === platform
     }
   }
   ```

2. **Used the utility** in `BlockNumberProvider` instead of inline array check:
   ```typescript
   // Before
   const isEvmChain = multicallChainId !== undefined && ALL_EVM_CHAIN_IDS.includes(multicallChainId)

   // After
   multicallChainId && isEVMChain(multicallChainId) ? multicallChainId : undefined
   ```

## Test plan

- [x] Navigate to `http://localhost:3001/swap?inputCurrency=lnBTC&outputCurrency=cBTC`
- [x] Verify swap UI renders correctly with Lightning BTC and Citrea BTC tokens
- [x] No "Chain not configured" errors in console
- [x] Typecheck passes (`yarn g:typecheck`)
- [x] Lint passes (via pre-commit hook)