### PR TITLE
feat(launchpad): add volume and trades to token detail page

### DIFF
--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -204,12 +204,7 @@ export default function TokenDetail() {
   }, [launchpadData?.token.totalVolumeBase])
 
   // Total trades from indexed data
-  const totalTrades = useMemo(() => {
-    if (!launchpadData?.token) {
-      return 0
-    }
-    return launchpadData.token.totalBuys + launchpadData.token.totalSells
-  }, [launchpadData?.token])
+  const totalTrades = (launchpadData?.token.totalBuys ?? 0) + (launchpadData?.token.totalSells ?? 0)
 
   const tokensRemaining = useMemo(() => {
     if (!reserves) {


### PR DESCRIPTION
## Summary
- Add Volume (total trading volume in JUSD) to token detail page
- Add Trades (total number of buys + sells) to token detail page
- These metrics were previously only visible in the launchpad overview cards

## Test plan
- [ ] Navigate to `/launchpad` and note the Volume and Trades for a token
- [ ] Click on the token to open the detail page
- [ ] Verify Volume and Trades are now displayed in the Token Info card
- [ ] Verify the values match the overview card