### PR TITLE
fix(bridge): include chainId in helpMeClaim request

### DIFF
--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -369,6 +369,7 @@ class LdsBridgeManager extends SwapEventEmitter {
     const { txHash } = await helpMeClaim({
       preimage: swap.preimage,
       preimageHash: prefix0x(swap.preimageHash),
+      chainId
     })
 
     swap.claimTx = txHash

--- a/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
@@ -69,6 +69,7 @@ export interface LockupCheckResponse {
 export interface HelpMeClaimRequest {
   preimage: string
   preimageHash: string
+  chainId: number
 }
 
 export interface HelpMeClaimResponse {


### PR DESCRIPTION
## Summary
- Add `chainId` parameter to `HelpMeClaimRequest` interface
- Pass `chainId` when calling `helpMeClaim` in `LdsBridgeManager`

This ensures the claim operation targets the correct chain by providing the chainId context to the backend API.

## Test plan
- [ ] Verify bridge claims work correctly on different chains
- [ ] Confirm chainId is properly passed through the API request