### PR TITLE
fix: disable warning modal for non-default tokens

### DIFF
--- a/packages/uniswap/src/features/tokens/safetyUtils.ts
+++ b/packages/uniswap/src/features/tokens/safetyUtils.ts
@@ -190,7 +190,7 @@ export function getSeverityFromTokenProtectionWarning(tokenProtectionWarning: To
     case TokenProtectionWarning.FotLow:
       return WarningSeverity.Medium
     case TokenProtectionWarning.NonDefault:
-      return WarningSeverity.Low
+      return WarningSeverity.None
     case TokenProtectionWarning.None:
       return WarningSeverity.None
   }


### PR DESCRIPTION
## Summary
- Disabled the "Always do your research" warning modal for non-default tokens
- This warning was incorrectly appearing for well-known tokens like USDT during cross-chain swaps
- Real security warnings (honeypots, spam, high fees, impersonators) remain active

## Test plan
- [ ] Perform a cross-chain swap from Ethereum USDT to Citrea JUSD
- [ ] Verify no warning modal appears for USDT
- [ ] Verify warnings still appear for actual malicious/spam tokens