### PR TITLE
Fix submarine swap status showing "Claiming" after user received funds

### DIFF
--- a/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
+++ b/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
@@ -204,8 +204,19 @@ function getStatusInfo(swap: SomeSwap): {
         icon: <Clock size="$icon.16" color="$neutral1" />,
       }
 
-    // Claim is pending - swap nearly complete
+    // Claim is pending - behavior depends on swap type
     case LdsSwapStatus.TransactionClaimPending:
+      // Submarine Swaps (cBTC → Lightning): User has ALREADY received their Lightning payment
+      // when this status is reached. Boltz is just claiming their cBTC from the lockup contract.
+      // The user doesn't care about Boltz's internal settlement - their swap is complete!
+      if (swap.type === SwapType.Submarine) {
+        return {
+          label: 'Completed',
+          status: 'completed',
+          icon: <CheckCircleFilled size="$icon.16" color="$statusSuccess" />,
+        }
+      }
+      // Chain/Reverse Swaps: Claim is actually pending - user still needs to receive funds
       return {
         label: 'Claiming',
         status: 'pending',


### PR DESCRIPTION
## Summary

- Fix UX bug where submarine swaps showed "Claiming" (pending) after the user already received their Lightning payment
- Now correctly shows "Completed" (success) for submarine swaps with `transaction.claim.pending` status

## Problem

For submarine swaps (cBTC → Lightning):
1. User sends cBTC to lockup contract
2. Boltz pays the Lightning invoice → **User receives funds**
3. Status becomes `transaction.claim.pending`
4. UI showed "Claiming" (orange/pending) ← **Bug: User already has their sats!**
5. Boltz claims cBTC (batch job)
6. Status becomes `transaction.claimed`

## Solution

Check swap type in `getStatusInfo()`:
- **Submarine swaps** + `claim.pending` → Show "Completed" (user has Lightning payment)
- **Chain/Reverse swaps** + `claim.pending` → Show "Claiming" (user still needs to claim)

## Test plan

- [ ] Create a submarine swap (cBTC → Lightning)
- [ ] Verify status shows "Completed" once Lightning payment is received
- [ ] Verify chain swaps still show "Claiming" when appropriate