### PR TITLE
fix(launchpad): show clear error message for insufficient gas fees

### DIFF
--- a/apps/web/src/hooks/useTokenAllowance.ts
+++ b/apps/web/src/hooks/useTokenAllowance.ts
@@ -108,6 +108,10 @@ export function useUpdateTokenAllowance(
         throw error
       } else {
         const symbol = amount?.currency.symbol ?? 'Token'
+        const errorString = String(error)
+        if (errorString.includes('Not enough funds for L1 fee') || errorString.includes('insufficient funds for gas')) {
+          throw new Error('Insufficient cBTC for gas fees')
+        }
         throw new Error(`${symbol} token allowance failed: ${error instanceof Error ? error.message : error}`)
       }
     }

--- a/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
+++ b/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
@@ -503,8 +503,15 @@ export function BuySellPanel({
       queryClient.invalidateQueries({ queryKey: ['launchpad-token', tokenAddress] })
     } catch (err: unknown) {
       let message = err instanceof Error ? err.message : 'Transaction failed'
+      const errorString = String(err)
       // Parse common contract errors for better UX
-      if (message.includes('ERC20InsufficientBalance') || message.includes('insufficient balance')) {
+      if (
+        message.includes('Insufficient cBTC for gas') ||
+        errorString.includes('Not enough funds for L1 fee') ||
+        errorString.includes('insufficient funds for gas')
+      ) {
+        message = 'Insufficient cBTC for gas fees'
+      } else if (message.includes('ERC20InsufficientBalance') || message.includes('insufficient balance')) {
         message = isBuy ? 'Insufficient JUSD balance' : `Insufficient ${tokenSymbol} balance`
       } else if (message.includes('ERC20InsufficientAllowance') || message.includes('insufficient allowance')) {
         message = isBuy ? 'Please approve JUSD first' : `Please approve ${tokenSymbol} first`


### PR DESCRIPTION
## Summary

- Parse L1 fee errors in `useTokenAllowance` hook to detect insufficient gas
- Add gas error handling in `BuySellPanel` catch block
- Users now see "Insufficient cBTC for gas fees" instead of cryptic "An internal error was received"

## Test plan

- [ ] Connect wallet with 0 cBTC balance
- [ ] Go to /launchpad and try to buy any token
- [ ] Verify error message shows "Insufficient cBTC for gas fees"