### PR TITLE
feat(bridge): add WBTC <-> cBTC bridge support

### DIFF
--- a/apps/web/src/state/sagas/transactions/swapSaga.ts
+++ b/apps/web/src/state/sagas/transactions/swapSaga.ts
@@ -26,6 +26,7 @@ import {
   handlePermitTransactionStep,
   handleSignatureStep,
 } from 'state/sagas/transactions/utils'
+import { handleWbtcBridge } from 'state/sagas/transactions/wbtcBridge'
 import { VitalTxFields } from 'state/transactions/types'
 import invariant from 'tiny-invariant'
 import { call } from 'typed-redux-saga'
@@ -65,6 +66,7 @@ import {
   isErc20ChainSwap,
   isGatewayJusd,
   isLightningBridge,
+  isWbtcBridge,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { getClassicQuoteFromResponse } from 'uniswap/src/features/transactions/swap/utils/tradingApi'
 import { useWallet } from 'uniswap/src/features/wallet/hooks/useWallet'
@@ -230,9 +232,9 @@ async function handleSwitchChains(
 ): Promise<{ chainSwitchFailed: boolean }> {
   const { selectChain, startChainId, swapTxContext } = params
 
-  // For ERC20 chain swaps, skip chain switching here entirely
-  // The chain switch will be handled in erc20ChainSwap.ts with proper non-blocking logic
-  if (isErc20ChainSwap(swapTxContext)) {
+  // For ERC20 chain swaps and WBTC bridge, skip chain switching here entirely
+  // The chain switch will be handled in their respective handlers with proper non-blocking logic
+  if (isErc20ChainSwap(swapTxContext) || isWbtcBridge(swapTxContext)) {
     return { chainSwitchFailed: false }
   }
 
@@ -263,10 +265,12 @@ function* swap(params: SwapParams) {
   const isLightningBridgeSwap = isLightningBridge(swapTxContext)
   const isBitcoinBridgeSwap = isBitcoinBridge(swapTxContext)
   const isErc20ChainSwapSwap = isErc20ChainSwap(swapTxContext)
+  const isWbtcBridgeSwap = isWbtcBridge(swapTxContext)
 
   // Skip chain switching only for lightning and bitcoin bridges
-  // ERC20 chain swaps need to switch to source chain (input currency chainId) before locking
-  const changeChain = !isLightningBridgeSwap && !isBitcoinBridgeSwap
+  // ERC20 chain swaps and WBTC bridge need to switch to source chain (input currency chainId) before locking
+  // but they handle the chain switch internally
+  const changeChain = !isLightningBridgeSwap && !isBitcoinBridgeSwap && !isWbtcBridgeSwap
   if (changeChain) {
     const { chainSwitchFailed } = yield* call(handleSwitchChains, params)
     if (chainSwitchFailed) {
@@ -390,7 +394,21 @@ function* swap(params: SwapParams) {
           break
         }
         case TransactionStepType.Erc20ChainSwapStep: {
+          requireRouting(swapTxContext, [Routing.ERC20_CHAIN_SWAP])
           yield* call(handleErc20ChainSwap, {
+            step,
+            setCurrentStep,
+            trade,
+            account,
+            selectChain: params.selectChain,
+            onTransactionHash: params.onTransactionHash,
+            onSuccess: params.onSuccess,
+          })
+          break
+        }
+        case TransactionStepType.WbtcBridgeStep: {
+          requireRouting(swapTxContext, [Routing.WBTC_BRIDGE])
+          yield* call(handleWbtcBridge, {
             step,
             setCurrentStep,
             trade,
@@ -416,8 +434,8 @@ function* swap(params: SwapParams) {
     return
   }
 
-  // For lightning bridge, bitcoin bridge, and ERC20 chain swaps, onSuccess is called earlier in the flow
-  if (!isLightningBridgeSwap && !isBitcoinBridgeSwap && !isErc20ChainSwapSwap) {
+  // For lightning bridge, bitcoin bridge, ERC20 chain swaps, and WBTC bridge, onSuccess is called earlier in the flow
+  if (!isLightningBridgeSwap && !isBitcoinBridgeSwap && !isErc20ChainSwapSwap && !isWbtcBridgeSwap) {
     yield* call(onSuccess)
   }
 }

--- a/apps/web/src/state/sagas/transactions/wbtcBridge.ts
+++ b/apps/web/src/state/sagas/transactions/wbtcBridge.ts
@@ -1,0 +1,329 @@
+import { popupRegistry } from 'components/Popups/registry'
+import { LdsBridgeStatus, PopupType } from 'components/Popups/types'
+import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
+import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
+import { clientToProvider } from 'hooks/useEthersProvider'
+import { waitForNetwork } from 'state/sagas/transactions/chainSwitchUtils'
+import { call } from 'typed-redux-saga'
+import {
+  WBTC_ETHEREUM_ADDRESS,
+  WbtcBridgeDirection,
+} from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import {
+  LdsSwapStatus,
+  buildErc20LockupTx,
+  buildEvmLockupTx,
+  getLdsBridgeManager,
+} from 'uniswap/src/features/lds-bridge'
+import { TransactionStepFailedError } from 'uniswap/src/features/transactions/errors'
+import { WbtcBridgeStep } from 'uniswap/src/features/transactions/swap/steps/wbtcBridge'
+import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
+import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
+import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
+import { logger } from 'utilities/src/logger/logger'
+import type { Chain, Client, Transport } from 'viem'
+import { getAccount, getConnectorClient } from 'wagmi/actions'
+
+async function getConnectorClientForChain(chainId: UniverseChainId): Promise<Client<Transport, Chain> | undefined> {
+  try {
+    return (await getConnectorClient(wagmiConfig, { chainId: chainId as any })) as Client<Transport, Chain> | undefined
+  } catch (error) {
+    logger.error(error instanceof Error ? error : new Error(String(error)), {
+      tags: { file: 'wbtcBridge', function: 'getConnectorClientForChain' },
+      extra: { chainId },
+    })
+    throw error
+  }
+}
+
+// Swap contract addresses
+export const SWAP_CONTRACTS = {
+  ethereum: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
+  citreaMainnet: '0x7397f25f230f7d5a83c18e1b68b32511bf35f860',
+  citreaTestnet: '0xf2e019a371e5Fd32dB2fC564Ad9eAE9E433133cc',
+}
+
+// Token configurations by API symbol - mainnet
+const TOKEN_CONFIGS_MAINNET: Record<string, { address: string; decimals: number; chainId: UniverseChainId }> = {
+  WBTC_ETH: { address: WBTC_ETHEREUM_ADDRESS, decimals: 8, chainId: UniverseChainId.Mainnet },
+  cBTC: { address: '0x0000000000000000000000000000000000000000', decimals: 18, chainId: UniverseChainId.CitreaMainnet },
+}
+
+// Token configurations by API symbol - testnet
+const TOKEN_CONFIGS_TESTNET: Record<string, { address: string; decimals: number; chainId: UniverseChainId }> = {
+  WBTC_ETH: { address: WBTC_ETHEREUM_ADDRESS, decimals: 8, chainId: UniverseChainId.Mainnet },
+  cBTC: { address: '0x0000000000000000000000000000000000000000', decimals: 18, chainId: UniverseChainId.CitreaTestnet },
+}
+
+// Helper to get the right config based on trade's Citrea chain
+function getTokenConfigs(
+  citreaChainId: UniverseChainId,
+): Record<string, { address: string; decimals: number; chainId: UniverseChainId }> {
+  return citreaChainId === UniverseChainId.CitreaTestnet ? TOKEN_CONFIGS_TESTNET : TOKEN_CONFIGS_MAINNET
+}
+
+function getCitreaSwapContract(citreaChainId: UniverseChainId): string {
+  return citreaChainId === UniverseChainId.CitreaTestnet ? SWAP_CONTRACTS.citreaTestnet : SWAP_CONTRACTS.citreaMainnet
+}
+
+const BOLTZ_DECIMALS = 8 // Boltz uses 8 decimals internally (same as WBTC!)
+
+/**
+ * Convert from token decimals to Boltz 8-decimal format
+ */
+function tokenToBoltzDecimals(amount: bigint, tokenDecimals: number): number {
+  if (tokenDecimals === BOLTZ_DECIMALS) {
+    return Number(amount)
+  } else if (tokenDecimals > BOLTZ_DECIMALS) {
+    const divisor = 10n ** BigInt(tokenDecimals - BOLTZ_DECIMALS)
+    return Number(amount / divisor)
+  } else {
+    const multiplier = 10n ** BigInt(BOLTZ_DECIMALS - tokenDecimals)
+    return Number(amount * multiplier)
+  }
+}
+
+interface HandleWbtcBridgeParams {
+  step: WbtcBridgeStep
+  setCurrentStep: SetCurrentStepFn
+  trade: Trade
+  account: AccountDetails
+  selectChain: (chainId: UniverseChainId) => Promise<boolean>
+  onTransactionHash?: (hash: string) => void
+  onSuccess?: () => void
+}
+
+export function* handleWbtcBridge(params: HandleWbtcBridgeParams) {
+  const { step, setCurrentStep, trade, account, selectChain, onTransactionHash, onSuccess } = params
+  const isWbtcToCbtc = step.direction === WbtcBridgeDirection.EthereumToCitrea
+  const isCbtcToWbtc = step.direction === WbtcBridgeDirection.CitreaToEthereum
+
+  // Determine Citrea chain ID from the trade (input for cBTC→WBTC, output for WBTC→cBTC)
+  const citreaChainId = isCbtcToWbtc
+    ? (trade.inputAmount.currency.chainId as UniverseChainId)
+    : (trade.outputAmount.currency.chainId as UniverseChainId)
+
+  const TOKEN_CONFIGS = getTokenConfigs(citreaChainId)
+
+  // Determine source and destination based on direction
+  const from = isWbtcToCbtc ? 'WBTC_ETH' : 'cBTC'
+  const to = isWbtcToCbtc ? 'cBTC' : 'WBTC_ETH'
+
+  const sourceChain = isWbtcToCbtc ? 'ethereum' : 'citrea'
+  const sourceChainId = isWbtcToCbtc ? UniverseChainId.Mainnet : citreaChainId
+
+  const ldsBridge = getLdsBridgeManager()
+
+  // Get token decimals for source token
+  const sourceDecimals = TOKEN_CONFIGS[from].decimals
+
+  // Chain display names
+  const CHAIN_DISPLAY_NAMES: Record<string, string> = {
+    ethereum: 'Ethereum',
+    citrea: 'Citrea',
+  }
+
+  // 1. Switch to source chain before creating swap
+  const currentAccount = getAccount(wagmiConfig)
+  const chainName = CHAIN_DISPLAY_NAMES[sourceChain]
+
+  logger.info('wbtcBridge', 'handleWbtcBridge', 'Chain check', {
+    currentChainId: currentAccount.chainId,
+    requiredChainId: sourceChainId,
+    needsSwitch: currentAccount.chainId !== sourceChainId,
+  })
+
+  if (currentAccount.chainId !== sourceChainId) {
+    logger.info('wbtcBridge', 'handleWbtcBridge', `Requesting chain switch to ${chainName}`)
+
+    void selectChain(sourceChainId).catch((error) => {
+      logger.warn('wbtcBridge', 'handleWbtcBridge', 'Chain switch request failed', { error })
+    })
+
+    try {
+      yield* call(waitForNetwork, sourceChainId, 30000)
+      logger.info('wbtcBridge', 'handleWbtcBridge', `Successfully switched to ${chainName}`)
+    } catch (error) {
+      throw new TransactionStepFailedError({
+        message: `Please switch your wallet to ${chainName} network and try again.`,
+        step,
+        originalError: error instanceof Error ? error : undefined,
+      })
+    }
+  }
+
+  // 2. Create swap on server
+  const inputAmount = trade.inputAmount.quotient.toString()
+  const userLockAmount = tokenToBoltzDecimals(BigInt(inputAmount), sourceDecimals)
+
+  const createChainSwapParams = {
+    from,
+    to,
+    claimAddress: account.address,
+    userLockAmount,
+    chainId: citreaChainId,
+  }
+
+  let chainSwap
+  try {
+    chainSwap = yield* call([ldsBridge, ldsBridge.createChainSwap], createChainSwapParams)
+  } catch (error) {
+    logger.error(error instanceof Error ? error : new Error(String(error)), {
+      tags: { file: 'wbtcBridge', function: 'handleWbtcBridge' },
+      extra: { createChainSwapParams },
+    })
+    throw new TransactionStepFailedError({
+      message: `Failed to create WBTC bridge swap: ${error instanceof Error ? error.message : String(error)}`,
+      step,
+      originalError: error instanceof Error ? error : new Error(String(error)),
+    })
+  }
+
+  setCurrentStep({ step, accepted: false })
+
+  // 3. Lock on source chain
+  let sourceClient
+  try {
+    sourceClient = yield* call(getConnectorClientForChain, sourceChainId)
+  } catch (error) {
+    throw new TransactionStepFailedError({
+      message: `Failed to get connector client for chain ${sourceChainId}: ${error instanceof Error ? error.message : String(error)}`,
+      step,
+      originalError: error instanceof Error ? error : new Error(String(error)),
+    })
+  }
+
+  const sourceProvider = clientToProvider(sourceClient, sourceChainId)
+  if (!sourceProvider) {
+    throw new TransactionStepFailedError({
+      message: `Failed to get provider for chain ${sourceChainId}`,
+      step,
+    })
+  }
+
+  const sourceSigner = sourceProvider.getSigner(account.address)
+
+  const swapContractAddress = isWbtcToCbtc ? SWAP_CONTRACTS.ethereum : getCitreaSwapContract(citreaChainId)
+
+  let lockResult
+  try {
+    if (isWbtcToCbtc) {
+      // WBTC → cBTC: WBTC is an ERC20 on Ethereum, use ERC20 lockup
+      lockResult = yield* call(buildErc20LockupTx, {
+        signer: sourceSigner,
+        contractAddress: swapContractAddress,
+        tokenAddress: TOKEN_CONFIGS[from].address,
+        preimageHash: chainSwap.preimageHash,
+        amount: BigInt(inputAmount),
+        claimAddress: chainSwap.lockupDetails.claimAddress!,
+        timelock: chainSwap.lockupDetails.timeoutBlockHeight,
+      })
+    } else {
+      // cBTC → WBTC: cBTC is native on Citrea, use native coin lockup
+      // Note: buildEvmLockupTx expects amountSatoshis from chainSwap.lockupDetails
+      lockResult = yield* call(buildEvmLockupTx, {
+        signer: sourceSigner,
+        contractAddress: chainSwap.lockupDetails.lockupAddress,
+        preimageHash: chainSwap.preimageHash,
+        claimAddress: chainSwap.lockupDetails.claimAddress,
+        timeoutBlockHeight: chainSwap.lockupDetails.timeoutBlockHeight,
+        amountSatoshis: chainSwap.lockupDetails.amount,
+      })
+    }
+  } catch (error) {
+    logger.error(error instanceof Error ? error : new Error(String(error)), {
+      tags: { file: 'wbtcBridge', function: 'handleWbtcBridge' },
+      extra: { step: 'lockup', direction: step.direction },
+    })
+    throw new TransactionStepFailedError({
+      message: `Failed to lock ${isWbtcToCbtc ? 'WBTC' : 'cBTC'}: ${error instanceof Error ? error.message : String(error)}`,
+      step,
+      originalError: error instanceof Error ? error : new Error(String(error)),
+    })
+  }
+
+  if (onTransactionHash) {
+    onTransactionHash(lockResult.hash)
+  }
+
+  setCurrentStep({ step, accepted: false })
+
+  // 4. Wait for Boltz to lock on target chain
+  try {
+    yield* call([ldsBridge, ldsBridge.waitForSwapUntilState], chainSwap.id, LdsSwapStatus.TransactionConfirmed)
+    setCurrentStep({ step, accepted: false })
+    yield* call([ldsBridge, ldsBridge.waitForSwapUntilState], chainSwap.id, LdsSwapStatus.TransactionServerMempool)
+    yield* call([ldsBridge, ldsBridge.waitForSwapUntilState], chainSwap.id, LdsSwapStatus.TransactionServerConfirmed)
+  } catch (error) {
+    logger.error(error instanceof Error ? error : new Error(String(error)), {
+      tags: { file: 'wbtcBridge', function: 'handleWbtcBridge' },
+      extra: { swapId: chainSwap.id, step: 'waitForBoltzLock' },
+    })
+    throw new TransactionStepFailedError({
+      message: `Failed waiting for bridge lock: ${error instanceof Error ? error.message : String(error)}. The swap may still be processing.`,
+      step,
+      originalError: error instanceof Error ? error : new Error(String(error)),
+    })
+  }
+
+  // 5. Auto-claim
+  setCurrentStep({ step, accepted: false })
+
+  if (onSuccess) {
+    yield* call(onSuccess)
+  }
+
+  popupRegistry.addPopup(
+    {
+      type: PopupType.ClaimInProgress,
+      count: 1,
+    },
+    `claim-in-progress-${chainSwap.id}`,
+    DEFAULT_TXN_DISMISS_MS,
+  )
+
+  try {
+    const claimedSwap = yield* call([ldsBridge, ldsBridge.autoClaimSwap], chainSwap.id)
+    setCurrentStep({ step, accepted: true })
+
+    popupRegistry.removePopup(`claim-in-progress-${chainSwap.id}`)
+
+    const fromChainId = sourceChainId
+    const toChainId = isWbtcToCbtc ? citreaChainId : UniverseChainId.Mainnet
+
+    if (claimedSwap.claimTx) {
+      const explorerUrl = getExplorerLink({
+        chainId: toChainId,
+        data: claimedSwap.claimTx,
+        type: ExplorerDataType.TRANSACTION,
+      })
+
+      popupRegistry.addPopup(
+        {
+          type: PopupType.Erc20ChainSwap,
+          id: claimedSwap.claimTx,
+          fromChainId,
+          toChainId,
+          fromAsset: from,
+          toAsset: to,
+          status: LdsBridgeStatus.Confirmed,
+          url: explorerUrl,
+        },
+        claimedSwap.claimTx,
+      )
+    }
+  } catch (error) {
+    popupRegistry.removePopup(`claim-in-progress-${chainSwap.id}`)
+    logger.error(error instanceof Error ? error : new Error(String(error)), {
+      tags: { file: 'wbtcBridge', function: 'handleWbtcBridge' },
+      extra: { swapId: chainSwap.id, step: 'autoClaimSwap' },
+    })
+    throw new TransactionStepFailedError({
+      message: `Auto-claim failed: ${error instanceof Error ? error.message : String(error)}`,
+      step,
+      originalError: error instanceof Error ? error : new Error(String(error)),
+    })
+  }
+}

--- a/packages/uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge.ts
@@ -4,6 +4,10 @@ import { ChainId, QuoteRequest } from 'uniswap/src/data/tradingApi/__generated__
 // Citrea chain IDs (Mainnet and Testnet)
 const CITREA_CHAIN_IDS = [ChainId._4114, ChainId._5115]
 
+// WBTC address on Ethereum Mainnet
+export const WBTC_ETHEREUM_ADDRESS = '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'
+const WBTC_ETHEREUM_ADDRESS_LOWER = WBTC_ETHEREUM_ADDRESS.toLowerCase()
+
 export const isCitreaChainId = (chainId: ChainId | undefined): boolean => {
   return chainId !== undefined && CITREA_CHAIN_IDS.includes(chainId)
 }
@@ -47,4 +51,33 @@ export enum Erc20ChainSwapDirection {
   CitreaToPolygon = 'CitreaToPolygon',
   EthereumToCitrea = 'EthereumToCitrea',
   CitreaToEthereum = 'CitreaToEthereum',
+}
+
+export enum WbtcBridgeDirection {
+  EthereumToCitrea = 'WbtcEthereumToCitrea',
+  CitreaToEthereum = 'WbtcCitreaToEthereum',
+}
+
+/**
+ * Checks if the quote request is a WBTC bridge swap between Ethereum and Citrea.
+ * WBTC (ERC20 on Ethereum) <-> cBTC (native on Citrea)
+ */
+export const isWbtcBridgeQuote = (params: QuoteRequest): boolean => {
+  const { tokenInChainId, tokenOutChainId, tokenIn, tokenOut } = params
+
+  // WBTC (Ethereum) -> cBTC (Citrea native)
+  const isWbtcToCbtc =
+    tokenInChainId === ChainId._1 &&
+    isCitreaChainId(tokenOutChainId) &&
+    tokenIn?.toLowerCase() === WBTC_ETHEREUM_ADDRESS_LOWER &&
+    (!tokenOut || tokenOut === ZERO_ADDRESS)
+
+  // cBTC (Citrea native) -> WBTC (Ethereum)
+  const isCbtcToWbtc =
+    isCitreaChainId(tokenInChainId) &&
+    tokenOutChainId === ChainId._1 &&
+    (!tokenIn || tokenIn === ZERO_ADDRESS) &&
+    tokenOut?.toLowerCase() === WBTC_ETHEREUM_ADDRESS_LOWER
+
+  return isWbtcToCbtc || isCbtcToWbtc
 }

--- a/packages/uniswap/src/data/apiClients/tradingApi/utils/swappableTokens.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/utils/swappableTokens.ts
@@ -1,5 +1,6 @@
 import { ADDRESS } from '@juicedollar/jusd'
 import { ChainId, GetSwappableTokensResponse, SafetyLevel } from 'uniswap/src/data/tradingApi/__generated__'
+import { WBTC_ETHEREUM_ADDRESS } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
 
 const JUSD_CITREA_MAINNET = ADDRESS[4114]!.juiceDollar
 const JUSD_CITREA_TESTNET = ADDRESS[5115]!.juiceDollar
@@ -37,6 +38,20 @@ export const swappableTokensData: Partial<Record<ChainId, Record<string, GetSwap
         },
         symbol: 'lnBTC',
         decimals: 18,
+      },
+      {
+        address: WBTC_ETHEREUM_ADDRESS,
+        chainId: ChainId._1,
+        name: 'Wrapped BTC',
+        project: {
+          logo: {
+            url: 'https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png',
+          },
+          safetyLevel: SafetyLevel.VERIFIED,
+          isSpam: false,
+        },
+        symbol: 'WBTC',
+        decimals: 8,
       },
     ],
     [JUSD_CITREA_MAINNET]: [
@@ -258,6 +273,22 @@ export const swappableTokensData: Partial<Record<ChainId, Record<string, GetSwap
     ],
   },
   [ChainId._1]: {
+    [WBTC_ETHEREUM_ADDRESS]: [
+      {
+        address: '0x0000000000000000000000000000000000000000',
+        chainId: ChainId._4114,
+        name: 'Citrea BTC',
+        project: {
+          logo: {
+            url: 'https://docs.juiceswap.com/media/icons/cbtc.png',
+          },
+          safetyLevel: SafetyLevel.VERIFIED,
+          isSpam: false,
+        },
+        symbol: 'cBTC',
+        decimals: 18,
+      },
+    ],
     [USDT_ETHEREUM]: [
       {
         address: JUSD_CITREA_MAINNET,

--- a/packages/uniswap/src/data/tradingApi/modifyTradingApiTypes.mts
+++ b/packages/uniswap/src/data/tradingApi/modifyTradingApiTypes.mts
@@ -167,10 +167,11 @@ responseFiles.forEach((file) => {
 addImport(bridgeQuoteFile, 'LightningBridgeDirection')
 addImport(bridgeQuoteFile, 'BitcoinBridgeDirection')
 addImport(bridgeQuoteFile, 'Erc20ChainSwapDirection')
+addImport(bridgeQuoteFile, 'WbtcBridgeDirection')
 modifyType(bridgeQuoteFile, 'BridgeQuote', [
   {
     name: 'direction',
-    type: 'LightningBridgeDirection | BitcoinBridgeDirection | Erc20ChainSwapDirection',
+    type: 'LightningBridgeDirection | BitcoinBridgeDirection | Erc20ChainSwapDirection | WbtcBridgeDirection',
     isOptional: true,
   },
 ])
@@ -185,6 +186,7 @@ addEnumMember(routingFile, 'Routing', { name: 'JUPITER', value: 'JUPITER' })
 addEnumMember(routingFile, 'Routing', { name: 'BITCOIN_BRIDGE', value: 'BITCOIN_BRIDGE' })
 addEnumMember(routingFile, 'Routing', { name: 'LN_BRIDGE', value: 'LN_BRIDGE' })
 addEnumMember(routingFile, 'Routing', { name: 'ERC20_CHAIN_SWAP', value: 'ERC20_CHAIN_SWAP' })
+addEnumMember(routingFile, 'Routing', { name: 'WBTC_BRIDGE', value: 'WBTC_BRIDGE' })
 addEnumMember(chainIdFile, 'ChainId', { name: '_4114', value: 4114 })
 addEnumMember(chainIdFile, 'ChainId', { name: '_5115', value: 5115 })
 addEnumMember(chainIdFile, 'ChainId', { name: '_21_000_000', value: 21000000 })

--- a/packages/uniswap/src/data/tradingApi/types.ts
+++ b/packages/uniswap/src/data/tradingApi/types.ts
@@ -69,6 +69,8 @@ export enum Erc20ChainSwapDirection {
   CitreaToEthereum = 'CitreaToEthereum',
 }
 
+export { WbtcBridgeDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+
 export interface LightningInvoice {
   requestId: string
   invoice: {

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -61,6 +61,7 @@ export const ASSET_CHAIN_ID_MAP: Record<string, UniverseChainId> = {
   'USDC_POLYGON': UniverseChainId.Polygon,
   'JUSD_CITREA': UniverseChainId.CitreaMainnet,
   'BTC': UniverseChainId.Bitcoin,
+  'WBTC_ETH': UniverseChainId.Mainnet,
 }
 
 /* eslint-disable max-params, @typescript-eslint/no-non-null-assertion, consistent-return, @typescript-eslint/explicit-function-return-type, max-lines */

--- a/packages/uniswap/src/features/transactions/steps/types.ts
+++ b/packages/uniswap/src/features/transactions/steps/types.ts
@@ -8,6 +8,7 @@ import { WrapTransactionStep } from 'uniswap/src/features/transactions/steps/wra
 import type { BitcoinBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/bitcoinBridge'
 import type { ClassicSwapSteps } from 'uniswap/src/features/transactions/swap/steps/classicSteps'
 import type { Erc20ChainSwapStep } from 'uniswap/src/features/transactions/swap/steps/erc20ChainSwap'
+import type { WbtcBridgeStep } from 'uniswap/src/features/transactions/swap/steps/wbtcBridge'
 import type { LightningBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/lightningBridge'
 import type { UniswapXSwapSteps } from 'uniswap/src/features/transactions/swap/steps/uniswapxSteps'
 import type { ValidatedTransactionRequest } from 'uniswap/src/features/transactions/types/transactionRequests'
@@ -35,6 +36,7 @@ export enum TransactionStepType {
   LightningBridgeSubmarineStep = 'LightningBridgeSubmarineStep',
   LightningBridgeReverseStep = 'LightningBridgeReverseStep',
   Erc20ChainSwapStep = 'Erc20ChainSwapStep',
+  WbtcBridgeStep = 'WbtcBridgeStep',
 }
 
 // TODO: add v4 lp flow
@@ -50,6 +52,7 @@ export type TransactionStep =
   | BitcoinBridgeTransactionStep
   | LightningBridgeTransactionStep
   | Erc20ChainSwapStep
+  | WbtcBridgeStep
 export type OnChainTransactionStep = TransactionStep & OnChainTransactionFields
 export type OnChainTransactionStepBatched = TransactionStep & OnChainTransactionFieldsBatched
 export type SignatureTransactionStep = TransactionStep & SignTypedDataStepFields

--- a/packages/uniswap/src/features/transactions/swap/components/UnichainInstantBalanceModal/constants.ts
+++ b/packages/uniswap/src/features/transactions/swap/components/UnichainInstantBalanceModal/constants.ts
@@ -16,4 +16,4 @@ export const CHAIN_TO_UNIVERSAL_ROUTER_ADDRESS: Partial<Record<UniverseChainId, 
   ],
 }
 
-export const FLASHBLOCKS_UI_SKIP_ROUTES: TradeRouting[] = [Routing.WRAP, Routing.UNWRAP, Routing.BRIDGE, Routing.BITCOIN_BRIDGE, Routing.LN_BRIDGE, Routing.ERC20_CHAIN_SWAP]
+export const FLASHBLOCKS_UI_SKIP_ROUTES: TradeRouting[] = [Routing.WRAP, Routing.UNWRAP, Routing.BRIDGE, Routing.BITCOIN_BRIDGE, Routing.LN_BRIDGE, Routing.ERC20_CHAIN_SWAP, Routing.WBTC_BRIDGE]

--- a/packages/uniswap/src/features/transactions/swap/review/hooks/useTokenApprovalInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/hooks/useTokenApprovalInfo.ts
@@ -45,8 +45,8 @@ export function useTokenApprovalInfo(params: TokenApprovalInfoParams): ApprovalT
 
   const tokenInAddress = getTokenAddressForApi(currencyIn)
 
-  // Only used for bridging (includes ERC20 chain swaps via Boltz)
-  const isBridge = routing === Routing.BRIDGE || routing === Routing.ERC20_CHAIN_SWAP
+  // Only used for bridging (includes ERC20 chain swaps and WBTC bridge via Boltz)
+  const isBridge = routing === Routing.BRIDGE || routing === Routing.ERC20_CHAIN_SWAP || routing === Routing.WBTC_BRIDGE
   const currencyOut = currencyOutAmount?.currency
   const tokenOutAddress = getTokenAddressForApi(currencyOut)
 

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
@@ -152,6 +152,7 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
       [Routing.CLASSIC]: classicSwapTxInfoService,
       [Routing.BRIDGE]: bridgeSwapTxInfoService,
       [Routing.ERC20_CHAIN_SWAP]: erc20ChainSwapTxInfoService,
+      [Routing.WBTC_BRIDGE]: erc20ChainSwapTxInfoService, // WBTC bridge uses same service as ERC20 chain swap
       [Routing.PRIORITY]: uniswapXSwapTxInfoService,
       [Routing.DUTCH_V2]: uniswapXSwapTxInfoService,
       [Routing.DUTCH_V3]: uniswapXSwapTxInfoService,

--- a/packages/uniswap/src/features/transactions/swap/steps/wbtcBridge.ts
+++ b/packages/uniswap/src/features/transactions/swap/steps/wbtcBridge.ts
@@ -1,0 +1,14 @@
+import { WbtcBridgeDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+import { TransactionStepType } from 'uniswap/src/features/transactions/steps/types'
+
+export interface WbtcBridgeStep {
+  type: TransactionStepType.WbtcBridgeStep
+  direction: WbtcBridgeDirection
+}
+
+export const createWbtcBridgeStep = (direction: WbtcBridgeDirection): WbtcBridgeStep => {
+  return {
+    type: TransactionStepType.WbtcBridgeStep,
+    direction,
+  }
+}

--- a/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useSwapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useSwapTxAndGasInfo.ts
@@ -98,6 +98,7 @@ export function useSwapTxAndGasInfo({
         })
       case Routing.BRIDGE:
       case Routing.ERC20_CHAIN_SWAP:
+      case Routing.WBTC_BRIDGE:
         return getBridgeSwapTxAndGasInfo({ trade: trade as BridgeTrade, swapTxInfo, approvalTxInfo })
       case Routing.CLASSIC:
         return getClassicSwapTxAndGasInfo({ trade: trade as ClassicTrade, swapTxInfo, approvalTxInfo, permitTxInfo })

--- a/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useTransactionRequestInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useTransactionRequestInfo.ts
@@ -130,11 +130,13 @@ function useSwapTransactionRequestInfo({
   const isBitcoinBridgeSwap = derivedSwapInfo.trade.trade?.routing === Routing.BITCOIN_BRIDGE
   const isLightningBridgeSwap = derivedSwapInfo.trade.trade?.routing === Routing.LN_BRIDGE
   const isErc20ChainSwapTrade = derivedSwapInfo.trade.trade?.routing === Routing.ERC20_CHAIN_SWAP
+  const isWbtcBridgeSwap = derivedSwapInfo.trade.trade?.routing === Routing.WBTC_BRIDGE
   // Gateway JUSD trades now use the standard swap flow (fetchSwap handles Gateway quotes)
   const shouldSkipSwapRequest =
     isBitcoinBridgeSwap ||
     isLightningBridgeSwap ||
     isErc20ChainSwapTrade ||
+    isWbtcBridgeSwap ||
     getShouldSkipSwapRequest({
       derivedSwapInfo,
       tokenApprovalInfo,

--- a/packages/uniswap/src/features/transactions/swap/types/swapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/swapTxAndGasInfo.ts
@@ -2,7 +2,7 @@ import { Routing, CreateSwapRequest } from "uniswap/src/data/tradingApi/__genera
 import { GasEstimate } from "uniswap/src/data/tradingApi/types"
 import { GasFeeResult, ValidatedGasFeeResult, validateGasFeeResult } from "uniswap/src/features/gas/types"
 import { BridgeTrade, BitcoinBridgeTrade, LightningBridgeTrade, ClassicTrade, GatewayJusdTrade, UniswapXTrade, UnwrapTrade, WrapTrade } from "uniswap/src/features/transactions/swap/types/trade"
-import { isBridge, isBitcoinBridge, isErc20ChainSwap, isLightningBridge, isClassic, isGatewayJusd, isUniswapX, isWrap, GatewayJusdRouting } from "uniswap/src/features/transactions/swap/utils/routing"
+import { isBridge, isBitcoinBridge, isErc20ChainSwap, isLightningBridge, isClassic, isGatewayJusd, isUniswapX, isWrap, isWbtcBridge, GatewayJusdRouting } from "uniswap/src/features/transactions/swap/utils/routing"
 import { isInterface } from "utilities/src/platform"
 import { Prettify } from "viem"
 import { ValidatedPermit } from "uniswap/src/features/transactions/swap/utils/trade"
@@ -93,7 +93,7 @@ export interface UniswapXSwapTxAndGasInfo extends BaseSwapTxAndGasInfo {
 }
 
 export interface BridgeSwapTxAndGasInfo extends BaseSwapTxAndGasInfo {
-  routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP
+  routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP | Routing.WBTC_BRIDGE
   trade: BridgeTrade
   txRequests: PopulatedTransactionRequestArray | undefined
 }
@@ -208,9 +208,9 @@ function validateSwapTxContext(swapTxContext: SwapTxAndGasInfo): ValidatedSwapTx
       return { ...swapTxContext, trade, gasFee, txRequests, includesDelegation, destinationAddress }
     } else if (isBridge(swapTxContext)) {
       const { trade, txRequests, includesDelegation } = swapTxContext
-      
-      // ERC20 chain swaps don't require txRequests since Boltz handles the swap
-      if (isErc20ChainSwap(swapTxContext)) {
+
+      // ERC20 chain swaps and WBTC bridge don't require txRequests since Boltz handles the swap
+      if (isErc20ChainSwap(swapTxContext) || isWbtcBridge(swapTxContext)) {
         return {
           ...swapTxContext,
           trade,
@@ -219,7 +219,7 @@ function validateSwapTxContext(swapTxContext: SwapTxAndGasInfo): ValidatedSwapTx
           includesDelegation,
         } as ValidatedBridgeSwapTxAndGasInfo
       }
-      
+
       if (txRequests) {
         return { ...swapTxContext, trade, gasFee, txRequests, includesDelegation }
       }

--- a/packages/uniswap/src/features/transactions/swap/types/trade.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/trade.ts
@@ -609,7 +609,7 @@ export class BridgeTrade {
   readonly executionPrice: Price<Currency, Currency>
 
   readonly tradeType: TradeType
-  readonly routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP
+  readonly routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP | Routing.WBTC_BRIDGE
   readonly indicative = false
   readonly swapFee?: SwapFee
   readonly inputTax: Percent = ZERO_PERCENT
@@ -621,7 +621,7 @@ export class BridgeTrade {
 
   constructor({ quote, currencyIn, currencyOut, tradeType }: { quote: BridgeQuoteResponse, currencyIn: Currency, currencyOut: Currency, tradeType: TradeType }) {
     this.quote = quote
-    this.routing = quote.routing as Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP
+    this.routing = quote.routing as Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP | Routing.WBTC_BRIDGE
     this.swapFee = getSwapFee(quote)
 
     const quoteInputAmount = quote.quote.input?.amount

--- a/packages/uniswap/src/features/transactions/swap/utils/generateSwapTransactionSteps.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/generateSwapTransactionSteps.ts
@@ -1,4 +1,4 @@
-import { Erc20ChainSwapDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+import { Erc20ChainSwapDirection, WbtcBridgeDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
 import { BridgeQuote } from 'uniswap/src/data/tradingApi/__generated__'
 import { BitcoinBridgeDirection, LightningBridgeDirection } from 'uniswap/src/data/tradingApi/types'
 import { createApprovalTransactionStep } from 'uniswap/src/features/transactions/steps/approve'
@@ -9,6 +9,7 @@ import { TransactionStep } from 'uniswap/src/features/transactions/steps/types'
 import { createBitcoinBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/bitcoinBridge'
 import { orderClassicSwapSteps } from 'uniswap/src/features/transactions/swap/steps/classicSteps'
 import { createErc20ChainSwapStep } from 'uniswap/src/features/transactions/swap/steps/erc20ChainSwap'
+import { createWbtcBridgeStep } from 'uniswap/src/features/transactions/swap/steps/wbtcBridge'
 import { createLightningBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/lightningBridge'
 import { createSignUniswapXOrderStep } from 'uniswap/src/features/transactions/swap/steps/signOrder'
 import {
@@ -31,6 +32,7 @@ import {
   isGatewayJusd,
   isLightningBridge,
   isUniswapX,
+  isWbtcBridge,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
 
 // eslint-disable-next-line complexity
@@ -102,6 +104,10 @@ export function generateSwapTransactionSteps(txContext: SwapTxAndGasInfo, _v4Ena
       // ERC20 chain swaps have routing ERC20_CHAIN_SWAP
       const direction = (trade.quote.quote as BridgeQuote).direction as Erc20ChainSwapDirection
       return [createErc20ChainSwapStep(direction)]
+    } else if (isWbtcBridge(txContext)) {
+      // WBTC bridge swaps have routing WBTC_BRIDGE
+      const direction = (trade.quote.quote as BridgeQuote).direction as WbtcBridgeDirection
+      return [createWbtcBridgeStep(direction)]
     } else if (isBridge(txContext)) {
       // Regular bridge swaps require txRequests
       if (txContext.txRequests && txContext.txRequests.length > 1) {

--- a/packages/uniswap/src/features/transactions/swap/utils/routing.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/routing.ts
@@ -45,8 +45,8 @@ export function isGatewayJusd<T extends { routing: TradeRouting }>(obj: T): obj 
 
 export function isBridge<T extends { routing: TradeRouting }>(
   obj: T,
-): obj is T & { routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP } {
-  return obj.routing === Routing.BRIDGE || obj.routing === Routing.ERC20_CHAIN_SWAP
+): obj is T & { routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP | Routing.WBTC_BRIDGE } {
+  return obj.routing === Routing.BRIDGE || obj.routing === Routing.ERC20_CHAIN_SWAP || obj.routing === Routing.WBTC_BRIDGE
 }
 
 export function isBitcoinBridge<T extends { routing: TradeRouting }>(
@@ -65,6 +65,12 @@ export function isErc20ChainSwap<T extends { routing: TradeRouting }>(
   obj: T,
 ): obj is T & { routing: Routing.ERC20_CHAIN_SWAP } {
   return obj.routing === Routing.ERC20_CHAIN_SWAP
+}
+
+export function isWbtcBridge<T extends { routing: TradeRouting }>(
+  obj: T,
+): obj is T & { routing: Routing.WBTC_BRIDGE } {
+  return obj.routing === Routing.WBTC_BRIDGE
 }
 
 export function isWrap<T extends { routing: TradeRouting }>(

--- a/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
@@ -137,6 +137,9 @@ export function transformTradingApiResponseToTrade(params: TradingApiResponseToT
     case Routing.ERC20_CHAIN_SWAP: {
       return new BridgeTrade({ quote: data as BridgeQuoteResponse, currencyIn, currencyOut, tradeType })
     }
+    case Routing.WBTC_BRIDGE: {
+      return new BridgeTrade({ quote: data as BridgeQuoteResponse, currencyIn, currencyOut, tradeType })
+    }
     case Routing.WRAP: {
       return new WrapTrade({ quote: data, currencyIn, currencyOut, tradeType })
     }


### PR DESCRIPTION
## Summary

- Add bidirectional bridge functionality between WBTC (ERC20 on Ethereum) and cBTC (native on Citrea)
- Implement `WBTC_BRIDGE` routing type with dedicated quote generation and swap execution
- Use Boltz/Lightning.Space API for atomic swaps with ERC20 lockup (WBTC→cBTC) and native lockup (cBTC→WBTC)

## Changes

### New Files
- `apps/web/src/state/sagas/transactions/wbtcBridge.ts` - Saga handler for WBTC bridge execution
- `packages/uniswap/src/features/transactions/swap/steps/wbtcBridge.ts` - Step type definition

### Modified Files
- `TradingApiClient.ts` - Add `getWbtcBridgeQuote()` with fee calculation and limit validation
- `isBitcoinBridge.ts` - Add `isWbtcBridgeQuote()` detection and `WbtcBridgeDirection` enum
- `routing.ts` - Add `isWbtcBridge()` type guard, extend `isBridge()`
- `trade.ts` / `swapTxAndGasInfo.ts` - Extend types for `Routing.WBTC_BRIDGE`
- `swapSaga.ts` - Add `WbtcBridgeStep` case handler
- Various hooks - Add WBTC bridge support to swap flow

## Test plan

- [ ] Test WBTC → cBTC bridge (Ethereum Mainnet → Citrea Mainnet)
- [ ] Test cBTC → WBTC bridge (Citrea Mainnet → Ethereum Mainnet)
- [ ] Verify quote loading and fee calculation
- [ ] Verify approval flow for WBTC
- [ ] Verify lockup and auto-claim transactions