### PR TITLE
feat(bridge): add EVM swap claiming functionality

### DIFF
--- a/apps/web/src/components/Popups/PopupItem.tsx
+++ b/apps/web/src/components/Popups/PopupItem.tsx
@@ -4,6 +4,7 @@ import {
   ClaimCompletedPopupContent,
   ClaimInProgressPopupContent,
   Erc20ChainSwapPopupContent,
+  EvmClaimSuccessPopupContent,
   EvmRefundSuccessPopupContent,
   FORTransactionPopupContent,
   FailedNetworkSwitchPopup,
@@ -110,7 +111,13 @@ export function PopupItem({ content, onClose }: { content: PopupContent; popKey:
       )
     }
     case PopupType.RefundableSwaps: {
-      return <RefundableSwapsPopupContent count={content.count} onClose={onClose} />
+      return (
+        <RefundableSwapsPopupContent
+          refundableCount={content.refundableCount}
+          claimableCount={content.claimableCount}
+          onClose={onClose}
+        />
+      )
     }
     case PopupType.RefundsInProgress: {
       return <RefundsInProgressPopupContent count={content.count} onClose={onClose} />
@@ -127,6 +134,17 @@ export function PopupItem({ content, onClose }: { content: PopupContent; popKey:
     case PopupType.EvmRefundSuccess: {
       return (
         <EvmRefundSuccessPopupContent
+          chainId={content.chainId}
+          txHash={content.txHash}
+          amount={content.amount}
+          tokenSymbol={content.tokenSymbol}
+          onClose={onClose}
+        />
+      )
+    }
+    case PopupType.EvmClaimSuccess: {
+      return (
+        <EvmClaimSuccessPopupContent
           chainId={content.chainId}
           txHash={content.txHash}
           amount={content.amount}

--- a/apps/web/src/components/Popups/types.ts
+++ b/apps/web/src/components/Popups/types.ts
@@ -20,6 +20,7 @@ export enum PopupType {
   ClaimInProgress = 'claimInProgress',
   ClaimCompleted = 'claimCompleted',
   EvmRefundSuccess = 'evmRefundSuccess',
+  EvmClaimSuccess = 'evmClaimSuccess',
 }
 
 export enum SwitchNetworkAction {
@@ -109,7 +110,8 @@ export type PopupContent =
     }
   | {
       type: PopupType.RefundableSwaps
-      count: number
+      refundableCount: number
+      claimableCount: number
     }
   | {
       type: PopupType.RefundsInProgress
@@ -129,6 +131,13 @@ export type PopupContent =
     }
   | {
       type: PopupType.EvmRefundSuccess
+      chainId: number
+      txHash: string
+      amount: string
+      tokenSymbol: string
+    }
+  | {
+      type: PopupType.EvmClaimSuccess
       chainId: number
       txHash: string
       amount: string

--- a/apps/web/src/hooks/useEvmClaim.ts
+++ b/apps/web/src/hooks/useEvmClaim.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react'
+import { EvmLockup, getLdsBridgeManager, prefix0x } from 'uniswap/src/features/lds-bridge'
+import { logger } from 'utilities/src/logger/logger'
+
+export function useEvmClaim() {
+  const executeClaim = useCallback(async (lockup: EvmLockup): Promise<string> => {
+    try {
+      // Get local swap to retrieve swap ID
+      const swaps = await getLdsBridgeManager().getSwaps()
+      const localSwap = Object.entries(swaps).find(
+        ([, swap]) => prefix0x(swap.preimageHash) === prefix0x(lockup.preimageHash)
+      )
+
+      if (!localSwap) {
+        throw new Error('Swap not found in local storage')
+      }
+
+      const [swapId] = localSwap
+
+      // Use autoClaimSwap which handles ponder confirmation and claim
+      const claimedSwap = await getLdsBridgeManager().autoClaimSwap(swapId)
+
+      if (!claimedSwap.claimTx) {
+        throw new Error('Claim transaction not found')
+      }
+
+      logger.info('useEvmClaim', 'executeClaim', `Claim successful: ${claimedSwap.claimTx}`)
+      return claimedSwap.claimTx
+    } catch (error) {
+      logger.error(error, { tags: { file: 'useEvmClaim', function: 'executeClaim' } })
+      throw error
+    }
+  }, [])
+
+  return { executeClaim }
+}

--- a/apps/web/src/hooks/useEvmRefund.ts
+++ b/apps/web/src/hooks/useEvmRefund.ts
@@ -1,8 +1,7 @@
 import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
 import { clientToProvider } from 'hooks/useEthersProvider'
-import { EvmRefundableLockup } from 'hooks/useEvmRefundableSwaps'
 import { useCallback } from 'react'
-import { getLdsBridgeManager, prefix0x } from 'uniswap/src/features/lds-bridge'
+import { EvmLockup, getLdsBridgeManager, prefix0x } from 'uniswap/src/features/lds-bridge'
 import { refundCoinSwap, refundErc20Swap } from 'uniswap/src/features/lds-bridge/transactions/evm'
 import { logger } from 'utilities/src/logger/logger'
 import { getConnectorClient, switchChain } from 'wagmi/actions'
@@ -34,7 +33,7 @@ const CONTRACT_ADDRESSES: Record<number, { coinSwap?: string; erc20Swap: string 
 }
 
 export function useEvmRefund() {
-  const executeRefund = useCallback(async (lockup: EvmRefundableLockup): Promise<string> => {
+  const executeRefund = useCallback(async (lockup: EvmLockup): Promise<string> => {
     try {
       const chainId = Number(lockup.chainId)
 

--- a/apps/web/src/hooks/useSyncBridgeSwaps.ts
+++ b/apps/web/src/hooks/useSyncBridgeSwaps.ts
@@ -7,13 +7,14 @@ export function useSyncBridgeSwaps(enabled = true) {
 
   return useQuery({
     queryKey: ['sync-bridge-swaps', account.address],
-    queryFn: async (): Promise<void> => {
+    queryFn: async (): Promise<{ synced: boolean }> => {
       if (!account.address) {
-        return
+        return { synced: false }
       }
 
       const ldsBridgeManager = getLdsBridgeManager()
       await ldsBridgeManager.syncSwapsWithGraphQLData(account.address)
+      return { synced: true }
     },
     enabled: enabled && !!account.address,
     staleTime: Infinity, // Only run once per account.address change

--- a/apps/web/src/pages/BridgeSwaps/ClaimableSwapsSection.tsx
+++ b/apps/web/src/pages/BridgeSwaps/ClaimableSwapsSection.tsx
@@ -1,0 +1,245 @@
+import { popupRegistry } from 'components/Popups/registry'
+import { PopupType } from 'components/Popups/types'
+import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
+import { useEvmClaim } from 'hooks/useEvmClaim'
+import { ClaimButton, ClaimableSection, ClaimableSwapCard } from 'pages/BridgeSwaps/styles'
+import { useCallback, useState } from 'react'
+import { Flex, Text } from 'ui/src'
+import { CheckCircleFilled } from 'ui/src/components/icons/CheckCircleFilled'
+import { EvmLockup } from 'uniswap/src/features/lds-bridge'
+import { getChainLabel, isUniverseChainId } from 'uniswap/src/features/chains/utils'
+import { SomeSwap } from 'uniswap/src/features/lds-bridge/lds-types/storage'
+import { prefix0x } from 'uniswap/src/features/lds-bridge/utils/hex'
+import { logger } from 'utilities/src/logger/logger'
+import { formatUnits } from 'viem'
+
+interface ClaimableSwapsSectionProps {
+  evmClaimableSwaps: EvmLockup[]
+  allSwaps: (SomeSwap & { id: string })[]
+  isLoading: boolean
+  onRefetch: () => Promise<void>
+}
+
+interface EvmClaimableSwapCardItemProps {
+  lockup: EvmLockup
+  allSwaps: (SomeSwap & { id: string })[]
+  isClaiming: boolean
+  onClaim: () => void
+}
+
+const decimalsByAddress: Record<string, number> = {
+  '0x0987d3720d38847ac6dbb9d025b9de892a3ca35c': 18,
+  '0xdac17f958d2ee523a2206206994597c13d831ec7': 6,
+  '0xc2132d05d31c914a87c6611c10748aeb04b58e8f': 6,
+}
+
+function EvmClaimableSwapCardItem({
+  lockup,
+  allSwaps,
+  isClaiming,
+  onClaim,
+}: EvmClaimableSwapCardItemProps): JSX.Element {
+  const decimals = decimalsByAddress[(lockup.tokenAddress || '').toLowerCase()] || 18
+  const amount = formatUnits(BigInt(lockup.amount), decimals)
+
+  const getTokenInfo = () => {
+    // Try to find the swap by preimageHash in local storage
+    const localSwap = allSwaps.find((swap) => prefix0x(swap.preimageHash) === prefix0x(lockup.preimageHash))
+
+    if (localSwap) {
+      // Use the asset from local swap history
+      return { symbol: localSwap.assetReceive, name: localSwap.assetReceive }
+    }
+
+    // Fallback to token address logic if not found in local swaps
+    if (!lockup.tokenAddress) {
+      return { symbol: 'cBTC', name: 'Native Token' }
+    }
+    const tokenAddr = lockup.tokenAddress.toLowerCase()
+    if (tokenAddr === '0x0000000000000000000000000000000000000000') {
+      return { symbol: 'cBTC', name: 'Native Token' }
+    }
+    // Common token mappings - can be extended
+    const tokenMap: Record<string, { symbol: string; name: string }> = {
+      '0xdac17f958d2ee523a2206206994597c13d831ec7': { symbol: 'USDT', name: 'Tether USD' },
+      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': { symbol: 'USDC', name: 'USD Coin' },
+      '0x0987d3720d38847ac6dbb9d025b9de892a3ca35c': { symbol: 'JUSD', name: 'Juice Dollar' },
+      '0xc2132d05d31c914a87c6611c10748aeb04b58e8f': { symbol: 'USDT', name: 'Tether USD' },
+    }
+    if (tokenAddr in tokenMap) {
+      return tokenMap[tokenAddr]
+    }
+    return { symbol: 'ERC20', name: 'Token' }
+  }
+
+  const tokenInfo = getTokenInfo()
+  const timelockBlock = lockup.timelock
+  const numericChainId = Number(lockup.chainId)
+  const chainName = isUniverseChainId(numericChainId) ? getChainLabel(numericChainId) : `Chain ${lockup.chainId}`
+
+  return (
+    <ClaimableSwapCard highlighted>
+      <Flex gap="$spacing8">
+        <Flex flexDirection="row" alignItems="center" justifyContent="space-between">
+          <Text variant="body3" color="$neutral1" fontWeight="600">
+            {amount} {tokenInfo.symbol}
+          </Text>
+          <Flex
+            backgroundColor="$statusSuccess"
+            paddingHorizontal="$spacing6"
+            paddingVertical="$spacing2"
+            borderRadius="$rounded8"
+          >
+            <Text variant="body4" color="$white" fontWeight="600" fontSize={11}>
+              Claimable
+            </Text>
+          </Flex>
+        </Flex>
+
+        <Flex gap="$spacing2">
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Text variant="body4" color="$neutral2" fontSize={12}>
+              Chain:
+            </Text>
+            <Text variant="body4" color="$neutral1" fontSize={12}>
+              {chainName}
+            </Text>
+          </Flex>
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Text variant="body4" color="$neutral2" fontSize={12}>
+              Token:
+            </Text>
+            <Text variant="body4" color="$neutral1" fontSize={12}>
+              {tokenInfo.name}
+            </Text>
+          </Flex>
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Text variant="body4" color="$neutral2" fontSize={12}>
+              Timelock Block:
+            </Text>
+            <Text variant="body4" color="$neutral1" fontSize={12}>
+              {timelockBlock}
+            </Text>
+          </Flex>
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Text variant="body4" color="$neutral2" fontSize={12}>
+              Hash:
+            </Text>
+            <Text variant="body4" color="$neutral3" fontFamily="$mono" fontSize={10}>
+              {lockup.preimageHash.slice(0, 10)}...{lockup.preimageHash.slice(-8)}
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+
+      <ClaimButton onPress={onClaim} disabled={isClaiming}>
+        <Text variant="buttonLabel4" color="$neutral1" fontSize={13}>
+          {isClaiming ? 'Claiming...' : 'Claim'}
+        </Text>
+      </ClaimButton>
+    </ClaimableSwapCard>
+  )
+}
+
+export function ClaimableSwapsSection({
+  evmClaimableSwaps,
+  allSwaps,
+  isLoading,
+  onRefetch,
+}: ClaimableSwapsSectionProps): JSX.Element | null {
+  const { executeClaim } = useEvmClaim()
+  const [claimingEvmSwaps, setClaimingEvmSwaps] = useState<Set<string>>(new Set())
+
+  const handleEvmClaim = useCallback(
+    async (lockup: EvmLockup) => {
+      setClaimingEvmSwaps((prev) => new Set(prev).add(lockup.preimageHash))
+      try {
+        const txHash = await executeClaim(lockup)
+        logger.info('ClaimableSwapsSection', 'handleEvmClaim', `Claim successful: ${txHash}`)
+
+        // Show success popup with explorer link
+        const decimals = decimalsByAddress[(lockup.tokenAddress || '').toLowerCase()] || 18
+        const amount = formatUnits(BigInt(lockup.amount), decimals)
+
+        // Get token info for display
+        const localSwap = allSwaps.find((swap) => prefix0x(swap.preimageHash) === prefix0x(lockup.preimageHash))
+        let tokenSymbol = 'cBTC'
+        if (localSwap) {
+          tokenSymbol = localSwap.assetReceive
+        } else if (lockup.tokenAddress && lockup.tokenAddress !== '0x0000000000000000000000000000000000000000') {
+          const tokenAddr = lockup.tokenAddress.toLowerCase()
+          const tokenMap: Record<string, string> = {
+            '0xdac17f958d2ee523a2206206994597c13d831ec7': 'USDT',
+            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': 'USDC',
+            '0x0987d3720d38847ac6dbb9d025b9de892a3ca35c': 'JUSD',
+            '0xc2132d05d31c914a87c6611c10748aeb04b58e8f': 'USDT',
+          }
+          tokenSymbol = tokenMap[tokenAddr] || 'ERC20'
+        }
+
+        popupRegistry.addPopup(
+          {
+            type: PopupType.EvmClaimSuccess,
+            chainId: Number(lockup.chainId),
+            txHash,
+            amount,
+            tokenSymbol,
+          },
+          `evm-claim-success-${txHash}`,
+          DEFAULT_TXN_DISMISS_MS,
+        )
+
+        await onRefetch()
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+
+        // Check for specific error messages
+        if (errorMessage.includes('user rejected')) {
+          logger.warn('ClaimableSwapsSection', 'handleEvmClaim', 'Transaction rejected by user')
+        } else {
+          logger.error(error, { tags: { file: 'ClaimableSwapsSection', function: 'handleEvmClaim' } })
+        }
+      } finally {
+        setClaimingEvmSwaps((prev) => {
+          const next = new Set(prev)
+          next.delete(lockup.preimageHash)
+          return next
+        })
+      }
+    },
+    [executeClaim, onRefetch, allSwaps],
+  )
+
+  if (isLoading || evmClaimableSwaps.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {evmClaimableSwaps.length > 0 && (
+        <ClaimableSection>
+          <Flex flexDirection="row" alignItems="center" gap="$spacing8">
+            <CheckCircleFilled size="$icon.20" color="$statusSuccess" />
+            <Text variant="heading3" color="$neutral1" fontWeight="600">
+              Swaps Available for Claiming ({evmClaimableSwaps.length})
+            </Text>
+          </Flex>
+          <Text variant="body3" color="$neutral2">
+            These swaps are ready to be claimed. Click the Claim button to receive your funds.
+          </Text>
+          <Flex gap="$spacing12">
+            {evmClaimableSwaps.map((lockup) => (
+              <EvmClaimableSwapCardItem
+                key={lockup.preimageHash}
+                lockup={lockup}
+                allSwaps={allSwaps}
+                isClaiming={claimingEvmSwaps.has(lockup.preimageHash)}
+                onClaim={() => handleEvmClaim(lockup)}
+              />
+            ))}
+          </Flex>
+        </ClaimableSection>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/pages/BridgeSwaps/index.tsx
+++ b/apps/web/src/pages/BridgeSwaps/index.tsx
@@ -1,7 +1,8 @@
 import { useBridgeSwaps } from 'hooks/useBridgeSwaps'
 import { useCrossChainSwapsEnabled } from 'hooks/useCrossChainSwapsEnabled'
-import { useEvmRefundableSwaps } from 'hooks/useEvmRefundableSwaps'
+import { useEvmClaimableAndRefundableSwaps } from 'hooks/useEvmRefundableSwaps'
 import { useRefundableSwaps } from 'hooks/useRefundableSwaps'
+import { ClaimableSwapsSection } from 'pages/BridgeSwaps/ClaimableSwapsSection'
 import { RefundableSwapsSection } from 'pages/BridgeSwaps/RefundableSwapsSection'
 import { SwapsTable } from 'pages/BridgeSwaps/SwapsTable'
 import {
@@ -30,12 +31,13 @@ export default function BridgeSwaps(): JSX.Element {
     refetch: refetchRefundable,
   } = useRefundableSwaps(crossChainSwapsEnabled)
   const {
-    data: evmSwapsData,
+    data: evmSwapsData = { refundable: [], locked: [], claimable: [] },
     isLoading: isLoadingEvmRefundable,
     refetch: refetchEvmRefundable,
-  } = useEvmRefundableSwaps(crossChainSwapsEnabled)
+  } = useEvmClaimableAndRefundableSwaps(crossChainSwapsEnabled)
 
   const evmRefundableSwaps = evmSwapsData.refundable
+  const evmClaimableSwaps = evmSwapsData.claimable
 
   const handleRefetch = useCallback(async () => {
     await Promise.all([refetch(), refetchRefundable(), refetchEvmRefundable()])
@@ -48,6 +50,7 @@ export default function BridgeSwaps(): JSX.Element {
   const stats = {
     total: swaps.length,
     refundable: refundableSwaps.length + evmRefundableSwaps.length,
+    claimable: evmClaimableSwaps.length,
   }
 
   return (
@@ -66,6 +69,12 @@ export default function BridgeSwaps(): JSX.Element {
               <StatValue>{stats.total}</StatValue>
               <StatLabel>Total Swaps</StatLabel>
             </StatItem>
+            {stats.claimable > 0 && (
+              <StatItem>
+                <StatValue>{stats.claimable}</StatValue>
+                <StatLabel>Claimable</StatLabel>
+              </StatItem>
+            )}
             {stats.refundable > 0 && (
               <StatItem>
                 <StatValue>{stats.refundable}</StatValue>
@@ -73,6 +82,13 @@ export default function BridgeSwaps(): JSX.Element {
               </StatItem>
             )}
           </StatsBar>
+
+          <ClaimableSwapsSection
+            evmClaimableSwaps={evmClaimableSwaps}
+            allSwaps={swaps}
+            isLoading={isLoadingEvmRefundable}
+            onRefetch={handleRefetch}
+          />
 
           <RefundableSwapsSection
             refundableSwaps={refundableSwaps}

--- a/apps/web/src/pages/BridgeSwaps/styles.ts
+++ b/apps/web/src/pages/BridgeSwaps/styles.ts
@@ -131,3 +131,50 @@ export const AddressInput = styled(Input, {
     borderColor: '$accent1',
   },
 })
+
+export const ClaimableSection = styled(Flex, {
+  gap: '$spacing16',
+  padding: '$spacing20',
+  backgroundColor: '$surface2',
+  borderRadius: '$rounded16',
+  borderWidth: 2,
+  borderColor: '$statusSuccess',
+})
+
+export const ClaimableSwapCard = styled(Flex, {
+  backgroundColor: '$surface3',
+  borderRadius: '$rounded12',
+  padding: '$spacing12',
+  gap: '$spacing8',
+  flexDirection: 'column',
+
+  variants: {
+    highlighted: {
+      true: {
+        borderWidth: 1,
+        borderColor: '$surface3',
+        backgroundColor: '$surface2',
+      },
+    },
+  } as const,
+})
+
+export const ClaimButton = styled(Button, {
+  backgroundColor: '$statusSuccess',
+  borderRadius: '$rounded12',
+  paddingHorizontal: '$spacing12',
+  paddingVertical: '$spacing8',
+  width: '100%',
+  alignSelf: 'stretch',
+  minHeight: 36,
+  hoverStyle: {
+    opacity: 0.9,
+  },
+  pressStyle: {
+    opacity: 0.8,
+  },
+  disabledStyle: {
+    opacity: 0.5,
+    backgroundColor: '$surface3',
+  },
+})

--- a/apps/web/src/pages/DebugLockup/index.tsx
+++ b/apps/web/src/pages/DebugLockup/index.tsx
@@ -1,0 +1,580 @@
+import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
+import { clientToProvider } from 'hooks/useEthersProvider'
+import { useAccount } from 'hooks/useAccount'
+import { useCallback, useState, useMemo } from 'react'
+import { Button, Flex, Input, Text } from 'ui/src'
+import { AlertTriangle } from 'ui/src/components/icons/AlertTriangle'
+import { CheckCircleFilled } from 'ui/src/components/icons/CheckCircleFilled'
+import { styled } from 'ui/src'
+import { buildErc20LockupTx, buildEvmLockupTx, checkErc20Allowance, approveErc20ForLdsBridge } from 'uniswap/src/features/lds-bridge/transactions/evm'
+import { logger } from 'utilities/src/logger/logger'
+import { getConnectorClient, switchChain } from 'wagmi/actions'
+import { parseUnits } from 'viem'
+import { getLdsBridgeManager } from 'uniswap/src/features/lds-bridge/LdsBridgeManager'
+window.ldsBridgeManager = getLdsBridgeManager
+const PageWrapper = styled(Flex, {
+  width: '100%',
+  maxWidth: 720,
+  mx: 'auto',
+  p: '$spacing24',
+  gap: '$spacing24',
+})
+
+const Card = styled(Flex, {
+  backgroundColor: '$surface2',
+  borderRadius: '$rounded16',
+  padding: '$spacing20',
+  gap: '$spacing16',
+  borderWidth: 1,
+  borderColor: '$surface3',
+})
+
+const FieldGroup = styled(Flex, {
+  gap: '$spacing8',
+})
+
+const StyledInput = styled(Input, {
+  backgroundColor: '$surface3',
+  borderRadius: '$rounded12',
+  padding: '$spacing12',
+  fontSize: 14,
+  color: '$neutral1',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  fontFamily: '$mono',
+  focusStyle: {
+    borderColor: '$accent1',
+    outlineWidth: 0,
+  },
+})
+
+const SubmitButton = styled(Button, {
+  backgroundColor: '$accent1',
+  borderRadius: '$rounded12',
+  padding: '$spacing16',
+  hoverStyle: {
+    opacity: 0.9,
+  },
+  pressStyle: {
+    opacity: 0.8,
+  },
+  disabledStyle: {
+    opacity: 0.5,
+    backgroundColor: '$surface3',
+  },
+})
+
+const WarningBanner = styled(Flex, {
+  backgroundColor: '$DEP_accentWarning',
+  borderRadius: '$rounded12',
+  padding: '$spacing16',
+  gap: '$spacing12',
+  flexDirection: 'row',
+  alignItems: 'center',
+  opacity: 0.15,
+})
+
+const SuccessBanner = styled(Flex, {
+  backgroundColor: '$statusSuccess',
+  borderRadius: '$rounded12',
+  padding: '$spacing16',
+  gap: '$spacing12',
+  flexDirection: 'row',
+  alignItems: 'center',
+  opacity: 0.15,
+})
+
+// Contract addresses for lockups (lowercase to avoid checksum issues)
+const CONTRACT_ADDRESSES: Record<number, { coinSwap?: string; erc20Swap: string }> = {
+  4114: {
+    // Citrea Mainnet
+    coinSwap: '0xfd92f846fe6e7d08d28d6a88676bb875e5d906ab',
+    erc20Swap: '0x7397f25f230f7d5a83c18e1b68b32511bf35f860',
+  },
+  137: {
+    // Polygon Mainnet
+    erc20Swap: '0x2e21f58da58c391f110467c7484edfa849c1cb9b',
+  },
+  1: {
+    // Ethereum Mainnet
+    erc20Swap: '0x2e21f58da58c391f110467c7484edfa849c1cb9b',
+  },
+}
+
+interface TokenInfo {
+  symbol: string
+  name: string
+  address: string
+  decimals: number
+  chainId: number
+}
+
+const SUPPORTED_TOKENS: TokenInfo[] = [
+  // Citrea Mainnet - Native token
+  {
+    symbol: 'cBTC',
+    name: 'Citrea Bitcoin (Native)',
+    address: '',
+    decimals: 8,
+    chainId: 4114,
+  },
+  // Ethereum - JUSD
+  {
+    symbol: 'JUSD',
+    name: 'Juice Dollar',
+    address: '0x0987d3720d38847ac6dbb9d025b9de892a3ca35c',
+    decimals: 18,
+    chainId: 4114,
+  },
+  // Ethereum - USDT
+  {
+    symbol: 'USDT',
+    name: 'Tether USD',
+    address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    decimals: 6,
+    chainId: 1,
+  },
+  // Polygon Mainnet - USDT
+  {
+    symbol: 'USDT',
+    name: 'Tether USD',
+    address: '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
+    decimals: 6,
+    chainId: 137,
+  },
+]
+
+const CHAINS = [
+  { id: 4114, name: 'Citrea Mainnet' },
+  { id: 1, name: 'Ethereum' },
+  { id: 137, name: 'Polygon' },
+]
+
+interface LockupFormData {
+  chainId: number
+  selectedToken: string // Format: "chainId-tokenAddress" or "chainId-native"
+  preimageHash: string
+  claimAddress: string
+  timelock: string
+  amount: string
+}
+
+export default function DebugLockup(): JSX.Element {
+  const account = useAccount()
+  const [formData, setFormData] = useState<LockupFormData>({
+    chainId: 4114,
+    selectedToken: '5115-native',
+    preimageHash: '',
+    claimAddress: '',
+    timelock: '',
+    amount: '',
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [txHash, setTxHash] = useState<string>('')
+  const [error, setError] = useState<string>('')
+
+  // Get available tokens for selected chain
+  const availableTokens = useMemo(() => {
+    return SUPPORTED_TOKENS.filter((token) => token.chainId === formData.chainId)
+  }, [formData.chainId])
+
+  // Get selected token info
+  const selectedTokenInfo = useMemo(() => {
+    return SUPPORTED_TOKENS.find((token) => {
+      const tokenKey = token.address ? `${token.chainId}-${token.address}` : `${token.chainId}-native`
+      return tokenKey === formData.selectedToken
+    })
+  }, [formData.selectedToken])
+
+  const isNativeToken = selectedTokenInfo?.address === ''
+
+  const handleInputChange = (field: keyof LockupFormData, value: string | number) => {
+    setFormData((prev) => {
+      const updated = { ...prev, [field]: value }
+      
+      // When chain changes, reset token selection to first available token
+      if (field === 'chainId') {
+        const chainTokens = SUPPORTED_TOKENS.filter((t) => t.chainId === value)
+        if (chainTokens.length > 0) {
+          const firstToken = chainTokens[0]
+          updated.selectedToken = firstToken.address ? `${firstToken.chainId}-${firstToken.address}` : `${firstToken.chainId}-native`
+        }
+      }
+      
+      return updated
+    })
+    setError('')
+    setTxHash('')
+  }
+
+  const handleSubmit = useCallback(async () => {
+    const validateForm = (): string | null => {
+      if (!account.address) {
+        return 'Please connect your wallet'
+      }
+      if (!formData.chainId) {
+        return 'Chain is required'
+      }
+      if (!formData.selectedToken || !selectedTokenInfo) {
+        return 'Token is required'
+      }
+      if (!formData.preimageHash || !/^(0x)?[0-9a-fA-F]{64}$/.test(formData.preimageHash)) {
+        return 'Preimage hash must be 64 hex characters (32 bytes)'
+      }
+      if (!formData.claimAddress || !/^0x[0-9a-fA-F]{40}$/.test(formData.claimAddress)) {
+        return 'Invalid claim address'
+      }
+      if (!formData.timelock || isNaN(Number(formData.timelock)) || Number(formData.timelock) <= 0) {
+        return 'Timelock block must be a positive number'
+      }
+      if (!formData.amount || isNaN(Number(formData.amount)) || Number(formData.amount) <= 0) {
+        return 'Amount must be a positive number'
+      }
+      return null
+    }
+
+    const validationError = validateForm()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    if (!selectedTokenInfo) {
+      setError('Token information not found')
+      return
+    }
+
+    setIsSubmitting(true)
+    setError('')
+    setTxHash('')
+
+    try {
+      const chainId = formData.chainId
+      const contractAddresses = CONTRACT_ADDRESSES[chainId] as { coinSwap?: string; erc20Swap: string } | undefined
+
+      if (!contractAddresses) {
+        throw new Error(`Chain ID ${chainId} is not supported`)
+      }
+
+      // Validate amount before proceeding
+      if (!formData.amount || formData.amount.trim() === '') {
+        throw new Error('Amount is required')
+      }
+
+      // Parse amount with proper decimals
+      let amountWei: bigint
+      try {
+        amountWei = parseUnits(formData.amount.trim(), selectedTokenInfo.decimals)
+      } catch (err) {
+        throw new Error(`Invalid amount: ${formData.amount}. Please enter a valid number.`)
+      }
+
+      if (amountWei <= 0n) {
+        throw new Error('Amount must be greater than 0')
+      }
+
+      // Switch chain if necessary
+      if (account.chainId !== chainId) {
+        await switchChain(wagmiConfig, { chainId })
+      }
+
+      const connectorClient = await getConnectorClient(wagmiConfig, { chainId })
+      const provider = clientToProvider(connectorClient, chainId)
+
+      if (!provider) {
+        throw new Error('Failed to get provider')
+      }
+
+      const signer = provider.getSigner()
+
+      // Ensure preimageHash has 0x prefix
+      const preimageHash = formData.preimageHash.startsWith('0x')
+        ? formData.preimageHash
+        : `0x${formData.preimageHash}`
+
+      if (isNativeToken) {
+        // Native token (cBTC) lockup
+        if (!contractAddresses.coinSwap) {
+          throw new Error(`Native token swaps not supported on chain ${chainId}`)
+        }
+
+        // For cBTC, convert to satoshis (8 decimals)
+        // BigInt to Number conversion - safe for amounts up to ~9 billion BTC
+        const amountSatoshis = Number(amountWei)
+        
+        if (!Number.isFinite(amountSatoshis) || amountSatoshis <= 0) {
+          throw new Error(`Invalid amount for native token: ${amountSatoshis}`)
+        }
+
+        const result = await buildEvmLockupTx({
+          signer,
+          contractAddress: contractAddresses.coinSwap,
+          preimageHash,
+          claimAddress: formData.claimAddress,
+          timeoutBlockHeight: Number(formData.timelock),
+          amountSatoshis,
+        })
+
+        setTxHash(result.hash)
+        logger.info('DebugLockup', 'handleSubmit', `Native lockup created: ${result.hash}`)
+      } else {
+        // ERC20 token lockup
+        // Check and approve if needed
+        const allowanceCheck = await checkErc20Allowance({
+          signer,
+          contractAddress: contractAddresses.erc20Swap,
+          tokenAddress: selectedTokenInfo.address,
+          amount: amountWei,
+        })
+
+        if (allowanceCheck.needsApproval) {
+          logger.info('DebugLockup', 'handleSubmit', 'Approval needed, requesting approval...')
+          const approvalResult = await approveErc20ForLdsBridge({
+            signer,
+            contractAddress: contractAddresses.erc20Swap,
+            tokenAddress: selectedTokenInfo.address,
+            amount: amountWei,
+          })
+          
+          logger.info('DebugLockup', 'handleSubmit', `Approval tx: ${approvalResult.hash}`)
+          // Wait for approval to be mined
+          await approvalResult.tx.wait()
+        }
+
+        const result = await buildErc20LockupTx({
+          signer,
+          contractAddress: contractAddresses.erc20Swap,
+          tokenAddress: selectedTokenInfo.address,
+          preimageHash,
+          amount: amountWei,
+          claimAddress: formData.claimAddress,
+          timelock: Number(formData.timelock),
+        })
+
+        setTxHash(result.hash)
+        logger.info('DebugLockup', 'handleSubmit', `ERC20 lockup created: ${result.hash}`)
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      setError(errorMessage)
+      logger.error(err, { tags: { file: 'DebugLockup', function: 'handleSubmit' } })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [formData, account, selectedTokenInfo, isNativeToken])
+
+  const getExplorerUrl = (hash: string): string => {
+    const explorers: Record<number, string> = {
+      1: 'https://etherscan.io',
+      137: 'https://polygonscan.com',
+      4114: 'https://explorer.citrea.xyz',
+    }
+    const baseUrl = explorers[formData.chainId] || 'https://etherscan.io'
+    return `${baseUrl}/tx/${hash}`
+  }
+
+  const SelectButton = styled(Button, {
+    backgroundColor: '$surface3',
+    borderRadius: '$rounded8',
+    paddingHorizontal: '$spacing12',
+    paddingVertical: '$spacing8',
+    minWidth: 120,
+    hoverStyle: {
+      backgroundColor: '$surface2',
+    },
+    variants: {
+      selected: {
+        true: {
+          backgroundColor: '$accent1',
+        },
+      },
+    } as const,
+  })
+
+  return (
+    <PageWrapper>
+      <Flex gap="$spacing12">
+        <Text variant="heading1" color="$neutral1">
+          Debug: Create Lockup
+        </Text>
+        <Text variant="body2" color="$neutral2">
+          Manually create a lockup transaction for testing purposes. Use with caution.
+        </Text>
+      </Flex>
+
+      <WarningBanner>
+        <AlertTriangle color="$statusCritical" size="$icon.24" />
+        <Flex gap="$spacing4" flex={1}>
+          <Text variant="body3" color="$neutral1" fontWeight="600">
+            Debug Tool - Use with Caution
+          </Text>
+          <Text variant="body4" color="$neutral2">
+            This tool creates real lockup transactions on-chain. Make sure you understand what you&apos;re doing.
+          </Text>
+        </Flex>
+      </WarningBanner>
+
+      <Card>
+        <Text variant="heading3" color="$neutral1">
+          Lockup Details
+        </Text>
+
+        <FieldGroup>
+          <Text variant="body3" color="$neutral2">
+            Chain
+          </Text>
+          <Flex flexDirection="row" gap="$spacing8" flexWrap="wrap">
+            {CHAINS.map((chain) => (
+              <SelectButton
+                key={chain.id}
+                selected={formData.chainId === chain.id}
+                onPress={() => handleInputChange('chainId', chain.id)}
+              >
+                <Text variant="body4" color="$neutral1" fontSize={12}>
+                  {chain.name}
+                </Text>
+              </SelectButton>
+            ))}
+          </Flex>
+        </FieldGroup>
+
+        <FieldGroup>
+          <Text variant="body3" color="$neutral2">
+            Token
+          </Text>
+          <Flex flexDirection="row" gap="$spacing8" flexWrap="wrap">
+            {availableTokens.map((token) => {
+              const tokenKey = token.address ? `${token.chainId}-${token.address}` : `${token.chainId}-native`
+              return (
+                <SelectButton
+                  key={tokenKey}
+                  selected={formData.selectedToken === tokenKey}
+                  onPress={() => handleInputChange('selectedToken', tokenKey)}
+                >
+                  <Text variant="body4" color="$neutral1" fontSize={12}>
+                    {token.symbol}
+                  </Text>
+                </SelectButton>
+              )
+            })}
+          </Flex>
+          {selectedTokenInfo && (
+            <Text variant="body4" color="$neutral3" fontSize={11}>
+              {selectedTokenInfo.name} • {selectedTokenInfo.decimals} decimals
+              {selectedTokenInfo.address && ` • ${selectedTokenInfo.address.slice(0, 10)}...`}
+            </Text>
+          )}
+        </FieldGroup>
+
+        <FieldGroup>
+          <Text variant="body3" color="$neutral2">
+            Preimage Hash (32 bytes)
+          </Text>
+          <StyledInput
+            value={formData.preimageHash}
+            onChangeText={(value: string) => handleInputChange('preimageHash', value)}
+            placeholder="0x1234567890abcdef..."
+          />
+          <Text variant="body4" color="$neutral3" fontSize={11}>
+            64 hex characters (with or without 0x prefix)
+          </Text>
+        </FieldGroup>
+
+        <FieldGroup>
+          <Text variant="body3" color="$neutral2">
+            Claim Address
+          </Text>
+          <StyledInput
+            value={formData.claimAddress}
+            onChangeText={(value: string) => handleInputChange('claimAddress', value)}
+            placeholder="0x..."
+          />
+        </FieldGroup>
+
+        <FieldGroup>
+          <Text variant="body3" color="$neutral2">
+            Timelock (Block Height)
+          </Text>
+          <StyledInput
+            value={formData.timelock}
+            onChangeText={(value: string) => handleInputChange('timelock', value)}
+            placeholder="12345678"
+          />
+          <Text variant="body4" color="$neutral3" fontSize={11}>
+            The block number when the lockup expires
+          </Text>
+        </FieldGroup>
+
+        <FieldGroup>
+          <Text variant="body3" color="$neutral2">
+            Amount {selectedTokenInfo && `(${selectedTokenInfo.symbol})`}
+          </Text>
+          <StyledInput
+            value={formData.amount}
+            onChangeText={(value: string) => handleInputChange('amount', value)}
+            placeholder={
+              selectedTokenInfo?.decimals === 8
+                ? '0.001'
+                : selectedTokenInfo?.decimals === 6
+                  ? '10.0'
+                  : '1.0'
+            }
+            inputMode="decimal"
+          />
+          <Text variant="body4" color="$neutral3" fontSize={11}>
+            {selectedTokenInfo ? (
+              <>
+                Enter amount in {selectedTokenInfo.symbol}. Examples:{' '}
+                {selectedTokenInfo.decimals === 8
+                  ? '0.001 (100,000 sats)'
+                  : selectedTokenInfo.decimals === 6
+                    ? '10.0 (10,000,000 units)'
+                    : '1.0 (1e18 wei)'}
+              </>
+            ) : (
+              'Select a token first'
+            )}
+          </Text>
+        </FieldGroup>
+
+        <SubmitButton onPress={handleSubmit} disabled={isSubmitting || !account.address}>
+          <Text variant="buttonLabel2" color="$white">
+            {isSubmitting ? 'Creating Lockup...' : account.address ? 'Create Lockup' : 'Connect Wallet'}
+          </Text>
+        </SubmitButton>
+      </Card>
+
+      {error && (
+        <WarningBanner>
+          <AlertTriangle color="$statusCritical" size="$icon.20" />
+          <Text variant="body3" color="$statusCritical">
+            {error}
+          </Text>
+        </WarningBanner>
+      )}
+
+      {txHash && (
+        <SuccessBanner>
+          <CheckCircleFilled color="$statusSuccess" size="$icon.20" />
+          <Flex gap="$spacing4" flex={1}>
+            <Text variant="body3" color="$statusSuccess" fontWeight="600">
+              Lockup Created Successfully!
+            </Text>
+            <Text variant="body4" color="$neutral2" fontFamily="$mono" fontSize={11}>
+              TX: {txHash}
+            </Text>
+            <Button
+              onPress={() => window.open(getExplorerUrl(txHash), '_blank')}
+              backgroundColor="transparent"
+              padding="$none"
+            >
+              <Text variant="body4" color="$accent1" fontSize={11}>
+                View on Explorer →
+              </Text>
+            </Button>
+          </Flex>
+        </SuccessBanner>
+      )}
+    </PageWrapper>
+  )
+}

--- a/apps/web/src/pages/RouteDefinitions.tsx
+++ b/apps/web/src/pages/RouteDefinitions.tsx
@@ -44,6 +44,7 @@ const LaunchpadCreate = lazy(() => import('pages/Launchpad/Create'))
 const BridgeSwaps = lazy(() => import('pages/BridgeSwaps'))
 const JuicePage = lazy(() => import('pages/Juice'))
 const JusdPage = lazy(() => import('pages/Jusd'))
+const DebugLockup = lazy(() => import('pages/DebugLockup'))
 
 interface RouterConfig {
   browserRouterEnabled?: boolean
@@ -429,6 +430,17 @@ export const routes: RouteDefinition[] = [
     getTitle: () => 'JuiceDollar (JUSD) | JuiceSwap',
     getDescription: () =>
       'Learn how JUSD, the decentralized stablecoin of JuiceDollar, works. Oracle-free, overcollateralized, and built on cypherpunk principles.',
+  }),
+  // Debug Lockup - Create lockups manually for testing
+  createRouteDefinition({
+    path: '/debug/lockup',
+    getElement: () => (
+      <Suspense fallback={null}>
+        <DebugLockup />
+      </Suspense>
+    ),
+    getTitle: () => 'Debug: Create Lockup | JuiceSwap',
+    getDescription: () => 'Manually create lockup transactions for testing purposes.',
   }),
   createRouteDefinition({ path: '*', getElement: () => <Navigate to="/not-found" replace /> }),
   createRouteDefinition({ path: '/not-found', getElement: () => <NotFound /> }),

--- a/apps/web/src/pages/Swap/index.tsx
+++ b/apps/web/src/pages/Swap/index.tsx
@@ -8,7 +8,7 @@ import { PageWrapper } from 'components/swap/styled'
 import { useAccount } from 'hooks/useAccount'
 import { useBAppsSwapTracking } from 'hooks/useBAppsSwapTracking'
 import { useCrossChainSwapsEnabled } from 'hooks/useCrossChainSwapsEnabled'
-import { useEvmRefundableSwaps } from 'hooks/useEvmRefundableSwaps'
+import { useEvmClaimableAndRefundableSwaps } from 'hooks/useEvmRefundableSwaps'
 import { useModalState } from 'hooks/useModalState'
 import { useRefundableSwaps } from 'hooks/useRefundableSwaps'
 import { RiseIn } from 'pages/Landing/components/animations'
@@ -89,7 +89,7 @@ export default function SwapPage() {
 
   const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
   const { data: refundableSwaps = [] } = useRefundableSwaps(crossChainSwapsEnabled)
-  const { data: evmRefundableSwaps = { refundable: [], locked: [] } } = useEvmRefundableSwaps(crossChainSwapsEnabled)
+  const { data: evmRefundableSwaps = { refundable: [], locked: [], claimable: [] } } = useEvmClaimableAndRefundableSwaps(crossChainSwapsEnabled)
 
   useEffect(() => {
     if (triggerConnect) {
@@ -99,17 +99,24 @@ export default function SwapPage() {
   }, [accountDrawer, triggerConnect, navigate, location.pathname])
 
   useEffect(() => {
-    if (refundableSwaps.length > 0 || evmRefundableSwaps.refundable.length > 0) {
+    const refundableCount = refundableSwaps.length + evmRefundableSwaps.refundable.length
+    const claimableCount = evmRefundableSwaps.claimable.length
+
+    // Remove existing popup first to ensure it refreshes with new counts
+    popupRegistry.removePopup('refundable-swaps')
+
+    if (refundableCount > 0 || claimableCount > 0) {
       popupRegistry.addPopup(
         {
           type: PopupType.RefundableSwaps,
-          count: refundableSwaps.length + evmRefundableSwaps.refundable.length,
+          refundableCount,
+          claimableCount,
         },
         'refundable-swaps',
         Infinity,
       )
     }
-  }, [refundableSwaps.length, evmRefundableSwaps.refundable.length])
+  }, [refundableSwaps.length, evmRefundableSwaps.refundable.length, evmRefundableSwaps.claimable.length])
 
   return (
     <Trace logImpression page={InterfacePageName.SwapPage}>

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -350,15 +350,12 @@ class LdsBridgeManager extends SwapEventEmitter {
       throw new Error('Swap not found')
     }
 
-    if (swap.status === LdsSwapStatus.TransactionClaimed) {
-      return swap
-    }
-
     // Wait for Ponder to confirm lockup before claiming.
     const chainId = ASSET_CHAIN_ID_MAP[swap.assetReceive]
     if (!chainId) {
       throw new Error('Chain ID not found')
     }
+
     const { promise: ponderPromise, cancel: cancelPonderPolling } = pollForLockupConfirmation(swap.preimageHash, chainId)
     await ponderPromise
     cancelPonderPolling()

--- a/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
@@ -226,9 +226,9 @@ export interface RegisterPreimageResponse {
   success: boolean
 }
 
-export interface EvmRefundableLockup {
+export interface EvmLockup {
   preimageHash: string
-  chainId: string
+  chainId: number
   amount: string
   claimAddress: string
   refundAddress: string
@@ -243,8 +243,11 @@ export interface EvmRefundableLockup {
 
 export interface LockupsResponse {
   data: {
-    lockupss: {
-      items: EvmRefundableLockup[]
+    refundable: {
+      items: EvmLockup[]
+    }
+    claimable: {
+      items: EvmLockup[]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds ability to claim EVM-based bridge swaps when they're ready
- New `ClaimableSwapsSection` component displays swaps available for claiming
- New `useEvmClaim` hook handles claim execution via `LdsBridgeManager.autoClaimSwap`
- Updates GraphQL queries to fetch both refundable and claimable lockups
- Adds claim success popup with transaction explorer links
- Includes debug lockup page (`/debug/lockup`) for testing lockup creation
- Updates popup notifications to differentiate between claimable and refundable swaps

## Test plan
- [ ] Test claiming flow on supported chains (Ethereum, Polygon, Citrea)
- [ ] Verify claimable swaps appear in the UI when conditions are met
- [ ] Confirm claim success popup shows with correct explorer link
- [ ] Test debug lockup page for creating test lockups
- [ ] Verify refundable vs claimable swap counts display correctly