### PR TITLE
Fix: show actual error messages for limit orders and approval errors

### DIFF
--- a/apps/web/src/components/ConfirmSwapModal/Error.tsx
+++ b/apps/web/src/components/ConfirmSwapModal/Error.tsx
@@ -22,25 +22,35 @@ interface ErrorModalContentProps {
   showTrade?: boolean
   swapResult?: SwapResult
   onRetry: () => void
+  /** The actual error object, if available. Used to show specific error messages. */
+  error?: Error
 }
 
-function getErrorContent({ errorType, trade }: { errorType: PendingModalError; trade?: InterfaceTrade }): {
+function getErrorContent({
+  errorType,
+  trade,
+  error,
+}: {
+  errorType: PendingModalError
+  trade?: InterfaceTrade
+  error?: Error
+}): {
   title: JSX.Element
-  message?: JSX.Element
+  message?: JSX.Element | string
   supportArticleURL?: string
 } {
   switch (errorType) {
     case PendingModalError.TOKEN_APPROVAL_ERROR:
       return {
         title: <Trans i18nKey="error.tokenApproval" />,
-        message: <Trans i18nKey="error.tokenApproval.message" />,
+        message: error?.message || <Trans i18nKey="error.tokenApproval.message" />,
         // TODO: Re-enable once support.juiceswap.com is configured
         // supportArticleURL: uniswapUrls.helpArticleUrls.approvalsExplainer,
       }
     case PendingModalError.PERMIT_ERROR:
       return {
         title: <Trans i18nKey="permit.approval.fail" />,
-        message: <Trans i18nKey="permit.approval.fail.message" />,
+        message: error?.message || <Trans i18nKey="permit.approval.fail.message" />,
         // TODO: Re-enable once support.juiceswap.com is configured
         // supportArticleURL: uniswapUrls.helpArticleUrls.approvalsExplainer,
       }
@@ -55,13 +65,16 @@ function getErrorContent({ errorType, trade }: { errorType: PendingModalError; t
       if (isLimitTrade(trade)) {
         return {
           title: <Trans i18nKey="common.limit.failed" />,
+          // Show the actual error message if available, otherwise use generic limit failure message
+          message: error?.message || <Trans i18nKey="limit.fail.generic" />,
           // TODO: Re-enable once support.juiceswap.com is configured
           // supportArticleURL: uniswapUrls.helpArticleUrls.limitsFailure,
         }
       } else {
         return {
           title: <Trans i18nKey="common.swap.failed" />,
-          message: <Trans i18nKey="swap.fail.message" />,
+          // Show the actual error message if available, otherwise use generic swap failure message
+          message: error?.message || <Trans i18nKey="swap.fail.generic" />,
           // TODO: Re-enable once support.juiceswap.com is configured
           // supportArticleURL: isUniswapXTrade(trade)
           //   ? uniswapUrls.helpArticleUrls.uniswapXFailure
@@ -71,20 +84,20 @@ function getErrorContent({ errorType, trade }: { errorType: PendingModalError; t
     case PendingModalError.WRAP_ERROR:
       return {
         title: <Trans i18nKey="common.wrap.failed" />,
-        message: <Trans i18nKey="token.wrap.fail.message" />,
+        message: error?.message || <Trans i18nKey="token.wrap.fail.message" />,
         // TODO: Re-enable once support.juiceswap.com is configured
         // supportArticleURL: uniswapUrls.helpArticleUrls.wethExplainer,
       }
     default:
       return {
         title: <Trans i18nKey="common.unknownError.error" />,
-        message: <Trans i18nKey="common.swap.failed" />,
+        message: error?.message || <Trans i18nKey="common.swap.failed" />,
       }
   }
 }
 
-export default function Error({ errorType, trade, showTrade, swapResult, onRetry }: ErrorModalContentProps) {
-  const { title, message } = getErrorContent({ errorType, trade })
+export default function Error({ errorType, trade, showTrade, swapResult, onRetry, error }: ErrorModalContentProps) {
+  const { title, message } = getErrorContent({ errorType, trade, error })
   const { t } = useTranslation()
 
   return (

--- a/apps/web/src/components/ConfirmSwapModal/index.tsx
+++ b/apps/web/src/components/ConfirmSwapModal/index.tsx
@@ -84,6 +84,7 @@ export function ConfirmSwapModal({
     priceUpdate,
     doesTradeDiffer,
     approvalError,
+    approvalErrorDetails,
     wrapTxHash,
     startSwapFlow,
     onCancel,
@@ -280,6 +281,7 @@ export function ConfirmSwapModal({
               showTrade={errorType !== PendingModalError.XV2_HARD_QUOTE_ERROR}
               swapResult={swapResult}
               errorType={errorType}
+              error={swapError ?? approvalErrorDetails}
               onRetry={() => {
                 if (errorType === PendingModalError.XV2_HARD_QUOTE_ERROR) {
                   onXV2RetryWithClassic?.()

--- a/apps/web/src/hooks/useConfirmModalState.ts
+++ b/apps/web/src/hooks/useConfirmModalState.ts
@@ -48,6 +48,7 @@ export function useConfirmModalState({
 }) {
   const [confirmModalState, setConfirmModalState] = useState<ConfirmModalState>(ConfirmModalState.REVIEWING)
   const [approvalError, setApprovalError] = useState<PendingModalError>()
+  const [approvalErrorDetails, setApprovalErrorDetails] = useState<Error>()
   const [pendingModalSteps, setPendingModalSteps] = useState<PendingConfirmModalState[]>([])
   const { formatCurrencyAmount } = useLocalizationContext()
 
@@ -101,6 +102,7 @@ export function useConfirmModalState({
       }
       logger.warn('useConfirmModalState', 'catchUserReject', 'Failed to wrap', { error: e, trade })
       setApprovalError(errorType)
+      setApprovalErrorDetails(e instanceof Error ? e : new Error(String(e)))
     },
     [trade],
   )
@@ -231,6 +233,7 @@ export function useConfirmModalState({
   const onCancel = () => {
     setConfirmModalState(ConfirmModalState.REVIEWING)
     setApprovalError(undefined)
+    setApprovalErrorDetails(undefined)
   }
 
   const [lastExecutionPrice, setLastExecutionPrice] = useState(trade.executionPrice)
@@ -249,6 +252,7 @@ export function useConfirmModalState({
     confirmModalState,
     doesTradeDiffer,
     approvalError,
+    approvalErrorDetails,
     pendingModalSteps,
     priceUpdate,
     wrapTxHash,

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -1007,6 +1007,7 @@
   "language.vietnamese": "Vietnamese",
   "large.price.difference": "Large price difference",
   "large.price.difference.tooltip": "Proceeding with this trade will result in a loss of funds. This difference can be due to large trades or low liquidity.",
+  "limit.fail.generic": "Limit order failed. Please try again.",
   "limit.open.count_one": "1 open limit",
   "limit.open.count_other": "{{count}} open limits",
   "limitPrice.buyingAboveMarketPrice.error.description": "Your limit price is {{percentage}}% higher than market. Adjust your limit price to proceed.",


### PR DESCRIPTION
## Summary
- Pass actual error object through ConfirmSwapModal error flow
- Add `approvalErrorDetails` state to `useConfirmModalState` hook
- Update `Error.tsx` to display real error message when available
- Add `limit.fail.generic` i18n string for limit order fallback

## Problem
The `ConfirmSwapModal` (used for Limit Orders) was showing generic error messages like "Try adjusting slippage to a higher value" even when:
- The error was a limit order submission failure
- The error was a token approval failure
- The actual error message was available

This is a follow-up to PR #564 which fixed the same issue for normal swaps and bridges.

## Solution
1. Store the actual error object in `useConfirmModalState` via `approvalErrorDetails`
2. Pass both `swapError` and `approvalErrorDetails` to the Error component
3. Display the actual error message when available, falling back to generic messages

## Test plan
- [ ] Trigger a limit order failure → should show actual error, not slippage hint
- [ ] Trigger a token approval failure → should show actual error
- [ ] Trigger a wrap failure → should show actual error