### PR TITLE
fix: remove white background from token logos

### DIFF
--- a/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
+++ b/packages/uniswap/src/components/CurrencyLogo/TokenLogo.tsx
@@ -1,5 +1,5 @@
-import { memo, useState } from 'react'
-import { Flex, Loader, Text, TextProps, UniversalImage, useColorSchemeFromSeed, useSporeColors } from 'ui/src'
+import { memo } from 'react'
+import { Flex, Loader, Text, TextProps, UniversalImage, useColorSchemeFromSeed } from 'ui/src'
 import { iconSizes, validColor, zIndexes } from 'ui/src/theme'
 import { STATUS_RATIO } from 'uniswap/src/components/CurrencyLogo/CurrencyLogo'
 import { NetworkLogo } from 'uniswap/src/components/CurrencyLogo/NetworkLogo'
@@ -60,10 +60,6 @@ export const TokenLogo = memo(function _TokenLogo({
     }
   }
 
-  // We want to avoid the extra render on mobile when updating the state, so we set this to `true` from the start.
-  const [showBackground, setShowBackground] = useState(isMobileApp ? true : false)
-
-  const colors = useSporeColors()
   const { foreground, background } = useColorSchemeFromSeed(name ?? symbol ?? '')
 
   const borderWidth = isTestnetToken ? size / TESTNET_BORDER_DIVISOR : 0
@@ -122,20 +118,6 @@ export const TokenLogo = memo(function _TokenLogo({
       width={size}
       position="relative"
     >
-      {!isTestnetToken && (
-        <Flex
-          opacity={showBackground ? 1 : 0}
-          height="96%"
-          width="96%"
-          zIndex={zIndexes.background}
-          backgroundColor={colors.white.val}
-          position="absolute"
-          top="2%"
-          left="2%"
-          borderRadius={size / 2}
-        />
-      )}
-
       <UniversalImage
         allowLocalUri
         fallback={fallback}
@@ -148,7 +130,6 @@ export const TokenLogo = memo(function _TokenLogo({
         }}
         testID="token-image"
         uri={logoUrl ?? undefined}
-        onLoad={() => setShowBackground(true)}
       />
 
       {isTestnetToken && (


### PR DESCRIPTION
close #573

### Changes
- Removed white background circle that appeared behind token logos in dark mode
- Cleaned up unused animation state

### Before
<img width="150" height="78" alt="image" src="https://github.com/user-attachments/assets/6a7f16ca-5723-4f87-bc01-cb472077be76" />

### After
<img width="151" height="81" alt="image" src="https://github.com/user-attachments/assets/8196cbeb-20de-4bf5-a60f-59bf03e1707d" />


### Files Changed
- `TokenLogo.tsx` - Removed background