### PR TITLE
fix: display actual error message for WBTC bridge failures

### DIFF
--- a/apps/web/src/state/sagas/transactions/wbtcBridge.ts
+++ b/apps/web/src/state/sagas/transactions/wbtcBridge.ts
@@ -5,6 +5,7 @@ import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
 import { clientToProvider } from 'hooks/useEthersProvider'
 import { waitForNetwork } from 'state/sagas/transactions/chainSwitchUtils'
 import { call } from 'typed-redux-saga'
+import { getFetchErrorMessage } from 'uniswap/src/data/apiClients/FetchError'
 import {
   WBTC_ETHEREUM_ADDRESS,
   WbtcBridgeDirection,
@@ -27,6 +28,14 @@ import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
 import { logger } from 'utilities/src/logger/logger'
 import type { Chain, Client, Transport } from 'viem'
 import { getAccount, getConnectorClient } from 'wagmi/actions'
+
+function getErrorMessage(error: unknown): string {
+  const fetchErrorMsg = getFetchErrorMessage(error)
+  if (fetchErrorMsg) {
+    return fetchErrorMsg
+  }
+  return error instanceof Error ? error.message : String(error)
+}
 
 async function getConnectorClientForChain(chainId: UniverseChainId): Promise<Client<Transport, Chain> | undefined> {
   try {
@@ -177,7 +186,7 @@ export function* handleWbtcBridge(params: HandleWbtcBridgeParams) {
       extra: { createChainSwapParams },
     })
     throw new TransactionStepFailedError({
-      message: `Failed to create WBTC bridge swap: ${error instanceof Error ? error.message : String(error)}`,
+      message: `Failed to create WBTC bridge swap: ${getErrorMessage(error)}`,
       step,
       originalError: error instanceof Error ? error : new Error(String(error)),
     })

--- a/packages/uniswap/src/features/transactions/errors.ts
+++ b/packages/uniswap/src/features/transactions/errors.ts
@@ -1,6 +1,6 @@
 import { datadogRum } from '@datadog/browser-rum'
 import { AppTFunction } from 'ui/src/i18n/types'
-import { FetchError } from 'uniswap/src/data/apiClients/FetchError'
+import { FetchError, getFetchErrorMessage } from 'uniswap/src/data/apiClients/FetchError'
 import { TokenApprovalTransactionStep } from 'uniswap/src/features/transactions/steps/approve'
 import { TokenRevocationTransactionStep } from 'uniswap/src/features/transactions/steps/revoke'
 import { TransactionStep, TransactionStepType } from 'uniswap/src/features/transactions/steps/types'
@@ -191,6 +191,11 @@ function getSwapErrorMessage(error: TransactionStepFailedError, t: AppTFunction)
  * Falls back to a generic message if no specific error details are available.
  */
 function getBridgeErrorMessage(error: TransactionStepFailedError, fallback: string): string {
+  // Try to get the actual error message from FetchError.data first
+  const fetchErrorMsg = getFetchErrorMessage(error.originalError)
+  if (fetchErrorMsg) {
+    return fetchErrorMsg
+  }
   // Try to get the original error message (most specific)
   if (error.originalError?.message) {
     return error.originalError.message


### PR DESCRIPTION
## Summary

- Extract error message from FetchError.data instead of showing generic "Response status: 400"
- Users now see meaningful messages like "insufficient liquidity" when bridge swaps fail

## Changes

- Add `getFetchErrorMessage` helper to `wbtcBridge.ts`
- Update `getBridgeErrorMessage` in `errors.ts` to check `FetchError.data` first

## Test plan

- [ ] Trigger a WBTC bridge swap with insufficient liquidity
- [ ] Verify the actual error message is displayed instead of "Response status: 400"