### PR TITLE
fix(landing): place "Scroll to learn more" below Citrea logo in hero

### DIFF
--- a/apps/web/src/pages/Landing/sections/Hero.tsx
+++ b/apps/web/src/pages/Landing/sections/Hero.tsx
@@ -388,56 +388,39 @@ export function Hero({ scrollToRef, transition }: HeroProps) {
           </Flex>
         </RiseIn>
 
-        {/* Secondary subtitle */}
+        {/* Secondary subtitle + Citrea logo + scroll CTA */}
         <RiseIn delay={0.3}>
-          <Flex
-            flexDirection="column"
-            alignItems="center"
-            justifyContent="center"
-            pointerEvents="none"
-            gap="$gap4"
-            mt={4}
-          >
-            <Text variant="body2" color="$neutral2">
-              <Trans i18nKey="hero.subtitle" />
-            </Text>
-            <img src="/images/logos/Citrea_Full_Logo.svg" alt="Citrea Logo" width={200} height="auto" />
+          <Flex flexDirection="column" alignItems="center" justifyContent="center" gap="$gap4" mt={4}>
+            <Flex flexDirection="column" alignItems="center" pointerEvents="none">
+              <Text variant="body2" color="$neutral2">
+                <Trans i18nKey="hero.subtitle" />
+              </Text>
+              <img src="/images/logos/Citrea_Full_Logo.svg" alt="Citrea Logo" width={200} height="auto" />
+            </Flex>
+            {!showBAppsContent && (
+              <Flex
+                alignItems="center"
+                justifyContent="center"
+                onPress={() => scrollToRef()}
+                cursor="pointer"
+                pt="$spacing8"
+                $lgHeight={{ display: 'none' }}
+              >
+                <Hover>
+                  <ColumnCenter>
+                    <Text variant="body2">
+                      <Trans i18nKey="hero.scroll" />
+                    </Text>
+                    <ChevronDown />
+                  </ColumnCenter>
+                </Hover>
+              </Flex>
+            )}
           </Flex>
         </RiseIn>
       </Flex>
 
       <Flex flex={1} />
-
-      {!showBAppsContent && (
-        <Flex
-          position="absolute"
-          width="100%"
-          centered
-          pointerEvents="none"
-          bottom={48}
-          style={{ transform: `translate(0px, ${translateY}px), opacity: ${opacityY}` }}
-          $lgHeight={{ display: 'none' }}
-        >
-          <RiseIn delay={0.3}>
-            <Flex
-              alignItems="center"
-              justifyContent="flex-start"
-              onPress={() => scrollToRef()}
-              cursor="pointer"
-              width={500}
-            >
-              <Hover>
-                <ColumnCenter>
-                  <Text variant="body2">
-                    <Trans i18nKey="hero.scroll" />
-                  </Text>
-                  <ChevronDown />
-                </ColumnCenter>
-              </Hover>
-            </Flex>
-          </RiseIn>
-        </Flex>
-      )}
     </Flex>
   )
 }


### PR DESCRIPTION
## Summary
Fixes the hero section so "Scroll to learn more" always appears **below** the Citrea logo instead of overlapping or appearing above it on some viewports.

## Changes
- Moved the scroll CTA from absolute positioning (bottom of hero) into the document flow, directly under the "Your Swap Hub on" + Citrea logo block.
- Kept the `$lgHeight` conditional: "Scroll to learn more" is hidden when viewport height ≤ 960px to avoid crowding on short screens.
- Kept the `!showBAppsContent` conditional so the scroll prompt stays hidden when the BApps campaign is visible.

## Visual order (when visible)
1. Your Swap Hub on  
2. Citrea logo  
3. Scroll to learn more + chevron

<img width="211" height="107" alt="image" src="https://github.com/user-attachments/assets/d96b40eb-3c4d-4788-9277-3cff1a43fb86" />
