### PR TITLE
feat: track claim transactions and unsubscribe from websocket after claim

### DIFF
--- a/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
+++ b/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
@@ -13,6 +13,7 @@ import { ChainTransactionsResponse } from 'uniswap/src/features/lds-bridge/lds-t
 import { ChainSwap, SomeSwap, SwapType } from 'uniswap/src/features/lds-bridge/lds-types/storage'
 import { LdsSwapStatus, swapStatusSuccess } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
 import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
+import { ellipseMiddle } from 'utilities/src/addresses'
 
 const Card = styled(Flex, {
   backgroundColor: '$surface2',
@@ -397,6 +398,25 @@ export function SwapCard({ swap }: SwapCardProps): JSX.Element {
           <DetailRow>
             <DetailLabel>Status:</DetailLabel>
             <DetailValue>{swap.status || 'Unknown'}</DetailValue>
+          </DetailRow>
+
+          <DetailRow>
+            <DetailLabel>User Address:</DetailLabel>
+            <DetailValue>
+              <TxLink
+                tag="a"
+                href={getExplorerLink({
+                  chainId: ASSET_CHAIN_ID_MAP[swap.assetReceive],
+                  type: ExplorerDataType.ADDRESS,
+                  data: swap.claimAddress,
+                })}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              >
+                {ellipseMiddle({ str: swap.claimAddress, charsEnd: 7, charsStart: 7 })}
+              </TxLink>
+            </DetailValue>
           </DetailRow>
 
           {/* Chain Swap: Show all transactions from API data */}

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeCitreaToBitcoin.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeCitreaToBitcoin.ts
@@ -143,6 +143,7 @@ export function* handleBitcoinBridgeCitreaToBitcoin(params: HandleBitcoinBridgeC
   //
 
   const { id: txHash } = yield* call(broadcastChainSwap, claimTx.toHex())
+  yield* call(ldsBridge.updateSwapClaimTx, chainSwap.id, txHash)
 
   popupRegistry.removePopup(chainSwap.id)
 

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -385,7 +385,23 @@ class LdsBridgeManager extends SwapEventEmitter {
       throw new Error('Swap not found')
     }
 
+    this.socketClient.unsubscribeFromSwapById(swapId)
+
     swap.refundTx = refundTxId
+    await this.storageManager.setSwap(swapId, swap)
+    await this._notifySwapChanges()
+  }
+
+  updateSwapClaimTx = async (swapId: string, claimTxId: string): Promise<void> => {
+    const swap = await this.storageManager.getSwap(swapId)
+    if (!swap) {
+      throw new Error('Swap not found')
+    }
+    
+    this.socketClient.unsubscribeFromSwapById(swapId)
+    
+    swap.claimTx = claimTxId
+    swap.status = LdsSwapStatus.UserClaimed
     await this.storageManager.setSwap(swapId, swap)
     await this._notifySwapChanges()
   }

--- a/packages/uniswap/src/features/lds-bridge/api/socket.ts
+++ b/packages/uniswap/src/features/lds-bridge/api/socket.ts
@@ -4,6 +4,7 @@ export const createLdsSocketClient = (): {
   disconnect: () => void
   subscribeToSwapUpdates: (swapId: string, callback: (event: SwapUpdateEvent) => void) => () => void
   unsubscribeFromSwapUpdates: (callback: (event: SwapUpdateEvent) => void) => void
+  unsubscribeFromSwapById: (swapId: string) => void
 } => {
   const apiUrl = process.env.REACT_APP_LDS_API_URL
   if (!apiUrl) {
@@ -86,6 +87,12 @@ export const createLdsSocketClient = (): {
     })
   }
 
+  const unsubscribeFromSwapById = (swapId: string): void => {
+    listeners.delete(swapId)
+    subscribedSwaps.delete(swapId)
+    pendingSubscriptions.delete(swapId)
+  }
+
   socket.onmessage = (event: MessageEvent): void => {
     const data = JSON.parse(event.data) as WebSocketMessage
     if (data.event === 'update' && data.channel === 'swap.update') {
@@ -105,5 +112,6 @@ export const createLdsSocketClient = (): {
     disconnect,
     subscribeToSwapUpdates,
     unsubscribeFromSwapUpdates,
+    unsubscribeFromSwapById,
   }
 }


### PR DESCRIPTION
## Summary
- Add user address display in SwapCard with explorer link for better transaction tracking
- Update swap with claim transaction hash after broadcasting for accurate status tracking
- Unsubscribe from websocket updates when swap is claimed or refunded to prevent unnecessary updates
- Set swap status to UserClaimed after claim transaction completes

## Test plan
- [ ] Verify user address displays correctly in SwapCard with working explorer link
- [ ] Confirm claim transaction hash is stored after broadcasting
- [ ] Check that websocket unsubscribes after swap is claimed
- [ ] Verify swap status updates to UserClaimed after claim
- [ ] Test that refund transactions also trigger websocket unsubscribe