### PR TITLE
feat: enhance bridge swap refund handling and user feedback

### DIFF
--- a/apps/web/src/pages/BridgeSwaps/RefundableSwapsSection.tsx
+++ b/apps/web/src/pages/BridgeSwaps/RefundableSwapsSection.tsx
@@ -2,7 +2,6 @@ import { popupRegistry } from 'components/Popups/registry'
 import { PopupType } from 'components/Popups/types'
 import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
 import { useEvmRefund } from 'hooks/useEvmRefund'
-import { EvmRefundableLockup } from 'hooks/useEvmRefundableSwaps'
 import { AddressInput, RefundButton, RefundableSection, RefundableSwapCard } from 'pages/BridgeSwaps/styles'
 import { formatSatoshiAmount } from 'pages/BridgeSwaps/utils'
 import { useCallback, useMemo, useState } from 'react'
@@ -14,6 +13,7 @@ import { AlertTriangleFilled } from 'ui/src/components/icons/AlertTriangleFilled
 import { CheckCircleFilled } from 'ui/src/components/icons/CheckCircleFilled'
 import { useValidateBitcoinAddress } from 'uniswap/src/data/apiClients/tradingApi/useValidateBitcoinAddress'
 import { getChainLabel, isUniverseChainId } from 'uniswap/src/features/chains/utils'
+import { EvmRefundableLockup } from 'uniswap/src/features/lds-bridge'
 import { SomeSwap } from 'uniswap/src/features/lds-bridge/lds-types/storage'
 import { prefix0x } from 'uniswap/src/features/lds-bridge/utils/hex'
 import { logger } from 'utilities/src/logger/logger'
@@ -53,8 +53,8 @@ function RefundableSwapCardItem({
     return !isError && validationData?.validated === true
   }, [address, isError, validationData])
 
-  const showError = address.trim() && isValid === false
-  const showSuccess = address.trim() && isValid === true
+  const showError = !!address.trim() && isValid === false
+  const showSuccess = !!address.trim() && isValid === true
 
   return (
     <RefundableSwapCard>

--- a/apps/web/src/pages/BridgeSwaps/SwapCard.styles.ts
+++ b/apps/web/src/pages/BridgeSwaps/SwapCard.styles.ts
@@ -1,0 +1,104 @@
+import { Flex, Text, styled } from 'ui/src'
+
+export const Card = styled(Flex, {
+  backgroundColor: '$surface2',
+  borderRadius: '$rounded16',
+  padding: '$spacing16',
+  gap: '$spacing12',
+  cursor: 'pointer',
+  pressStyle: {
+    opacity: 0.9,
+  },
+  hoverStyle: {
+    backgroundColor: '$surface3',
+  },
+})
+
+export const CardHeader = styled(Flex, {
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+})
+
+export const SwapInfo = styled(Flex, {
+  flex: 1,
+  gap: '$spacing8',
+})
+
+export const SwapAmounts = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing8',
+  flexWrap: 'wrap',
+})
+
+export const StatusBadge = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing4',
+  paddingHorizontal: '$spacing12',
+  paddingVertical: '$spacing4',
+  borderRadius: '$rounded8',
+  variants: {
+    status: {
+      pending: {
+        backgroundColor: '$DEP_accentWarning',
+      },
+      completed: {
+        backgroundColor: '$statusSuccess',
+      },
+      failed: {
+        backgroundColor: '$statusCritical',
+      },
+    },
+  },
+})
+
+export const DetailRow = styled(Flex, {
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  paddingVertical: '$spacing4',
+  gap: '$spacing8',
+})
+
+export const DetailLabel = styled(Text, {
+  variant: 'body3',
+  color: '$neutral2',
+})
+
+export const DetailValue = styled(Text, {
+  variant: 'body3',
+  color: '$neutral1',
+  fontFamily: '$mono',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: '60%',
+})
+
+export const TxLink = styled(Text, {
+  variant: 'body3',
+  color: '$accent1',
+  fontFamily: '$mono',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: '60%',
+  cursor: 'pointer',
+  textDecorationLine: 'none',
+  hoverStyle: {
+    textDecorationLine: 'underline',
+  },
+})
+
+export const ExpandButton = styled(Flex, {
+  padding: '$spacing8',
+  borderRadius: '$rounded8',
+  variants: {
+    expanded: {
+      true: {
+        transform: [{ rotate: '180deg' }],
+      },
+    },
+  },
+})

--- a/packages/uniswap/src/features/lds-bridge/api/client.ts
+++ b/packages/uniswap/src/features/lds-bridge/api/client.ts
@@ -134,7 +134,7 @@ export async function broadcastChainSwap(hex: string): Promise<{ id: string }> {
   })
 }
 
-export async function fetchSwapCurrentStatus(swapId: string): Promise<{ status: LdsSwapStatus }> {
+export async function fetchSwapCurrentStatus(swapId: string): Promise<{ status: LdsSwapStatus, failureReason?: string }> {
   return await LdsApiClient.get<{ status: LdsSwapStatus }>(`/swap/v2/swap/${swapId}`)
 }
 


### PR DESCRIPTION
## Summary
- Added Bitcoin network support to chain tip block number queries with appropriate refresh intervals
- Implemented refund ETA display showing remaining blocks until refund becomes available
- Added failure reason display in expanded swap cards for better error visibility
- Improved refundable swap filtering logic to prevent false positives and only show truly refundable swaps
- Added loading states to prevent premature popup display before data is fetched
- Extracted SwapCard styles to separate file for better code organization
- Updated swap status to `UserRefunded` after successful refund execution
- Cleaned up debug console logs from `LdsBridgeManager`
- Added `failureReason` field to swap status API response type

## Test plan
- [x] Verify Bitcoin and EVM chain tip queries work correctly
- [x] Confirm refund ETA displays accurate remaining blocks
- [x] Check failure reasons show in expanded swap cards
- [x] Validate refundable swap filtering excludes non-refundable states
- [x] Test popup only appears after loading completes
- [x] Verify styles render correctly after extraction