### PR TITLE
fix: adjust refund ETA calculation to include timeout block

### DIFF
--- a/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
+++ b/apps/web/src/pages/BridgeSwaps/SwapCard.tsx
@@ -270,7 +270,9 @@ const useRefundEtaEstimate = (swap: SomeSwap) => {
   const currentTip = useChainTipBlockNumber(ASSET_CHAIN_ID_MAP[swap.assetSend], isEligibleForRefund)
   const timeoutBlockHeight = Number(lockupDetails?.timeoutBlockHeight)
   const remainingBlocks =
-    Number(timeoutBlockHeight) - Number(currentTip.data) > 0 ? Number(timeoutBlockHeight) - Number(currentTip.data) : 0
+    1 + Number(timeoutBlockHeight) - Number(currentTip.data) > 0
+      ? 1 + Number(timeoutBlockHeight) - Number(currentTip.data)
+      : 0
 
   return {
     isEligibleForRefund: isEligibleForRefund && !isNonRefundableStatus,


### PR DESCRIPTION
## Summary
- Fixed refund ETA calculation to add 1 to the remaining blocks count
- This ensures the timeout block itself is included in the countdown
- Prevents showing "Available for refund" one block early

## Test plan
- [x] Verify refund becomes available at the correct block height
- [x] Confirm countdown shows accurate remaining blocks including timeout block