### PR TITLE
feat: improve bridge error handling and refactor swap state polling

### DIFF
--- a/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
+++ b/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
@@ -80,7 +80,7 @@ function WebUniswapProviderInner({ children }: PropsWithChildren) {
   )
 
   const navigateToBridgesSwaps = useCallback(() => {
-    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+    navigate('/bridge-swaps')
   }, [])
 
   const navigateToUrl = useCallback(

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
@@ -34,6 +34,8 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
     userLockAmount,
     chainId: citreaChainId,
   })
+
+  step.backendAccepted = true
   step.bip21 = chainSwapResponse.lockupDetails.bip21
   setCurrentStep({ step, accepted: true })
 

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeCitreaToBitcoin.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeCitreaToBitcoin.ts
@@ -54,6 +54,8 @@ export function* handleBitcoinBridgeCitreaToBitcoin(params: HandleBitcoinBridgeC
     chainId: citreaChainId,
   })
 
+  step.backendAccepted = true
+
   // Ensure wallet is on Citrea before signing the lockup transaction
   yield* call(ensureCorrectChain, {
     targetChainId: citreaChainId,

--- a/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
+++ b/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
@@ -229,6 +229,8 @@ export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
     })
   }
 
+  step.backendAccepted = true
+
   // Update step to show swap creation is complete, now waiting for lockup
   setCurrentStep({ step, accepted: false })
 

--- a/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
@@ -35,6 +35,8 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
   })
 
   step.invoice = reverseSwap.invoice as string
+  step.backendAccepted = true
+
   setCurrentStep({ step, accepted: true })
 
   yield* call([ldsBridge, ldsBridge.waitForSwapUntilState], reverseSwap.id, LdsSwapStatus.TransactionConfirmed)

--- a/apps/web/src/state/sagas/transactions/lightningBridgeSubmarine.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeSubmarine.ts
@@ -51,6 +51,8 @@ export function* handleLightningBridgeSubmarine(params: HandleLightningBridgeSub
     chainId: citreaChainId,
   })
 
+  step.backendAccepted = true
+
   // Ensure wallet is on Citrea before signing the lockup transaction
   yield* call(ensureCorrectChain, {
     targetChainId: citreaChainId,

--- a/packages/uniswap/src/features/lds-bridge/lds-types/websocket.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/websocket.ts
@@ -111,6 +111,7 @@ export function getSwapStatusCategory(status?: LdsSwapStatus): 'pending' | 'succ
 export interface SwapUpdateEvent {
   id?: string
   status: LdsSwapStatus
+  failureReason?: string
 }
 
 export interface WebSocketMessage {

--- a/packages/uniswap/src/features/transactions/errors.ts
+++ b/packages/uniswap/src/features/transactions/errors.ts
@@ -269,18 +269,21 @@ function getStepSpecificErrorContent(
       return {
         title: t('common.swap.failed'),
         message: getBridgeErrorMessage(error, t('bridge.fail.message')),
+        buttonText: error.step.backendAccepted ? "Go to my bridge swaps" : undefined,
       }
     case TransactionStepType.BitcoinBridgeCitreaToBitcoinStep:
     case TransactionStepType.BitcoinBridgeBitcoinToCitreaStep:
       return {
         title: t('common.swap.failed'),
         message: getBridgeErrorMessage(error, t('bridge.fail.message')),
+        buttonText: error.step.backendAccepted ? "Go to my bridge swaps" : undefined,
       }
     case TransactionStepType.LightningBridgeSubmarineStep:
     case TransactionStepType.LightningBridgeReverseStep:
       return {
         title: t('common.swap.failed'),
         message: getBridgeErrorMessage(error, t('bridge.fail.message')),
+        buttonText: error.step.backendAccepted ? "Go to my bridge swaps" : undefined,
       }
     case TransactionStepType.WbtcBridgeStep:
       return {

--- a/packages/uniswap/src/features/transactions/swap/steps/bitcoinBridge.ts
+++ b/packages/uniswap/src/features/transactions/swap/steps/bitcoinBridge.ts
@@ -3,11 +3,13 @@ import { TransactionStepType } from 'uniswap/src/features/transactions/steps/typ
 
 export interface BitcoinBridgeCitreaToBitcoinStep {
   type: TransactionStepType.BitcoinBridgeCitreaToBitcoinStep
+  backendAccepted?: boolean
 }
 
 export interface BitcoinBridgeBitcoinToCitreaStep {
   type: TransactionStepType.BitcoinBridgeBitcoinToCitreaStep
   bip21?: string
+  backendAccepted?: boolean
 }
 
 export type BitcoinBridgeTransactionStep = BitcoinBridgeCitreaToBitcoinStep | BitcoinBridgeBitcoinToCitreaStep

--- a/packages/uniswap/src/features/transactions/swap/steps/erc20ChainSwap.ts
+++ b/packages/uniswap/src/features/transactions/swap/steps/erc20ChainSwap.ts
@@ -20,6 +20,7 @@ export interface Erc20ChainSwapStep {
   direction: Erc20ChainSwapDirection
   subStep?: Erc20ChainSwapSubStep
   txHash?: string
+  backendAccepted?: boolean
 }
 
 export const createErc20ChainSwapStep = (direction: Erc20ChainSwapDirection): Erc20ChainSwapStep => {

--- a/packages/uniswap/src/features/transactions/swap/steps/lightningBridge.ts
+++ b/packages/uniswap/src/features/transactions/swap/steps/lightningBridge.ts
@@ -3,11 +3,13 @@ import { TransactionStepType } from 'uniswap/src/features/transactions/steps/typ
 
 export interface LightningBridgeSubmarineStep {
   type: TransactionStepType.LightningBridgeSubmarineStep
+  backendAccepted?: boolean
 }
 
 export interface LightningBridgeReverseStep {
   type: TransactionStepType.LightningBridgeReverseStep
   invoice?: string
+  backendAccepted?: boolean
 }
 
 export type LightningBridgeTransactionStep = LightningBridgeSubmarineStep | LightningBridgeReverseStep


### PR DESCRIPTION
## Summary
- Refactored `LdsBridgeManager.waitForSwapUntilState()` for better maintainability
- Enhanced bridge error handling with backend acceptance tracking
- Improved error modal UX with navigation to bridge swaps page

## Changes

### Code Quality Improvements
- **Refactored swap state polling** (`LdsBridgeManager.ts`)
  - Replaced complex Promise with manual flags with `AbortController` pattern
  - Separated concerns into `waitViaWebSocket`, `pollUntilState`, and `timeoutPromise` methods
  - Eliminated race conditions from manual `resolved` flag management
  - Increased polling interval from 3s to 15s for reduced API load

### Enhanced Error Handling
- **Backend acceptance tracking**
  - Added `backendAccepted` flag to all bridge step types (Bitcoin, Lightning, ERC20)
  - Set flag after successful swap creation in all bridge sagas
  - Enables differentiated error handling based on swap lifecycle stage

- **Improved error messages**
  - Added `failureReason` to `SwapUpdateEvent` for WebSocket error propagation
  - Custom button text "Go to my bridge swaps" when backend has accepted swap
  - More user-friendly error messages throughout

### Better UX
- **Error modal improvements** (`SwapErrorScreen.tsx`)
  - Navigate to `/bridge-swaps` when backend-accepted swap fails
  - Close modal immediately before navigation (prevents visual flash)
  - Use `UniswapContext` for cross-platform navigation

- **Navigation fix** (`WebUniswapContext.tsx`)
  - Changed from `window.open` to `navigate` for cleaner in-app navigation

## Test Plan
- [x] Test swap error scenarios with backend-accepted flag set
- [x] Verify modal closes before navigation
- [x] Verify error button shows correct text based on swap state
- [x] Test WebSocket state polling refactor
- [x] Verify no linter errors

closes #593