### PR TITLE
feat: add abandoned swap status and optimize swap synchronization

### DIFF
--- a/apps/web/src/pages/BridgeSwaps/SwapCard.styles.ts
+++ b/apps/web/src/pages/BridgeSwaps/SwapCard.styles.ts
@@ -51,6 +51,9 @@ export const StatusBadge = styled(Flex, {
       failed: {
         backgroundColor: '$statusCritical',
       },
+      abandoned: {
+        backgroundColor: '$neutral3',
+      },
     },
   },
 })

--- a/packages/uniswap/src/features/lds-bridge/api/client.ts
+++ b/packages/uniswap/src/features/lds-bridge/api/client.ts
@@ -23,6 +23,7 @@ import type {
   UserClaimsAndRefundsResponse,
 } from 'uniswap/src/features/lds-bridge/lds-types/api'
 import { LdsSwapStatus } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
+import { prefix0x } from '..'
 
 export type {
   ChainPairsResponse,
@@ -250,4 +251,36 @@ export async function fetchUserClaimsAndRefunds(address: string): Promise<UserCl
     claims: response.data.myClaims.items.filter((item) => item.claimTxHash != null),
     refunds: response.data.myRefunds.items.filter((item) => item.refundTxHash != null),
   }
+}
+
+export async function fetchLockupsByPreimageHashes(preimageHashes: string[]): Promise<{ data: { lockupss: { items: EvmLockup[] | null } } }> {
+  return await LdsApiClient.post<{ data: { lockupss: { items: EvmLockup[] | null } } }>('/claim/graphql', {
+    body: JSON.stringify({
+      query: `{
+        lockupss(
+          where: {
+            preimageHash_in: [${preimageHashes.map((hash) => `"${prefix0x(hash)}"`).join(',')}]
+          }
+          limit: 1000
+        ) {
+          items {
+            id
+            preimageHash
+            chainId
+            amount
+            claimAddress
+            refundAddress
+            timelock
+            tokenAddress
+            swapType
+            claimed
+            refunded
+            claimTxHash
+            refundTxHash
+            lockupTxHash
+          }
+        }
+      }`,
+    }),
+  })
 }

--- a/packages/uniswap/src/features/lds-bridge/lds-types/websocket.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/websocket.ts
@@ -25,6 +25,7 @@ export enum LdsSwapStatus {
   // Local user statuses (not from LDS)
   UserRefunded = 'local.userRefunded',
   UserClaimed = 'local.userClaimed',
+  UserAbandoned = 'local.userAbandoned',
 }
 
 export const swapStatusPending = {
@@ -61,7 +62,14 @@ export const swapStatusFinal = [
   ...Object.values(swapStatusSuccess),
   LdsSwapStatus.UserRefunded,
   LdsSwapStatus.UserClaimed,
+  LdsSwapStatus.UserAbandoned,
   swapStatusPending.TransactionClaimPending, // Stop polling once claim is pending
+]
+
+export const localUserFinalStatuses = [
+  LdsSwapStatus.UserRefunded,
+  LdsSwapStatus.UserClaimed,
+  LdsSwapStatus.UserAbandoned,
 ]
 
 // Chain swap status progression order (for ERC20 chain swaps)


### PR DESCRIPTION
## Summary
- Added `UserAbandoned` status to identify swaps where users never funded the transaction
- Optimized swap synchronization by batching GraphQL queries for incomplete swaps only
- Enhanced swap lifecycle management for both EVM and Bitcoin chains

## Changes

### New Status: UserAbandoned
- Created `localUserFinalStatuses` array containing user-driven final states
- Added "No payment sent" badge with neutral grey styling
- Prevents unnecessary refund eligibility checks for abandoned swaps

### Sync Optimization
- Replaced full user claims/refunds query with targeted `fetchLockupsByPreimageHashes`
- Only queries swaps without claim/refund transactions and not in final states
- Reduces API load and improves performance

### Abandoned Swap Detection
- **EVM Swaps**: Marks expired swaps with no on-chain lockup as abandoned
- **BTC Swaps**: Checks mempool for lockup transactions, marks as abandoned if none found
- Automatically updates swap status during background sync

## Test plan
- [ ] Verify abandoned swaps display "No payment sent" badge
- [ ] Confirm refund button doesn't appear for abandoned swaps
- [ ] Test that expired EVM swaps without lockups are marked abandoned
- [ ] Test that BTC swaps without mempool activity are marked abandoned
- [ ] Verify sync performance improvement with multiple incomplete swaps