### PR TITLE
Hide swapp across network bridge pairs

### DIFF
--- a/apps/web/src/components/Liquidity/Create/SelectTokenStep.tsx
+++ b/apps/web/src/components/Liquidity/Create/SelectTokenStep.tsx
@@ -678,6 +678,7 @@ export function SelectTokensStep({
           switchNetworkAction={SwitchNetworkAction.LP}
           onCurrencySelect={handleCurrencySelect}
           chainIds={supportedChains}
+          hideBridgingSection
         />
       </PrefetchBalancesWrapper>
     </>

--- a/apps/web/src/components/SearchModal/CurrencySearch.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearch.tsx
@@ -24,6 +24,7 @@ interface CurrencySearchProps {
   onCurrencySelect: (currency: Currency) => void
   onDismiss: () => void
   chainIds?: UniverseChainId[]
+  hideBridgingSection?: boolean
 }
 
 export function CurrencySearch({
@@ -32,6 +33,7 @@ export function CurrencySearch({
   onCurrencySelect,
   onDismiss,
   chainIds,
+  hideBridgingSection,
 }: CurrencySearchProps) {
   const account = useAccount()
   const { chainId, setSelectedChainId, isUserSelectedToken, setIsUserSelectedToken, isMultichainContext } =
@@ -83,6 +85,7 @@ export function CurrencySearch({
           }
           onClose={onDismiss}
           onSelectCurrency={handleCurrencySelectTokenSelectorCallback}
+          hideBridgingSection={hideBridgingSection}
         />
       </Flex>
     </Trace>

--- a/apps/web/src/components/SearchModal/CurrencySearchModal.tsx
+++ b/apps/web/src/components/SearchModal/CurrencySearchModal.tsx
@@ -18,6 +18,7 @@ interface CurrencySearchModalProps {
   showCurrencyAmount?: boolean
   currencyField?: CurrencyField
   chainIds?: UniverseChainId[]
+  hideBridgingSection?: boolean
 }
 
 export default memo(function CurrencySearchModal({
@@ -27,6 +28,7 @@ export default memo(function CurrencySearchModal({
   currencyField = CurrencyField.INPUT,
   switchNetworkAction,
   chainIds,
+  hideBridgingSection,
 }: CurrencySearchModalProps) {
   return (
     <Modal
@@ -45,6 +47,7 @@ export default memo(function CurrencySearchModal({
         switchNetworkAction={switchNetworkAction}
         onDismiss={onDismiss}
         chainIds={chainIds}
+        hideBridgingSection={hideBridgingSection}
       />
     </Modal>
   )

--- a/apps/web/src/components/Tokens/TokenDetails/index.tsx
+++ b/apps/web/src/components/Tokens/TokenDetails/index.tsx
@@ -196,6 +196,7 @@ function TDPSwapComponent() {
         initialOutputCurrency={initialOutputCurrency}
         onCurrencyChange={handleCurrencyChange}
         tokenColor={tokenColor}
+        hideBridgingSection
       />
       <TokenWarningCard currencyInfo={currencyInfo} onPress={() => setShowWarningModal(true)} />
       {currencyInfo && (

--- a/apps/web/src/pages/Swap/index.tsx
+++ b/apps/web/src/pages/Swap/index.tsx
@@ -179,6 +179,7 @@ export function Swap({
   swapRedirectCallback,
   tokenColor,
   usePersistedFilteredChainIds = false,
+  hideBridgingSection = false,
 }: {
   chainId?: UniverseChainId
   onCurrencyChange?: (selected: CurrencyState) => void
@@ -193,6 +194,7 @@ export function Swap({
   tokenColor?: string
   usePersistedFilteredChainIds?: boolean
   passkeyAuthStatus?: PasskeyAuthStatus
+  hideBridgingSection?: boolean
 }) {
   const input = currencyToAsset(initialInputCurrency)
   const output = currencyToAsset(initialOutputCurrency)
@@ -233,6 +235,7 @@ export function Swap({
                   onCurrencyChange={onCurrencyChange}
                   prefilledState={prefilledState}
                   tokenColor={tokenColor}
+                  hideBridgingSection={hideBridgingSection}
                 />
               </Flex>
             </SwapFormStoreContextProvider>
@@ -258,6 +261,7 @@ function UniversalSwapFlow({
   onCurrencyChange,
   swapRedirectCallback,
   tokenColor,
+  hideBridgingSection = false,
 }: {
   hideHeader?: boolean
   hideFooter?: boolean
@@ -267,6 +271,7 @@ function UniversalSwapFlow({
   onCurrencyChange?: (selected: CurrencyState, isBridgePair?: boolean) => void
   swapRedirectCallback?: SwapRedirectFn
   tokenColor?: string
+  hideBridgingSection?: boolean
 }) {
   const [currentTab, setCurrentTab] = useState(SwapTab.Swap)
   const { pathname } = useLocation()
@@ -359,6 +364,7 @@ function UniversalSwapFlow({
                 prefilledState={prefilledState}
                 tokenColor={tokenColor}
                 onSubmitSwap={handleSubmitSwap}
+                hideBridgingSection={hideBridgingSection}
               />
             </SwapDependenciesStoreContextProvider>
             {!hideFooter && (

--- a/packages/uniswap/src/components/TokenSelector/TokenSelector.tsx
+++ b/packages/uniswap/src/components/TokenSelector/TokenSelector.tsx
@@ -67,6 +67,7 @@ export interface TokenSelectorProps {
   output?: TradeableAsset
   isSurfaceReady?: boolean
   isLimits?: boolean
+  hideBridgingSection?: boolean
   onClose: () => void
   focusHook?: ComponentProps<typeof BottomSheetView>['focusHook']
   onSelectChain?: (chainId: UniverseChainId | null) => void
@@ -94,6 +95,7 @@ export function TokenSelectorContent({
   chainIds,
   isSurfaceReady = true,
   isLimits,
+  hideBridgingSection = false,
   onClose,
   onSelectChain,
   onSelectCurrency,
@@ -261,6 +263,7 @@ export function TokenSelectorContent({
             oppositeSelectedToken={output}
             activeAccountAddress={activeAccountAddress}
             chainFilter={chainFilter}
+            hideBridgingSection={hideBridgingSection}
             onSelectCurrency={onSelectCurrencyCallback}
           />
         )
@@ -270,6 +273,7 @@ export function TokenSelectorContent({
             oppositeSelectedToken={input}
             activeAccountAddress={activeAccountAddress}
             chainFilter={chainFilter}
+            hideBridgingSection={hideBridgingSection}
             onSelectCurrency={onSelectCurrencyCallback}
           />
         )
@@ -290,6 +294,7 @@ export function TokenSelectorContent({
     input,
     onSendEmptyActionPress,
     output,
+    hideBridgingSection,
   ])
 
   return (

--- a/packages/uniswap/src/components/TokenSelector/lists/TokenSelectorSwapList.tsx
+++ b/packages/uniswap/src/components/TokenSelector/lists/TokenSelectorSwapList.tsx
@@ -16,7 +16,10 @@ function useTokenSectionsForSwap({
   activeAccountAddress,
   chainFilter,
   oppositeSelectedToken,
-}: TokenSectionsHookProps): GqlResult<OnchainItemSection<TokenSelectorOption>[]> {
+  hideBridgingSection = false,
+}: TokenSectionsHookProps & { hideBridgingSection?: boolean }): GqlResult<
+  OnchainItemSection<TokenSelectorOption>[]
+> {
   const { defaultChainId } = useEnabledChains()
 
   // Compute effective chain filter once, use for all hooks to ensure consistent filtering
@@ -48,7 +51,10 @@ function useTokenSectionsForSwap({
 
   const { data: bridgePairOptions } = useCommonBridgeTokensOptions()
 
-  const loading = !commonTokenOptions && commonTokenOptionsLoading && bridgingTokenOptionsLoading
+  const loading =
+    !commonTokenOptions &&
+    commonTokenOptionsLoading &&
+    (hideBridgingSection || bridgingTokenOptionsLoading)
 
   const refetchAllRef = useRef<() => void>(() => {})
 
@@ -73,8 +79,8 @@ function useTokenSectionsForSwap({
   })
 
   const bridgingSectionTokenOptions: TokenSelectorOption[] = useMemo(
-    () => bridgePairOptions ?? [],
-    [bridgePairOptions],
+    () => (hideBridgingSection ? [] : (bridgePairOptions ?? [])),
+    [bridgePairOptions, hideBridgingSection],
   )
 
   const bridgingSection = useOnchainItemListSection({
@@ -87,8 +93,19 @@ function useTokenSectionsForSwap({
       return undefined
     }
 
+    if (hideBridgingSection) {
+      return [...(suggestedSection ?? []), ...(yourTokensSection ?? [])]
+    }
+
     return [...(suggestedSection ?? []), ...(bridgingSection ?? []), ...(yourTokensSection ?? [])]
-  }, [commonTokenOptionsLoading, portfolioTokenOptionsLoading, suggestedSection, yourTokensSection, bridgingSection])
+  }, [
+    commonTokenOptionsLoading,
+    portfolioTokenOptionsLoading,
+    suggestedSection,
+    yourTokensSection,
+    bridgingSection,
+    hideBridgingSection,
+  ])
 
   return useMemo(
     () => ({
@@ -106,9 +123,11 @@ function _TokenSelectorSwapList({
   activeAccountAddress,
   chainFilter,
   oppositeSelectedToken,
+  hideBridgingSection = false,
 }: TokenSectionsHookProps & {
   onSelectCurrency: OnSelectCurrency
   chainFilter: UniverseChainId | null
+  hideBridgingSection?: boolean
 }): JSX.Element {
   const {
     data: sections,
@@ -119,6 +138,7 @@ function _TokenSelectorSwapList({
     activeAccountAddress,
     chainFilter,
     oppositeSelectedToken,
+    hideBridgingSection,
   })
 
   return (

--- a/packages/uniswap/src/features/transactions/swap/SwapFlow/CurrentScreen.native.tsx
+++ b/packages/uniswap/src/features/transactions/swap/SwapFlow/CurrentScreen.native.tsx
@@ -20,10 +20,12 @@ import { useTimeout } from 'utilities/src/time/timing'
 export function CurrentScreen({
   settings,
   onSubmitSwap,
+  hideBridgingSection,
 }: {
   settings: TransactionSettingConfig[]
   onSubmitSwap?: (txHash?: string) => Promise<void> | void
   tokenColor?: string
+  hideBridgingSection?: boolean
 }): JSX.Element {
   const { screen } = useTransactionModalContext()
 
@@ -31,7 +33,7 @@ export function CurrentScreen({
     case TransactionScreen.Form:
       return (
         <Trace logImpression section={SectionName.SwapForm}>
-          <SwapFormScreenDelayedRender settings={settings} />
+          <SwapFormScreenDelayedRender settings={settings} hideBridgingSection={hideBridgingSection} />
           <TransactionModalFooterContainer>
             <SwapFormWarningStoreContextProvider>
               <SwapFormButton />
@@ -58,10 +60,23 @@ const SWAP_FORM_SCREEN_TRANSITION_DELAY = 75
 const SWAP_REVIEW_SCREEN_TRANSITION_DELAY = 450
 
 // We add a short hardcoded delay to allow the sheet to animate quickly both on first render and when going back from Review -> Form.
-function SwapFormScreenDelayedRender({ settings }: { settings: TransactionSettingConfig[] }): JSX.Element {
+function SwapFormScreenDelayedRender({
+  settings,
+  hideBridgingSection,
+}: {
+  settings: TransactionSettingConfig[]
+  hideBridgingSection?: boolean
+}): JSX.Element {
   const { isContentHidden } = useDelayedRender(SWAP_FORM_SCREEN_TRANSITION_DELAY)
 
-  return <SwapFormScreen settings={settings} hideContent={isContentHidden} focusHook={useFocusEffect} />
+  return (
+    <SwapFormScreen
+      settings={settings}
+      hideContent={isContentHidden}
+      focusHook={useFocusEffect}
+      hideBridgingSection={hideBridgingSection}
+    />
+  )
 }
 
 // We add a short hardcoded delay to allow the sheet to animate quickly when going from Form -> Review.

--- a/packages/uniswap/src/features/transactions/swap/SwapFlow/CurrentScreen.tsx
+++ b/packages/uniswap/src/features/transactions/swap/SwapFlow/CurrentScreen.tsx
@@ -5,6 +5,7 @@ export function CurrentScreen(_props: {
   settings: TransactionSettingConfig[]
   onSubmitSwap?: (txHash?: string) => Promise<void> | void
   tokenColor?: string
+  hideBridgingSection?: boolean
 }): JSX.Element {
   throw new PlatformSplitStubError('CurrentScreen')
 }

--- a/packages/uniswap/src/features/transactions/swap/SwapFlow/CurrentScreen.web.tsx
+++ b/packages/uniswap/src/features/transactions/swap/SwapFlow/CurrentScreen.web.tsx
@@ -17,10 +17,12 @@ export function CurrentScreen({
   settings,
   onSubmitSwap,
   tokenColor,
+  hideBridgingSection,
 }: {
   settings: TransactionSettingConfig[]
   onSubmitSwap?: (txHash?: string) => Promise<void> | void
   tokenColor?: string
+  hideBridgingSection?: boolean
 }): JSX.Element {
   const { screen, setScreen } = useTransactionModalContext()
 
@@ -30,7 +32,12 @@ export function CurrentScreen({
   return (
     <>
       <Trace logImpression section={SectionName.SwapForm}>
-        <SwapFormScreen settings={settings} hideContent={false} tokenColor={tokenColor} />
+        <SwapFormScreen
+          settings={settings}
+          hideContent={false}
+          tokenColor={tokenColor}
+          hideBridgingSection={hideBridgingSection}
+        />
       </Trace>
 
       {/*

--- a/packages/uniswap/src/features/transactions/swap/SwapFlow/SwapFlow.tsx
+++ b/packages/uniswap/src/features/transactions/swap/SwapFlow/SwapFlow.tsx
@@ -21,9 +21,16 @@ export interface SwapFlowProps extends Omit<TransactionModalProps, 'fullscreen' 
   hideFooter?: boolean
   onSubmitSwap?: (txHash?: string) => Promise<void> | void
   tokenColor?: string
+  hideBridgingSection?: boolean
 }
 
-export function SwapFlow({ settings, onSubmitSwap, tokenColor, ...transactionModalProps }: SwapFlowProps): JSX.Element {
+export function SwapFlow({
+  settings,
+  onSubmitSwap,
+  tokenColor,
+  hideBridgingSection,
+  ...transactionModalProps
+}: SwapFlowProps): JSX.Element {
   const transactionSettingsContext = useGetTransactionSettingsContextValue()
   const swapDependenciesStore = useSwapDependenciesStoreBase()
   const swapFormStore = useSwapFormStoreBase()
@@ -37,7 +44,12 @@ export function SwapFlow({ settings, onSubmitSwap, tokenColor, ...transactionMod
           {/* Re-create the SwapTxStoreContextProvider, since rendering within a Portal causes its children to be in a separate component tree. */}
           <SwapTxStoreContextProvider>
             <SwapDependenciesStoreContext.Provider value={swapDependenciesStore}>
-              <CurrentScreen settings={settings} tokenColor={tokenColor} onSubmitSwap={onSubmitSwap} />
+              <CurrentScreen
+                settings={settings}
+                tokenColor={tokenColor}
+                onSubmitSwap={onSubmitSwap}
+                hideBridgingSection={hideBridgingSection}
+              />
             </SwapDependenciesStoreContext.Provider>
           </SwapTxStoreContextProvider>
         </SwapFormStoreContext.Provider>

--- a/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormScreen.tsx
+++ b/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormScreen.tsx
@@ -32,6 +32,7 @@ interface SwapFormScreenProps {
   settings: TransactionSettingConfig[]
   tokenColor?: string
   focusHook?: ComponentProps<typeof BottomSheetView>['focusHook']
+  hideBridgingSection?: boolean
 }
 
 const EXIT_STYLE: FlexProps['exitStyle'] = { opacity: 0 }
@@ -45,6 +46,7 @@ export function SwapFormScreen({
   settings = [Slippage, TradeRoutingPreference],
   tokenColor,
   focusHook,
+  hideBridgingSection,
 }: SwapFormScreenProps): JSX.Element {
   const { bottomSheetViewStyles } = useTransactionModalContext()
   const { selectingCurrencyField, hideSettings } = useSwapFormStore((s) => ({
@@ -68,7 +70,11 @@ export function SwapFormScreen({
         </SwapFormScreenStoreContextProvider>
       )}
 
-      <SwapTokenSelector isModalOpen={showTokenSelector} focusHook={focusHook} />
+      <SwapTokenSelector
+        isModalOpen={showTokenSelector}
+        focusHook={focusHook}
+        hideBridgingSection={hideBridgingSection}
+      />
     </TransactionModalInnerContainer>
   )
 }

--- a/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapTokenSelector/SwapTokenSelector.tsx
+++ b/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapTokenSelector/SwapTokenSelector.tsx
@@ -12,9 +12,11 @@ import { CurrencyField } from 'uniswap/src/types/currency'
 export function SwapTokenSelector({
   isModalOpen,
   focusHook,
+  hideBridgingSection,
 }: {
   isModalOpen: boolean
   focusHook?: ComponentProps<typeof BottomSheetView>['focusHook']
+  hideBridgingSection?: boolean
 }): JSX.Element | null {
   const { selectingCurrencyField, input, output } = useSwapFormStore((s) => ({
     selectingCurrencyField: s.selectingCurrencyField,
@@ -55,6 +57,7 @@ export function SwapTokenSelector({
       focusHook={focusHook}
       onClose={handleHideTokenSelector}
       onSelectCurrency={onSelectCurrency}
+      hideBridgingSection={hideBridgingSection}
     />
   )
 }


### PR DESCRIPTION
## Summary
Hides the **“Swap across networks”** section in the token picker where cross-network bridge shortcuts are not appropriate.

## Changes
- **Create liquidity:** `CurrencySearchModal` passes `hideBridgingSection` so the picker shows only default shortcuts and **Your tokens**.
- **Token details page (embedded swap):** `Swap` passes `hideBridgingSection` so the Sell/Buy token modal matches the same behavior.
- **Shared:** Optional `hideBridgingSection` on `TokenSelector` / swap list; plumbed through `SwapFlow` → `SwapFormScreen` → `SwapTokenSelector`. `CurrentScreen` stub props updated for type-checking.