### PR TITLE
LN to Citrea success toast opens Citrea tx explorer

### DIFF
--- a/apps/web/src/components/Popups/PopupContent.tsx
+++ b/apps/web/src/components/Popups/PopupContent.tsx
@@ -244,10 +244,12 @@ export function BridgingPopupContent({ hash, onClose }: { hash: string; onClose:
 export function LightningBridgePopupContent({
   direction,
   status,
+  url,
   onClose,
 }: {
   direction: LightningBridgeDirection
   status: LdsBridgeStatus
+  url?: string
   onClose: () => void
 }) {
   const { t } = useTranslation()
@@ -291,7 +293,7 @@ export function LightningBridgePopupContent({
   const isPending = status === LdsBridgeStatus.Pending
 
   const onClick = () => {
-    window.open('/bridge-swaps', '_blank', 'noopener,noreferrer')
+    window.open(url, '_blank', 'noopener,noreferrer')
     onClose()
   }
 

--- a/apps/web/src/components/Popups/PopupItem.tsx
+++ b/apps/web/src/components/Popups/PopupItem.tsx
@@ -85,7 +85,14 @@ export function PopupItem({ content, onClose }: { content: PopupContent; popKey:
       )
     }
     case PopupType.LightningBridge: {
-      return <LightningBridgePopupContent direction={content.direction} status={content.status} onClose={onClose} />
+      return (
+        <LightningBridgePopupContent
+          direction={content.direction}
+          status={content.status}
+          url={content.url}
+          onClose={onClose}
+        />
+      )
     }
     case PopupType.BitcoinBridge: {
       return (

--- a/apps/web/src/components/Popups/types.ts
+++ b/apps/web/src/components/Popups/types.ts
@@ -90,6 +90,7 @@ export type PopupContent =
       id: string
       direction: LightningBridgeDirection
       status: LdsBridgeStatus
+      url?: string
     }
   | {
       type: PopupType.BitcoinBridge

--- a/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
@@ -14,6 +14,7 @@ import {
 import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
 import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
+import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
 
 interface HandleLightningBridgeReverseParams {
   step: LightningBridgeReverseStep
@@ -89,19 +90,7 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
     accepted: true,
   })
 
-  popupRegistry.addPopup(
-    {
-      type: PopupType.LightningBridge,
-      id: reverseSwap.id,
-      direction: LightningBridgeDirection.Reverse,
-      status: LdsBridgeStatus.Pending,
-    },
-    reverseSwap.id,
-  )
-
   const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], reverseSwap)
-
-  popupRegistry.removePopup(reverseSwap.id)
 
   if (claimResponse.pending) {
     setCurrentStep({
@@ -114,15 +103,24 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
       accepted: true,
     })
 
-    popupRegistry.addPopup(
-      {
-        type: PopupType.LightningBridge,
-        id: claimResponse.txHash,
-        direction: LightningBridgeDirection.Reverse,
-        status: LdsBridgeStatus.Confirmed,
-      },
-      claimResponse.txHash,
-    )
+    const explorerUrl = getExplorerLink({
+      chainId: citreaChainId,
+      data: claimResponse.txHash,
+      type: ExplorerDataType.TRANSACTION,
+    })
+
+    if (explorerUrl) {
+      popupRegistry.addPopup(
+        {
+          type: PopupType.LightningBridge,
+          id: claimResponse.txHash,
+          direction: LightningBridgeDirection.Reverse,
+          status: LdsBridgeStatus.Confirmed,
+          url: explorerUrl,
+        },
+        claimResponse.txHash,
+      )
+    }
 
     if (onSuccess) {
       yield* call(onSuccess)


### PR DESCRIPTION
Success toast only after claim; passes explorer url from saga. Removes interim pending toast during claim. Confirmed clicks use explorer when url is set, not /bridge-swaps.