### PR TITLE
LDS activity row: explorer link for claimed swaps

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/ActivityRow.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/ActivityRow.tsx
@@ -73,6 +73,7 @@ function StatusIndicator({
 export function ActivityRow({ activity }: { activity: Activity }) {
   const {
     chainId,
+    outputChainId,
     title,
     descriptor,
     otherAccount,
@@ -94,8 +95,21 @@ export function ActivityRow({ activity }: { activity: Activity }) {
 
   const explorerUrl = getExplorerLink({ chainId, data: txHash ?? hash, type: ExplorerDataType.TRANSACTION })
 
+  const ldsClaimExplorerUrl =
+    hash.startsWith(LDS_ACTIVITY_PREFIX) && txHash && isHash(txHash)
+      ? getExplorerLink({
+          chainId: outputChainId ?? chainId,
+          data: txHash,
+          type: ExplorerDataType.TRANSACTION,
+        })
+      : undefined
+
   const onClick = useCallback(() => {
     if (hash.startsWith(LDS_ACTIVITY_PREFIX)) {
+      if (activity.status === TransactionStatus.Success && ldsClaimExplorerUrl) {
+        window.open(ldsClaimExplorerUrl, '_blank')
+        return
+      }
       navigate('/bridge-swaps')
       return
     }
@@ -113,13 +127,26 @@ export function ActivityRow({ activity }: { activity: Activity }) {
     }
 
     window.open(explorerUrl, '_blank')
-  }, [activity.logos, activity.status, explorerUrl, hash, navigate, offchainOrderDetails, openOffchainActivityModal])
+  }, [
+    activity.logos,
+    activity.status,
+    explorerUrl,
+    hash,
+    navigate,
+    offchainOrderDetails,
+    openOffchainActivityModal,
+    ldsClaimExplorerUrl,
+  ])
 
   return (
     <Trace
       logPress
       element={ElementName.MiniPortfolioActivityRow}
-      properties={{ hash, chain_id: chainId, explorer_url: explorerUrl }}
+      properties={{
+        hash,
+        chain_id: chainId,
+        explorer_url: ldsClaimExplorerUrl ?? explorerUrl,
+      }}
     >
       <PortfolioRow
         left={

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.tsx
@@ -231,6 +231,7 @@ export function swapToActivity(swap: SomeSwap & { id: string }): Activity {
     logos: [getAssetLogo(swap.assetSend), getAssetLogo(swap.assetReceive)],
     from: swap.claimAddress,
     type: TransactionType.Bridging,
+    txHash: swap.claimTx ?? undefined,
   }
 }
 


### PR DESCRIPTION
Mini portfolio Activity: LDS bridge rows now include txHash when swap.claimTx exists. On row click, if the swap is successful and we have a valid EVM hash, we open the block explorer for that transaction on the destination chain (outputChainId, e.g. Citrea for LN → Citrea). Otherwise (pending, failed, or no claim hash), behavior is unchanged: navigate to /bridge-swaps. Telemetry uses the claim explorer URL when applicable.

Test plan:
- Complete a bridge swap (e.g. lnBTC → cBTC or BTC → cBTC) and wait until it finishes successfully with a claim transaction.
- Open the account drawer → Activity.
- Click the corresponding bridge row.

Expected: the browser opens the block explorer to the claim transaction (not only /bridge-swaps).