### PR TITLE
update LDS bridge BTC logo source and amount text styling

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/parseLdsBridge.tsx
@@ -1,4 +1,3 @@
-import bitcoinLogo from 'assets/images/coins/bitcoin.png'
 import { Activity, ActivityMap } from 'components/AccountDrawer/MiniPortfolio/Activity/types'
 import { inferChainIdFromSwap } from 'components/AccountDrawer/MiniPortfolio/Activity/utils'
 import { formatSatoshiAmount } from 'pages/BridgeSwaps/utils'
@@ -41,7 +40,7 @@ const LDS_ASSET_METADATA: Partial<Record<string, LdsAssetMetadata>> = {
   },
   BTC: {
     chainId: UniverseChainId.LightningNetwork,
-    logoUrl: bitcoinLogo,
+    logoUrl: 'https://assets.coingecko.com/coins/images/1/large/bitcoin.png',
     symbol: 'BTC',
   },
   // Citrea tokens
@@ -135,7 +134,8 @@ const StyledBridgeAmountText = styled(Text, {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  variant: 'body2',
+  variant: 'body3',
+  color: '$neutral2',
 })
 
 /**


### PR DESCRIPTION
Use a stable BTC logo URL and adjust bridge amount text to body3 + neutral2 for consistent activity row styling.

## Before:
<img width="379" height="351" alt="image" src="https://github.com/user-attachments/assets/4f201dc2-c2ea-434c-a189-65b58204e98c" />

## After:
<img width="392" height="492" alt="image" src="https://github.com/user-attachments/assets/1be09340-a656-4caf-a6de-db7c7aad72c3" />

