### PR TITLE
Use rpc.juiceswap.com for Citrea mainnet RPC

### DIFF
--- a/apps/web/public/csp.json
+++ b/apps/web/public/csp.json
@@ -117,7 +117,7 @@
     "https://ponder.juiceswap.com",
     "https://dev.ponder.juiceswap.com",
     "https://dev.rpc.testnet.juiceswap.com",
-    "https://rpc.citreascan.com",
+    "https://rpc.juiceswap.com",
     "https://lightning.space",
     "https://dev.lightning.space",
     "https://*.lightning.space",

--- a/apps/web/public/dev-csp.json
+++ b/apps/web/public/dev-csp.json
@@ -14,7 +14,7 @@
     "https://ponder.juiceswap.com",
     "https://dev.ponder.juiceswap.com",
     "https://dev.rpc.testnet.juiceswap.com",
-    "https://rpc.citreascan.com",
+    "https://rpc.juiceswap.com",
     "https://lightning.space",
     "https://dev.lightning.space",
     "https://*.lightning.space",

--- a/packages/uniswap/src/features/chains/evm/info/citrea-mainnet.ts
+++ b/packages/uniswap/src/features/chains/evm/info/citrea-mainnet.ts
@@ -42,10 +42,10 @@ const citreaMainnet = defineChain({
   },
   rpcUrls: {
     default: {
-      http: ['https://rpc.citreascan.com'],
+      http: ['https://rpc.juiceswap.com'],
     },
     public: {
-      http: ['https://rpc.citreascan.com'],
+      http: ['https://rpc.juiceswap.com'],
     },
   },
   blockExplorers: {
@@ -94,16 +94,16 @@ export const CITREA_MAINNET_CHAIN_INFO = {
   pendingTransactionsRetryOptions: undefined,
   rpcUrls: {
     [RPCType.Public]: {
-      http: ['https://rpc.citreascan.com'],
+      http: ['https://rpc.juiceswap.com'],
     },
     [RPCType.Default]: {
-      http: ['https://rpc.citreascan.com'],
+      http: ['https://rpc.juiceswap.com'],
     },
     [RPCType.Fallback]: {
-      http: ['https://rpc.citreascan.com'],
+      http: ['https://rpc.juiceswap.com'],
     },
     [RPCType.Interface]: {
-      http: ['https://rpc.citreascan.com'],
+      http: ['https://rpc.juiceswap.com'],
     },
   },
   // 100 JUSD for USD price quotes (JUSD has 18 decimals, so 100 * 10^18)


### PR DESCRIPTION
## Summary
- Replace `rpc.citreascan.com` with `rpc.juiceswap.com` for Citrea mainnet RPC
- Both resolve to the same Azure Front Door endpoint, but JuiceSwap should use its own branded domain
- Updated chain config, CSP policy (prod + dev)

## Test plan
- [ ] Verify RPC calls work with `rpc.juiceswap.com` (swap, liquidity, etc.)
- [ ] Verify CSP does not block RPC requests