### PR TITLE
Point Trading API docs URL to Swagger

### DIFF
--- a/packages/uniswap/src/constants/urls.ts
+++ b/packages/uniswap/src/constants/urls.ts
@@ -13,7 +13,7 @@ const tradingApiVersionPrefix = config.tradingApiWebTestEnv === 'true' ? '' : '/
 export const CHROME_EXTENSION_UNINSTALL_URL_PATH = '/extension/uninstall'
 
 export const uniswapUrls = {
-  tradingApiDocsUrl: 'https://api.juiceswap.com/',
+  tradingApiDocsUrl: 'https://api.juiceswap.com/swagger',
   unichainUrl: 'https://www.unichain.org/',
   uniswapXUrl: 'https://x.juiceswap.com/',
   helpCenterUrl: 'https://help.juiceswap.com/',


### PR DESCRIPTION
Updates `uniswapUrls.tradingApiDocsUrl` from `https://api.juiceswap.com/` to `https://api.juiceswap.com/swagger` so the Trading API card opens the Swagger UI.