### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.13.1'
           cache: 'yarn'

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -6,16 +6,16 @@ jobs:
   deploy-to-prod:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v6
 
       - name: 🧷️ Get version
-        uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b
+        uses: juliangruber/read-file-action@v1
         id: version
         with:
           path: VERSION
 
       - name: 🧾️ Get release notes
-        uses: juliangruber/read-file-action@02bbba9876a8f870efd4ad64e3b9088d3fb94d4b
+        uses: juliangruber/read-file-action@v1
         id: release-notes
         with:
           path: RELEASE
@@ -29,10 +29,8 @@ jobs:
           tag_prefix: ""
 
       - name: 🪽 Release
-        uses: actions/create-release@c9ba6969f07ed90fae07e2e66100dd03f9b1a50e
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.github-tag-action.outputs.new_tag }}
-          release_name: Release ${{ steps.github-tag-action.outputs.new_tag }}
+          name: Release ${{ steps.github-tag-action.outputs.new_tag }}
           body: ${{ steps.release-notes.outputs.content }}

--- a/.github/workflows/web-dev.yaml
+++ b/.github/workflows/web-dev.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.13.1'
           cache: 'yarn'
@@ -40,12 +40,12 @@ jobs:
           NODE_ENV: production
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_DEV_CREDENTIALS }}
 
       - name: Upload to Azure Storage
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             az storage blob upload-batch --account-name ${{ env.AZURE_ACCOUNT_NAME }} -d '$web' -s ./apps/web/build --overwrite

--- a/.github/workflows/web-prd.yaml
+++ b/.github/workflows/web-prd.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.13.1'
           cache: 'yarn'
@@ -40,12 +40,12 @@ jobs:
           NODE_ENV: production
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_PRD_CREDENTIALS }}
 
       - name: Upload to Azure Storage
-        uses: azure/CLI@v2
+        uses: azure/CLI@v3
         with:
           inlineScript: |
             az storage blob upload-batch --account-name ${{ env.AZURE_ACCOUNT_NAME }} -d '$web' -s ./apps/web/build --overwrite


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 → v6 and `actions/setup-node` v4 → v6
- Update `azure/login` v2 → v3 and `azure/CLI` v2 → v3
- Replace archived `actions/create-release` with `softprops/action-gh-release` v2
- Update `juliangruber/read-file-action` from pinned SHA to v1 tag

## Why
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026. This update moves all workflows to Node.js 24-compatible action versions.

## Affected workflows
- `web-dev.yaml` (DEV deploy)
- `web-prd.yaml` (PRD deploy)
- `build-check.yml` (PR build check)
- `auto-release-pr.yaml` (auto release PR)
- `tag_and_release.yml` (manual tag & release)

## Test plan
- [ ] Verify DEV deploy workflow runs successfully
- [ ] Verify build-check passes on this PR
- [ ] Manual trigger of tag_and_release (optional)