### PR TITLE
Replace total swaps with total pools on landing page

### DIFF
--- a/apps/web/src/pages/Landing/sections/Stats.tsx
+++ b/apps/web/src/pages/Landing/sections/Stats.tsx
@@ -171,7 +171,7 @@ function Cards({ inView }: { inView: boolean }) {
   // Currently hardcoded, BE task [DAT-1435] to make this data available
   const allTimeVolume = 5.2 * 10 ** 6
   const allTimeUsers = 82886
-  const totalSwaps = 13218
+  const totalPools = 44
   const displayTVL = totalTVL > 0 ? totalTVL : 575000
 
   // Show bApps campaign card for Citrea Testnet
@@ -212,9 +212,9 @@ function Cards({ inView }: { inView: boolean }) {
       </LeftBottom>
       <RightBottom>
         <StatCard
-          title={t('stats.totalSwaps')}
+          title={t('stats.totalPools')}
           value={formatNumberOrString({
-            value: totalSwaps,
+            value: totalPools,
             type: NumberType.TokenQuantityStats,
           })}
           delay={0.6}

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -1807,7 +1807,7 @@
   "stats.24volume": "24H volume",
   "stats.allTimeSwappers": "All time swappers",
   "stats.allTimeUsers": "All time users",
-  "stats.totalSwaps": "Total swaps",
+  "stats.totalPools": "Total pools",
   "stats.allTimeVolume": "All time volume",
   "stats.fdv": "FDV",
   "stats.fdv.description": "Fully diluted valuation (FDV) calculates the total market value assuming all tokens are in circulation.",


### PR DESCRIPTION
## Summary
- Replace "Total swaps" stat card with "Total pools" on the landing page
- Update hardcoded value from 13,218 swaps to 44 pools (current count from ponder API)
- Update i18n key from `stats.totalSwaps` to `stats.totalPools`

## Test plan
- [ ] Verify landing page shows "Total pools" with value 44
- [ ] Verify other stat cards (volume, TVL, users) are unaffected