### PR TITLE
Add Dockerfile for ARM64 Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,12 @@ node_modules
 .github
 .yarn/cache
 .yarn/install-state.gz
-apps/mobile
-apps/extension
+apps/mobile/src
+apps/mobile/android
+apps/mobile/ios
+apps/mobile/e2e
+apps/extension/src
+apps/extension/e2e
 **/cypress
 **/test-results
 **/playwright-metamask-report

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.git
+.github
+.yarn/cache
+.yarn/install-state.gz
+apps/mobile
+apps/extension
+**/cypress
+**/test-results
+**/playwright-metamask-report
+**/build
+**/dist
+**/*.test.ts
+**/*.test.tsx

--- a/.github/workflows/web-dev.yaml
+++ b/.github/workflows/web-dev.yaml
@@ -8,44 +8,40 @@ on:
       - 'packages/**'
       - 'yarn.lock'
       - 'package.json'
+      - 'Dockerfile'
   workflow_dispatch:
 
 env:
-  AZURE_ACCOUNT_NAME: 'stjswappdev'
-  AZURE_CDN_PROFILE: 'afd-dfx-api-dev'
-  AZURE_CDN_ENDPOINT: 'fde-jsw-swp-dev'
-  AZURE_RESOURCE_GROUP: 'rg-dfx-api-dev'
+  DOCKER_TAGS: dfxswiss/juiceswap-dapp:beta
 
 jobs:
-  build-and-deploy:
-    name: Build and deploy Web App to DEV
+  build-and-push:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          node-version: '22.13.1'
-          cache: 'yarn'
-          cache-dependency-path: yarn.lock
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build web app
-        run: yarn web build:development
-        env:
-          NODE_ENV: production
-
-      - name: Log in to Azure
-        uses: azure/login@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          creds: ${{ secrets.AZURE_DEV_CREDENTIALS }}
+          platforms: arm64
 
-      - name: Upload to Azure Storage
-        uses: azure/CLI@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
         with:
-          inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.AZURE_ACCOUNT_NAME }} -d '$web' -s ./apps/web/build --overwrite
+          context: .
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64
+          build-args: |
+            BUILD_MODE=development

--- a/.github/workflows/web-prd.yaml
+++ b/.github/workflows/web-prd.yaml
@@ -8,44 +8,40 @@ on:
       - 'packages/**'
       - 'yarn.lock'
       - 'package.json'
+      - 'Dockerfile'
   workflow_dispatch:
 
 env:
-  AZURE_ACCOUNT_NAME: 'stjswappprd'
-  AZURE_CDN_PROFILE: 'afd-dfx-api-prd'
-  AZURE_CDN_ENDPOINT: 'fde-jsw-swp-prd'
-  AZURE_RESOURCE_GROUP: 'rg-dfx-api-prd'
+  DOCKER_TAGS: dfxswiss/juiceswap-dapp:latest
 
 jobs:
-  build-and-deploy:
-    name: Build and deploy Web App to PRODUCTION
+  build-and-push:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          node-version: '22.13.1'
-          cache: 'yarn'
-          cache-dependency-path: yarn.lock
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Build web app
-        run: yarn web build:production
-        env:
-          NODE_ENV: production
-
-      - name: Log in to Azure
-        uses: azure/login@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          creds: ${{ secrets.AZURE_PRD_CREDENTIALS }}
+          platforms: arm64
 
-      - name: Upload to Azure Storage
-        uses: azure/CLI@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
         with:
-          inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.AZURE_ACCOUNT_NAME }} -d '$web' -s ./apps/web/build --overwrite
+          context: .
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64
+          build-args: |
+            BUILD_MODE=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR /app
 COPY .yarnrc.yml yarn.lock package.json ./
 COPY .yarn/ .yarn/
 
-# Copy workspace package.json files
+# Copy all workspace package.json files (yarn needs them for resolution)
 COPY apps/web/package.json apps/web/
+COPY apps/mobile/package.json apps/mobile/
+COPY apps/extension/package.json apps/extension/
 COPY packages/ packages/
 COPY config/ config/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM node:22.13.1-alpine AS builder
+
+WORKDIR /app
+
+# Copy yarn config and lockfile
+COPY .yarnrc.yml yarn.lock package.json ./
+COPY .yarn/ .yarn/
+
+# Copy workspace package.json files
+COPY apps/web/package.json apps/web/
+COPY packages/ packages/
+COPY config/ config/
+
+# Install dependencies
+RUN yarn install --immutable
+
+# Copy source
+COPY apps/web/ apps/web/
+COPY tsconfig.json turbo.json ./
+
+# Build (production or development mode)
+ARG BUILD_MODE=production
+ENV NODE_ENV=production
+RUN yarn web build:${BUILD_MODE}
+
+# --- Serve with nginx ---
+FROM nginx:alpine
+
+# SPA fallback: serve index.html for all routes
+RUN printf 'server {\n\
+    listen 3000;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+\n\
+    location / {\n\
+        try_files $uri $uri/ /index.html;\n\
+    }\n\
+\n\
+    location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {\n\
+        expires 1y;\n\
+        add_header Cache-Control "public, immutable";\n\
+    }\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/apps/web/build/ /usr/share/nginx/html/
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=5s \
+  CMD wget -qO- http://127.0.0.1:3000/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN yarn web build:${BUILD_MODE}
 # --- Serve with nginx ---
 FROM nginx:alpine
 
+RUN apk add --no-cache curl
+
 # SPA fallback: serve index.html for all routes
 RUN printf 'server {\n\
     listen 3000;\n\
@@ -49,4 +51,4 @@ COPY --from=builder /app/apps/web/build/ /usr/share/nginx/html/
 EXPOSE 3000
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=5s \
-  CMD wget -qO- http://127.0.0.1:3000/ || exit 1
+  CMD curl -sf http://127.0.0.1:3000/ || exit 1


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile: Node 22 + Yarn Berry build → Nginx serve on port 3000
- Replace Azure Storage blob upload with Docker Hub push (`dfxswiss/juiceswap-dapp`)
- ARM64-only builds for Apple Silicon servers (dfxprd/dfxdev)
- Supports `BUILD_MODE` build arg (`production` for PRD, `development` for DEV)
- Add `.dockerignore` to exclude mobile/extension apps and test files

## Test plan
- [ ] Verify DEV build produces ARM64 image with development mode
- [ ] Pull and run image on ARM64 host
- [ ] Verify SPA routing works (all routes serve index.html)