### PR TITLE
Fix Dockerfile: remove non-existent tsconfig.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yarn install --immutable
 
 # Copy source
 COPY apps/web/ apps/web/
-COPY tsconfig.json turbo.json ./
+COPY turbo.json ./
 
 # Build (production or development mode)
 ARG BUILD_MODE=production


### PR DESCRIPTION
## Summary
- Remove `tsconfig.json` from Dockerfile COPY — file does not exist in monorepo root
- tsconfig lives in `apps/web/tsconfig.json` and is already copied via `COPY apps/web/ apps/web/`

## Test plan
- [ ] CI build succeeds