### PR TITLE
Add native build tools for ARM64 Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:22.13.1-alpine AS builder
 
+# Native build tools for ARM64 compilation (sharp, esbuild, swc, etc.)
+RUN apk add --no-cache python3 make g++ linux-headers
+
 WORKDIR /app
 
 # Copy yarn config and lockfile


### PR DESCRIPTION
## Summary
- Install `python3`, `make`, `g++`, `linux-headers` in builder stage
- Required for native module compilation (sharp, esbuild, @swc/core, bufferutil, etc.) under QEMU ARM64 emulation

## Context
`yarn install --immutable` fails on ARM64 because native modules need C/C++ compilation tools that aren't in `node:alpine`.

## Test plan
- [ ] CI Docker build succeeds