### PR TITLE
Fix ARM64 Docker build and add SSH deploy

### DIFF
--- a/.github/workflows/web-dev.yaml
+++ b/.github/workflows/web-dev.yaml
@@ -14,24 +14,22 @@ on:
 env:
   DOCKER_TAGS: dfxswiss/juiceswap-dapp:beta
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push:
-    name: Build and push Docker image
-    runs-on: ubuntu-latest
+  build-and-deploy:
+    name: Build and deploy to DEV
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,3 +43,19 @@ jobs:
           platforms: linux/arm64
           build-args: |
             BUILD_MODE=development
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to DEV
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
+            "jsw-dapp"

--- a/.github/workflows/web-prd.yaml
+++ b/.github/workflows/web-prd.yaml
@@ -14,24 +14,22 @@ on:
 env:
   DOCKER_TAGS: dfxswiss/juiceswap-dapp:latest
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-push:
-    name: Build and push Docker image
-    runs-on: ubuntu-latest
+  build-and-deploy:
+    name: Build and deploy to PRD
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -45,3 +43,19 @@ jobs:
           platforms: linux/arm64
           build-args: |
             BUILD_MODE=production
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to PRD
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "jsw-dapp"


### PR DESCRIPTION
## Summary
- Switch from `ubuntu-latest` + QEMU emulation to `ubuntu-24.04-arm` native runner — fixes native module compilation failures (`cpu-features`, `bufferutil`, `utf-8-validate`)
- Add SSH deploy step via cloudflared tunnel to dfxdev (DEV) and dfxprd (PRD)
- Aligns with the deploy pattern used by JuiceDollar/bapp

## Required GitHub Secrets
The following secrets need to be set in the repo (same as JuiceDollar/bapp):
- `DEPLOY_DEV_SSH_KEY`, `DEPLOY_DEV_SSH_KNOWN_HOSTS`, `DEPLOY_DEV_HOST`, `DEPLOY_DEV_USER`
- `DEPLOY_PRD_SSH_KEY`, `DEPLOY_PRD_SSH_KNOWN_HOSTS`, `DEPLOY_PRD_HOST`, `DEPLOY_PRD_USER`

## Test plan
- [ ] DEV workflow builds and pushes `dfxswiss/juiceswap-dapp:beta` to Docker Hub
- [ ] DEV workflow deploys to dfxdev via SSH
- [ ] PRD workflow builds and pushes `dfxswiss/juiceswap-dapp:latest` to Docker Hub
- [ ] PRD workflow deploys to dfxprd via SSH