### PR TITLE
Fix Docker build: use --mode=skip-build for yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ COPY apps/extension/package.json apps/extension/
 COPY packages/ packages/
 COPY config/ config/
 
-# Skip postinstall scripts (husky needs .git, turbo prepare not needed for web build)
-RUN YARN_ENABLE_SCRIPTS=false yarn install --immutable
+# Skip all build/postinstall scripts (husky needs .git, turbo prepare not needed for web build)
+RUN yarn install --immutable --mode=skip-build
 
 # Copy source
 COPY apps/web/ apps/web/


### PR DESCRIPTION
## Summary
- Replace `YARN_ENABLE_SCRIPTS=false` with `--mode=skip-build`
- `YARN_ENABLE_SCRIPTS=false` only skips npm package scripts, not workspace lifecycle scripts
- `--mode=skip-build` skips ALL build scripts including the root workspace postinstall (`husky install && yarn g:prepare`)

## Test plan
- [ ] CI Docker build succeeds