### PR TITLE
Fix Docker build: init git for vite config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN yarn install --immutable --mode=skip-build
 COPY apps/web/ apps/web/
 COPY turbo.json ./
 
+# Vite config uses git rev-parse HEAD for commit hash
+RUN git init && git commit --allow-empty -m "docker"
+
 # Build (production or development mode)
 ARG BUILD_MODE=production
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ COPY apps/extension/package.json apps/extension/
 COPY packages/ packages/
 COPY config/ config/
 
-# Skip postinstall scripts (husky needs .git, turbo prepare not needed for web build)
-RUN YARN_ENABLE_SCRIPTS=false yarn install --immutable
+# Skip all build/postinstall scripts (husky needs .git, turbo prepare not needed for web build)
+RUN yarn install --immutable --mode=skip-build
 
 # Copy source
 COPY apps/web/ apps/web/


### PR DESCRIPTION
## Summary
- Vite config calls `git rev-parse HEAD` for commit hash injection
- `.git` is excluded from Docker build context (`.dockerignore`)
- Init a dummy git repo in the builder stage so the command doesn't fail

## Test plan
- [ ] CI Docker build succeeds