### PR TITLE
Pass commit hash as Docker build-arg instead of git init hack

### DIFF
--- a/.github/workflows/web-dev.yaml
+++ b/.github/workflows/web-dev.yaml
@@ -43,6 +43,7 @@ jobs:
           platforms: linux/arm64
           build-args: |
             BUILD_MODE=development
+            COMMIT_HASH=${{ github.sha }}
 
       - name: Install cloudflared
         run: |

--- a/.github/workflows/web-prd.yaml
+++ b/.github/workflows/web-prd.yaml
@@ -43,6 +43,7 @@ jobs:
           platforms: linux/arm64
           build-args: |
             BUILD_MODE=production
+            COMMIT_HASH=${{ github.sha }}
 
       - name: Install cloudflared
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.13.1-alpine AS builder
 
 # Native build tools for ARM64 compilation (sharp, esbuild, swc, etc.)
-RUN apk add --no-cache python3 make g++ linux-headers git
+RUN apk add --no-cache python3 make g++ linux-headers
 
 WORKDIR /app
 
@@ -23,12 +23,11 @@ RUN yarn install --immutable --mode=skip-build
 COPY apps/web/ apps/web/
 COPY turbo.json ./
 
-# Vite config uses git rev-parse HEAD for commit hash
-RUN git init && git commit --allow-empty -m "docker"
-
 # Build (production or development mode)
 ARG BUILD_MODE=production
+ARG COMMIT_HASH=unknown
 ENV NODE_ENV=production
+ENV COMMIT_HASH=${COMMIT_HASH}
 RUN yarn web build:${BUILD_MODE}
 
 # --- Serve with nginx ---

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -32,8 +32,15 @@ const reactPlugin = () =>
       })
     : reactOxc()
 
-// Get git commit hash
-const commitHash = execSync('git rev-parse HEAD').toString().trim()
+// Get git commit hash (falls back to COMMIT_HASH env var for Docker builds)
+let commitHash = process.env.COMMIT_HASH || ''
+if (!commitHash) {
+  try {
+    commitHash = execSync('git rev-parse HEAD').toString().trim()
+  } catch {
+    commitHash = 'unknown'
+  }
+}
 
 export default defineConfig(({ mode }) => {
   // Load ALL env variables (including those without VITE_ prefix)


### PR DESCRIPTION
## Summary
- Pass `COMMIT_HASH` as Docker build-arg from CI (`github.sha`) instead of running `git init` + `git commit` inside Docker
- Add graceful fallback in `vite.config.mts`: `COMMIT_HASH` env → `git rev-parse` → `'unknown'`
- Remove `git` from Docker image dependencies (smaller image, faster build)

Replaces #706 with a proper solution.

## Test plan
- [ ] DEV CI/CD builds and deploys successfully
- [ ] `REACT_APP_GIT_COMMIT_HASH` is set correctly in the built app
- [ ] Local `yarn web dev` still works (uses git rev-parse fallback)