### PR TITLE
Fix Docker build: two-step install with codegen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,11 +3,9 @@ node_modules
 .github
 .yarn/cache
 .yarn/install-state.gz
-apps/mobile/src
 apps/mobile/android
 apps/mobile/ios
 apps/mobile/e2e
-apps/extension/src
 apps/extension/e2e
 **/cypress
 **/test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ RUN sed -i 's/"postinstall": "husky install && yarn g:prepare"/"postinstall": "t
 # Install dependencies + native modules
 RUN yarn install
 
-# Copy turbo config (needed for codegen) and source
+# Copy turbo config, source, and mobile/extension .graphql files (needed for codegen)
 COPY turbo.json ./
 COPY apps/web/ apps/web/
+COPY apps/mobile/src/ apps/mobile/src/
+COPY apps/extension/src/ apps/extension/src/
 
 # Run codegen after native modules are built
 RUN yarn g:prepare


### PR DESCRIPTION
## Summary
Fixes the ARM64 Docker build by splitting install and codegen into separate steps.

### Problem
On ARM64, `yarn install` postinstall (`husky install && yarn g:prepare`) fails because
`turbo run prepare` (codegen) starts before native modules (esbuild, sharp) finish compiling.
On amd64, pre-built binaries are used so this race condition doesn't occur.

### Solution
1. Patch postinstall to skip it entirely (`sed` replaces with `true`)
2. Run `yarn install` — installs all deps + compiles native modules
3. Copy source including mobile/extension `.graphql` files (needed for codegen)
4. Run `yarn g:prepare` — codegen now succeeds because all native modules are ready

### Verified
- Full Docker build on dfxdev (native ARM64): **SUCCESS**
- Container serves web app on port 3000: **HTTP 200**

## Test plan
- [x] Local Docker build on ARM64 (dfxdev)
- [x] Container healthcheck passes
- [ ] CI build on `ubuntu-24.04-arm` runner