### PR TITLE
fix: stop polling launchpad endpoint for non-launchpad tokens

### DIFF
--- a/apps/web/src/hooks/useLaunchpadTokens.ts
+++ b/apps/web/src/hooks/useLaunchpadTokens.ts
@@ -130,8 +130,11 @@ export function useLaunchpadToken(address: string | undefined, chainId?: number)
     queryKey: ['launchpad-token', address, chainId],
     queryFn: async (): Promise<{ token: LaunchpadToken } | null> => {
       const response = await fetch(`${API_URL}/v1/launchpad/token/${address}`)
+      if (response.status === 404) {
+        return null // Not a launchpad token
+      }
       if (!response.ok) {
-        throw new Error('Token not found')
+        throw new Error('Failed to fetch launchpad token')
       }
       const data: { token: LaunchpadToken } = await response.json()
       // Verify token is on the expected chain (prevents showing testnet token on mainnet)
@@ -142,7 +145,8 @@ export function useLaunchpadToken(address: string | undefined, chainId?: number)
     },
     enabled: !!address,
     staleTime: 10_000,
-    refetchInterval: 30_000,
+    retry: false,
+    refetchInterval: (query) => (query.state.data ? 30_000 : false),
   })
 }
 


### PR DESCRIPTION
## Summary
- Return `null` on 404 instead of throwing (cached as valid react-query result)
- Add `retry: false` to prevent react-query retries on failure
- Make `refetchInterval` conditional: only poll every 30s when token data was actually found, stop for non-launchpad tokens

## Context
`useLaunchpadToken` is called for every visible token via `QueryTokenLogo` and `CurrencyLogoOverrideContext` in the swap flow. For non-launchpad tokens the API returns 404, but the hook threw an error and `refetchInterval: 30_000` kept polling forever — causing ~20 unnecessary Ponder requests/min.

With this fix, non-launchpad tokens get `null` cached with `staleTime: 10_000` and polling stops immediately. Actual launchpad tokens continue polling every 30s as before.

## Test plan
- [ ] Verify launchpad token logos still display correctly on swap/explore pages
- [ ] Verify non-launchpad tokens don't trigger repeated API calls (check network tab)
- [ ] Verify `TokenDetail` page still shows live launchpad data with 30s polling