### PR TITLE
fix: resolve output token for cross-chain swap URLs

### DIFF
--- a/apps/web/src/state/swap/hooks.tsx
+++ b/apps/web/src/state/swap/hooks.tsx
@@ -574,7 +574,7 @@ export function useInitialCurrencyState(): {
     defaultChainId,
   ])
 
-  const outputChainIsSupported = useSupportedChainId(parsedCurrencyState.outputChainId)
+  const isCrossChainSwap = parsedCurrencyState.outputChainId && parsedCurrencyState.outputChainId !== supportedChainId
 
   const initialOutputCurrencyAddress = useMemo(() => {
     // If there are parsed output currency params, use them
@@ -588,8 +588,8 @@ export function useInitialCurrencyState(): {
             parsedCurrencyState.outputCurrencyAddress
           : parsedCurrencyState.outputCurrencyAddress
 
-      // clear output if identical unless there's a supported outputChainId which means we're bridging
-      if (initialInputCurrencyAddress === resolvedAddress && !outputChainIsSupported) {
+      // clear output if identical unless there's a different outputChainId which means we're bridging
+      if (initialInputCurrencyAddress === resolvedAddress && !isCrossChainSwap) {
         return undefined
       }
       return resolvedAddress
@@ -608,7 +608,7 @@ export function useInitialCurrencyState(): {
     initialInputCurrencyAddress,
     parsedCurrencyState.outputCurrencyAddress,
     parsedCurrencyState.outputChainId,
-    outputChainIsSupported,
+    isCrossChainSwap,
     hasCurrencyQueryParams,
     initialChainId,
     supportedChainId,


### PR DESCRIPTION
## Summary
- Cross-chain swap URLs like `?inputCurrency=lnBTC&outputCurrency=cBTC` failed to resolve the output token (cBTC showed as "Select token")
- Root cause: `useSupportedChainId(outputChainId)` checked against the enabled chains list, which could be empty when a WalletConnect session reports a limited/stale chain namespace
- Fix: replace `useSupportedChainId` with a direct `outputChainId !== supportedChainId` comparison to detect cross-chain swaps independently of the dynamic chains list

## Test plan
- [ ] Navigate to `/#/swap?inputCurrency=lnBTC&outputCurrency=cBTC` — should show lnBTC → cBTC
- [ ] Navigate to `/#/swap?inputCurrency=BTC&outputCurrency=cBTC` — should show BTC → cBTC
- [ ] Navigate to `/#/swap` — should show default cBTC → JUSD (no regression)
- [ ] Same-chain swap URLs (e.g. `?inputCurrency=cBTC&outputCurrency=JUSD`) still work