### PR TITLE
feat: user-signed claim fallback when sponsored claims unavailable

### DIFF
--- a/apps/web/src/hooks/useEvmClaim.ts
+++ b/apps/web/src/hooks/useEvmClaim.ts
@@ -1,16 +1,48 @@
+import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
+import { clientToProvider } from 'hooks/useEthersProvider'
 import { useCallback } from 'react'
 import { fetchBridgeSwapByPreimageHash } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import {
   EvmLockup,
   HelpMeClaimResponse,
   SomeSwap,
+  claimCoinSwap,
+  claimErc20Swap,
   getLdsBridgeManager,
+  getLockup,
   helpMeClaim,
   prefix0x,
 } from 'uniswap/src/features/lds-bridge'
+import { logger } from 'utilities/src/logger/logger'
+import { getConnectorClient, switchChain } from 'wagmi/actions'
+
+const CONTRACT_ADDRESSES: Partial<Record<number, { coinSwap?: string; erc20Swap: string }>> = {
+  4114: {
+    coinSwap: '0xFD92F846fe6E7d08d28D6A88676BB875E5D906ab',
+    erc20Swap: '0x7397F25F230f7d5A83c18e1B68b32511bf35F860',
+  },
+  5115: {
+    coinSwap: '0xd02731fD8c5FDD53B613A699234FAd5EE8851B65',
+    erc20Swap: '0xf2e019a371e5Fd32dB2fC564Ad9eAE9E433133cc',
+  },
+  137: {
+    erc20Swap: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
+  },
+  80002: {
+    erc20Swap: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
+  },
+  1: {
+    erc20Swap: '0x2E21F58Da58c391F110467c7484EdfA849C1CB9B',
+  },
+}
+
+function isNativeToken(tokenAddress: string | undefined): boolean {
+  return !tokenAddress || tokenAddress === '0x0000000000000000000000000000000000000000'
+}
 
 export function useEvmClaim() {
-  const executeClaimIndexed = useCallback(async (lockup: EvmLockup): Promise<HelpMeClaimResponse> => {
+  const executeSponsoredClaimIndexed = useCallback(async (lockup: EvmLockup): Promise<HelpMeClaimResponse> => {
     const preimage = lockup.knownPreimage?.preimage
     if (!preimage) {
       throw new Error('Preimage not found')
@@ -22,22 +54,102 @@ export function useEvmClaim() {
     })
   }, [])
 
-  const executeClaimLocal = useCallback(async (swap: SomeSwap): Promise<HelpMeClaimResponse> => {
-    const claimResponse = await getLdsBridgeManager().autoClaimSwap(swap)
-    return claimResponse
+  const executeSponsoredClaimLocal = useCallback(async (swap: SomeSwap): Promise<HelpMeClaimResponse> => {
+    return getLdsBridgeManager().autoClaimSwap(swap)
+  }, [])
+
+  const executeSponsoredClaim = useCallback(
+    async (lockup: EvmLockup): Promise<HelpMeClaimResponse> => {
+      const swap = await fetchBridgeSwapByPreimageHash({ preimageHash: lockup.preimageHash }).catch(() => null)
+      if (swap) {
+        return executeSponsoredClaimLocal(swap)
+      }
+      return executeSponsoredClaimIndexed(lockup)
+    },
+    [executeSponsoredClaimIndexed, executeSponsoredClaimLocal],
+  )
+
+  const executeUserSignedClaim = useCallback(async (lockup: EvmLockup): Promise<HelpMeClaimResponse> => {
+    const chainId = Number(lockup.chainId)
+
+    let preimage = lockup.knownPreimage?.preimage ?? null
+
+    if (!preimage) {
+      const swap = await fetchBridgeSwapByPreimageHash({ preimageHash: lockup.preimageHash }).catch(() => null)
+      preimage = swap?.preimage ?? null
+    }
+
+    if (!preimage) {
+      const lockupData = await getLockup(lockup.preimageHash, chainId).catch(() => null)
+      preimage = lockupData?.data.lockups?.preimage ?? null
+    }
+
+    if (!preimage) {
+      throw new Error('Preimage not found')
+    }
+
+    const chainContracts = CONTRACT_ADDRESSES[chainId]
+    if (!chainContracts) {
+      throw new Error(`Unsupported chain ID: ${chainId}`)
+    }
+
+    const isNative = isNativeToken(lockup.tokenAddress)
+    const contractAddress = isNative ? chainContracts.coinSwap : chainContracts.erc20Swap
+    if (!contractAddress) {
+      throw new Error(`No ${isNative ? 'coin swap' : 'ERC20 swap'} contract for chain ${chainId}`)
+    }
+
+    try {
+      await switchChain(wagmiConfig, { chainId: chainId as any })
+    } catch (error) {
+      logger.warn('useEvmClaim', 'executeUserSignedClaim', 'Failed to switch chain, continuing anyway', { error })
+    }
+
+    const client = await getConnectorClient(wagmiConfig, { chainId: chainId as any })
+    const provider = clientToProvider(client, chainId)
+    const signer = provider!.getSigner()
+
+    const amount = BigInt(lockup.amount)
+    const timelock = Number(lockup.timelock)
+
+    let txHash: string
+
+    if (isNative) {
+      txHash = await claimCoinSwap({
+        signer,
+        contractAddress,
+        preimage: prefix0x(preimage),
+        amount,
+        refundAddress: lockup.refundAddress,
+        timelock,
+      })
+    } else {
+      txHash = await claimErc20Swap({
+        signer,
+        contractAddress,
+        tokenAddress: lockup.tokenAddress,
+        preimage: prefix0x(preimage),
+        amount,
+        refundAddress: lockup.refundAddress,
+        timelock,
+      })
+    }
+
+    return { txHash, success: true, pending: false }
   }, [])
 
   const executeClaim = useCallback(
     async (lockup: EvmLockup): Promise<HelpMeClaimResponse> => {
-      const swap = await fetchBridgeSwapByPreimageHash({ preimageHash: lockup.preimageHash }).catch(() => null)
+      const chainId = Number(lockup.chainId) as UniverseChainId
+      const isSponsoredAvailable = await getLdsBridgeManager().isSponsoredClaimWalletEligible(chainId)
 
-      if (swap) {
-        return executeClaimLocal(swap)
+      if (isSponsoredAvailable) {
+        return executeSponsoredClaim(lockup)
       }
 
-      return executeClaimIndexed(lockup)
+      return executeUserSignedClaim(lockup)
     },
-    [executeClaimIndexed, executeClaimLocal],
+    [executeSponsoredClaim, executeUserSignedClaim],
   )
 
   return { executeClaim }

--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
@@ -1,10 +1,18 @@
 import BigNumber from 'bignumber.js'
 import { popupRegistry } from 'components/Popups/registry'
 import { BitcoinBridgeDirection, LdsBridgeStatus, PopupType } from 'components/Popups/types'
+import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
+import { clientToProvider } from 'hooks/useEthersProvider'
 import { JuiceswapAuthFunctions } from 'state/sagas/transactions/swapSaga'
 import { call } from 'typed-redux-saga'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
-import { LdsSwapStatus, btcToSat, getLdsBridgeManager } from 'uniswap/src/features/lds-bridge'
+import {
+  LdsSwapStatus,
+  btcToSat,
+  claimCoinSwap,
+  getLdsBridgeManager,
+  satoshiToWei,
+} from 'uniswap/src/features/lds-bridge'
 import { TransactionStepFailedError } from 'uniswap/src/features/transactions/errors'
 import {
   BitcoinBridgeBitcoinToCitreaStep,
@@ -13,6 +21,8 @@ import {
 import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/swapCallback'
 import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
+import type { Chain, Client, Transport } from 'viem'
+import { getConnectorClient } from 'wagmi/actions'
 
 interface HandleBitcoinBridgeBitcoinToCitreaParams {
   step: BitcoinBridgeBitcoinToCitreaStep
@@ -108,14 +118,43 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
     accepted: true,
   })
 
-  const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], chainSwap)
+  const isSponsoredAvailable = yield* call([ldsBridge, ldsBridge.isSponsoredClaimWalletEligible], citreaChainId)
 
-  if (claimResponse.pending) {
-    setCurrentStep({
-      step: { ...step, subStep: BtcToCitreaSubStep.ClaimPending, txHash: claimResponse.txHash },
-      accepted: false,
+  let claimTxHash: string | undefined
+
+  if (isSponsoredAvailable) {
+    const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], chainSwap)
+
+    if (claimResponse.pending) {
+      setCurrentStep({
+        step: { ...step, subStep: BtcToCitreaSubStep.ClaimPending, txHash: claimResponse.txHash },
+        accepted: false,
+      })
+    }
+    if (claimResponse.txHash && claimResponse.success) {
+      claimTxHash = claimResponse.txHash
+    }
+  } else {
+    const client = (yield* call(async () => getConnectorClient(wagmiConfig, { chainId: citreaChainId as any }))) as
+      | Client<Transport, Chain>
+      | undefined
+    const provider = clientToProvider(client, citreaChainId)
+    if (!provider) {
+      throw new TransactionStepFailedError({ message: 'Failed to get provider for claim', step })
+    }
+    const signer = provider.getSigner(account.address)
+
+    claimTxHash = yield* call(claimCoinSwap, {
+      signer,
+      contractAddress: chainSwap.claimDetails.lockupAddress,
+      preimage: chainSwap.preimage,
+      amount: satoshiToWei(chainSwap.claimDetails.amount),
+      refundAddress: chainSwap.claimDetails.refundAddress!,
+      timelock: chainSwap.claimDetails.timeoutBlockHeight,
     })
-  } else if (claimResponse.txHash && claimResponse.success) {
+  }
+
+  if (claimTxHash) {
     setCurrentStep({
       step: { ...step, subStep: BtcToCitreaSubStep.Complete },
       accepted: true,
@@ -124,12 +163,12 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
     popupRegistry.addPopup(
       {
         type: PopupType.BitcoinBridge,
-        id: claimResponse.txHash,
+        id: claimTxHash,
         status: LdsBridgeStatus.Confirmed,
         direction: BitcoinBridgeDirection.BitcoinToCitrea,
         url: '/bridge-swaps',
       },
-      claimResponse.txHash,
+      claimTxHash,
     )
     if (onSuccess) {
       yield* call(onSuccess)

--- a/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
+++ b/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
@@ -2,7 +2,6 @@ import { ADDRESS } from '@juicedollar/jusd'
 import { popupRegistry } from 'components/Popups/registry'
 import { LdsBridgeStatus, PopupType } from 'components/Popups/types'
 import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
-import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
 import { clientToProvider } from 'hooks/useEthersProvider'
 import { JuiceswapAuthFunctions } from 'state/sagas/transactions/swapSaga'
 import { call } from 'typed-redux-saga'
@@ -13,6 +12,7 @@ import {
   approveErc20ForLdsBridge,
   buildErc20LockupTx,
   checkErc20Allowance,
+  claimErc20Swap,
   getLdsBridgeManager,
 } from 'uniswap/src/features/lds-bridge'
 import { TransactionStepFailedError } from 'uniswap/src/features/transactions/errors'
@@ -422,17 +422,12 @@ export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
     accepted: false,
   })
 
-  // Show claim in progress popup
-  popupRegistry.addPopup(
-    {
-      type: PopupType.ClaimInProgress,
-      count: 1,
-    },
-    `claim-in-progress-${chainSwap.id}`,
-    DEFAULT_TXN_DISMISS_MS,
-  )
+  const destChainId = TOKEN_CONFIGS[to].chainId
+  const isSponsoredAvailable = yield* call([ldsBridge, ldsBridge.isSponsoredClaimWalletEligible], destChainId)
 
-  try {
+  let claimTxHash: string | undefined
+
+  if (isSponsoredAvailable) {
     const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], chainSwap)
 
     if (claimResponse.pending) {
@@ -441,47 +436,84 @@ export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
         accepted: false,
       })
     }
-
     if (claimResponse.txHash && claimResponse.success) {
-      const fromChainId = TOKEN_CONFIGS[from].chainId
-      const toChainId = TOKEN_CONFIGS[to].chainId
-
-      const explorerUrl = getExplorerLink({
-        chainId: toChainId,
-        data: claimResponse.txHash,
-        type: ExplorerDataType.TRANSACTION,
-      })
-
-      popupRegistry.addPopup(
-        {
-          type: PopupType.Erc20ChainSwap,
-          id: claimResponse.txHash,
-          fromChainId,
-          toChainId,
-          fromAsset: from,
-          toAsset: to,
-          status: LdsBridgeStatus.Confirmed,
-          url: explorerUrl,
-        },
-        claimResponse.txHash,
-      )
-
-      if (onSuccess) {
-        yield* call(onSuccess)
-      }
+      claimTxHash = claimResponse.txHash
     }
-  } catch (error) {
-    logger.error(error instanceof Error ? error : new Error(String(error)), {
-      tags: { file: 'erc20ChainSwap', function: 'handleErc20ChainSwap' },
-      extra: { swapId: chainSwap.id, step: 'autoClaimSwapById' },
+  } else {
+    const destTokenAddress = TOKEN_CONFIGS[to].address
+
+    try {
+      yield* call(selectChain, destChainId)
+      yield* call(waitForNetwork, destChainId)
+    } catch (_error) {
+      yield* call(waitForNetwork, destChainId)
+    }
+
+    let destClient
+    try {
+      destClient = yield* call(getConnectorClientForChain, destChainId)
+    } catch (error) {
+      throw new TransactionStepFailedError({
+        message: `Failed to get connector client for destination chain: ${error instanceof Error ? error.message : String(error)}`,
+        step,
+        originalError: error instanceof Error ? error : new Error(String(error)),
+      })
+    }
+
+    const destProvider = clientToProvider(destClient, destChainId)
+    if (!destProvider) {
+      throw new TransactionStepFailedError({ message: 'Failed to get provider for claim', step })
+    }
+    const destSigner = destProvider.getSigner(account.address)
+
+    const destSwapContract =
+      destChainId === UniverseChainId.Mainnet
+        ? SWAP_CONTRACTS.ethereum
+        : destChainId === UniverseChainId.Polygon
+          ? SWAP_CONTRACTS.polygon
+          : getCitreaSwapContract(citreaChainId)
+
+    const claimAmount =
+      (BigInt(chainSwap.claimDetails.amount) * 10n ** BigInt(TOKEN_CONFIGS[to].decimals)) /
+      10n ** BigInt(BOLTZ_DECIMALS)
+
+    claimTxHash = yield* call(claimErc20Swap, {
+      signer: destSigner,
+      contractAddress: destSwapContract,
+      tokenAddress: destTokenAddress,
+      preimage: chainSwap.preimage,
+      amount: claimAmount,
+      refundAddress: chainSwap.claimDetails.refundAddress!,
+      timelock: chainSwap.claimDetails.timeoutBlockHeight,
     })
-    throw new TransactionStepFailedError({
-      message: `Auto-claim failed: ${error instanceof Error ? error.message : String(error)}`,
-      step,
-      originalError: error instanceof Error ? error : new Error(String(error)),
+  }
+
+  if (claimTxHash) {
+    const fromChainId = TOKEN_CONFIGS[from].chainId
+    const toChainId = TOKEN_CONFIGS[to].chainId
+
+    const explorerUrl = getExplorerLink({
+      chainId: toChainId,
+      data: claimTxHash,
+      type: ExplorerDataType.TRANSACTION,
     })
-  } finally {
-    // Remove claim in progress popup on error
-    popupRegistry.removePopup(`claim-in-progress-${chainSwap.id}`)
+
+    popupRegistry.addPopup(
+      {
+        type: PopupType.Erc20ChainSwap,
+        id: claimTxHash,
+        fromChainId,
+        toChainId,
+        fromAsset: from,
+        toAsset: to,
+        status: LdsBridgeStatus.Confirmed,
+        url: explorerUrl,
+      },
+      claimTxHash,
+    )
+
+    if (onSuccess) {
+      yield* call(onSuccess)
+    }
   }
 }

--- a/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
@@ -1,11 +1,19 @@
 import { BigNumber } from 'bignumber.js'
 import { popupRegistry } from 'components/Popups/registry'
 import { LdsBridgeStatus, PopupType } from 'components/Popups/types'
+import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
+import { clientToProvider } from 'hooks/useEthersProvider'
 import { JuiceswapAuthFunctions } from 'state/sagas/transactions/swapSaga'
 import { call } from 'typed-redux-saga'
 import { LightningBridgeDirection } from 'uniswap/src/data/tradingApi/types'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
-import { LdsSwapStatus, btcToSat, getLdsBridgeManager } from 'uniswap/src/features/lds-bridge'
+import {
+  LdsSwapStatus,
+  btcToSat,
+  claimCoinSwap,
+  getLdsBridgeManager,
+  satoshiToWei,
+} from 'uniswap/src/features/lds-bridge'
 import { TransactionStepFailedError } from 'uniswap/src/features/transactions/errors'
 import {
   LightningBridgeReverseStep,
@@ -15,6 +23,8 @@ import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/s
 import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
+import type { Chain, Client, Transport } from 'viem'
+import { getConnectorClient } from 'wagmi/actions'
 
 interface HandleLightningBridgeReverseParams {
   step: LightningBridgeReverseStep
@@ -90,14 +100,43 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
     accepted: true,
   })
 
-  const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], reverseSwap)
+  const isSponsoredAvailable = yield* call([ldsBridge, ldsBridge.isSponsoredClaimWalletEligible], citreaChainId)
 
-  if (claimResponse.pending) {
-    setCurrentStep({
-      step: { ...step, subStep: LnReverseSubStep.ClaimPending, txHash: claimResponse.txHash },
-      accepted: false,
+  let claimTxHash: string | undefined
+
+  if (isSponsoredAvailable) {
+    const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], reverseSwap)
+
+    if (claimResponse.pending) {
+      setCurrentStep({
+        step: { ...step, subStep: LnReverseSubStep.ClaimPending, txHash: claimResponse.txHash },
+        accepted: false,
+      })
+    }
+    if (claimResponse.txHash && claimResponse.success) {
+      claimTxHash = claimResponse.txHash
+    }
+  } else {
+    const client = (yield* call(async () => getConnectorClient(wagmiConfig, { chainId: citreaChainId as any }))) as
+      | Client<Transport, Chain>
+      | undefined
+    const provider = clientToProvider(client, citreaChainId)
+    if (!provider) {
+      throw new TransactionStepFailedError({ message: 'Failed to get provider for claim', step })
+    }
+    const signer = provider.getSigner(account.address)
+
+    claimTxHash = yield* call(claimCoinSwap, {
+      signer,
+      contractAddress: reverseSwap.lockupAddress,
+      preimage: reverseSwap.preimage,
+      amount: satoshiToWei(reverseSwap.onchainAmount),
+      refundAddress: reverseSwap.refundAddress,
+      timelock: reverseSwap.timeoutBlockHeight,
     })
-  } else if (claimResponse.txHash && claimResponse.success) {
+  }
+
+  if (claimTxHash) {
     setCurrentStep({
       step: { ...step, subStep: LnReverseSubStep.Complete },
       accepted: true,
@@ -105,7 +144,7 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
 
     const explorerUrl = getExplorerLink({
       chainId: citreaChainId,
-      data: claimResponse.txHash,
+      data: claimTxHash,
       type: ExplorerDataType.TRANSACTION,
     })
 
@@ -113,12 +152,12 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
       popupRegistry.addPopup(
         {
           type: PopupType.LightningBridge,
-          id: claimResponse.txHash,
+          id: claimTxHash,
           direction: LightningBridgeDirection.Reverse,
           status: LdsBridgeStatus.Confirmed,
           url: explorerUrl,
         },
-        claimResponse.txHash,
+        claimTxHash,
       )
     }
 

--- a/apps/web/src/state/sagas/transactions/wbtcBridge.ts
+++ b/apps/web/src/state/sagas/transactions/wbtcBridge.ts
@@ -18,7 +18,10 @@ import {
   buildErc20LockupTx,
   buildEvmLockupTx,
   checkErc20Allowance,
+  claimCoinSwap,
+  claimErc20Swap,
   getLdsBridgeManager,
+  satoshiToWei,
 } from 'uniswap/src/features/lds-bridge'
 import { TransactionStepFailedError } from 'uniswap/src/features/transactions/errors'
 import { WbtcBridgeStep, WbtcBridgeSubStep } from 'uniswap/src/features/transactions/swap/steps/wbtcBridge'
@@ -368,56 +371,102 @@ export function* handleWbtcBridge(params: HandleWbtcBridgeParams) {
     DEFAULT_TXN_DISMISS_MS,
   )
 
+  const destChainId = isWbtcToCbtc ? citreaChainId : UniverseChainId.Mainnet
+  const isSponsoredAvailable = yield* call([ldsBridge, ldsBridge.isSponsoredClaimWalletEligible], destChainId)
+
+  let claimTxHash: string | undefined
+
   try {
-    const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], chainSwap)
+    if (isSponsoredAvailable) {
+      const claimResponse = yield* call([ldsBridge, ldsBridge.autoClaimSwap], chainSwap)
 
-    popupRegistry.removePopup(`claim-in-progress-${chainSwap.id}`)
+      if (claimResponse.pending) {
+        setCurrentStep({
+          step: { ...step, subStep: WbtcBridgeSubStep.ClaimPending, txHash: claimResponse.txHash },
+          accepted: false,
+        })
+      }
+      if (claimResponse.txHash && claimResponse.success) {
+        claimTxHash = claimResponse.txHash
+      }
+    } else {
+      try {
+        yield* call(selectChain, destChainId)
+        yield* call(waitForNetwork, destChainId)
+      } catch (_error) {
+        yield* call(waitForNetwork, destChainId)
+      }
 
-    if (claimResponse.pending) {
-      setCurrentStep({
-        step: { ...step, subStep: WbtcBridgeSubStep.ClaimPending, txHash: claimResponse.txHash },
-        accepted: false,
-      })
-    } else if (claimResponse.txHash && claimResponse.success) {
-      setCurrentStep({ step: { ...step, subStep: WbtcBridgeSubStep.Complete }, accepted: true })
+      let destClient
+      try {
+        destClient = yield* call(getConnectorClientForChain, destChainId)
+      } catch (error) {
+        throw new TransactionStepFailedError({
+          message: `Failed to get connector client for destination chain: ${error instanceof Error ? error.message : String(error)}`,
+          step,
+          originalError: error instanceof Error ? error : new Error(String(error)),
+        })
+      }
 
-      const fromChainId = sourceChainId
-      const toChainId = isWbtcToCbtc ? citreaChainId : UniverseChainId.Mainnet
+      const destProvider = clientToProvider(destClient, destChainId)
+      if (!destProvider) {
+        throw new TransactionStepFailedError({ message: 'Failed to get provider for claim', step })
+      }
+      const destSigner = destProvider.getSigner(account.address)
 
-      const explorerUrl = getExplorerLink({
-        chainId: toChainId,
-        data: claimResponse.txHash,
-        type: ExplorerDataType.TRANSACTION,
-      })
-
-      popupRegistry.addPopup(
-        {
-          type: PopupType.Erc20ChainSwap,
-          id: claimResponse.txHash,
-          fromChainId,
-          toChainId,
-          fromAsset: from,
-          toAsset: to,
-          status: LdsBridgeStatus.Confirmed,
-          url: explorerUrl,
-        },
-        claimResponse.txHash,
-      )
-
-      if (onSuccess) {
-        yield* call(onSuccess)
+      if (isWbtcToCbtc) {
+        claimTxHash = yield* call(claimCoinSwap, {
+          signer: destSigner,
+          contractAddress: chainSwap.claimDetails.lockupAddress,
+          preimage: chainSwap.preimage,
+          amount: satoshiToWei(chainSwap.claimDetails.amount),
+          refundAddress: chainSwap.claimDetails.refundAddress!,
+          timelock: chainSwap.claimDetails.timeoutBlockHeight,
+        })
+      } else {
+        claimTxHash = yield* call(claimErc20Swap, {
+          signer: destSigner,
+          contractAddress: SWAP_CONTRACTS.ethereum,
+          tokenAddress: TOKEN_CONFIGS[to].address,
+          preimage: chainSwap.preimage,
+          amount: BigInt(chainSwap.claimDetails.amount),
+          refundAddress: chainSwap.claimDetails.refundAddress!,
+          timelock: chainSwap.claimDetails.timeoutBlockHeight,
+        })
       }
     }
-  } catch (error) {
+  } finally {
     popupRegistry.removePopup(`claim-in-progress-${chainSwap.id}`)
-    logger.error(error instanceof Error ? error : new Error(String(error)), {
-      tags: { file: 'wbtcBridge', function: 'handleWbtcBridge' },
-      extra: { swapId: chainSwap.id, step: 'autoClaimSwapById' },
+  }
+
+  if (claimTxHash) {
+    setCurrentStep({ step: { ...step, subStep: WbtcBridgeSubStep.Complete }, accepted: true })
+
+    const fromChainId = sourceChainId
+    const toChainId = isWbtcToCbtc ? citreaChainId : UniverseChainId.Mainnet
+
+    const explorerUrl = getExplorerLink({
+      chainId: toChainId,
+      data: claimTxHash,
+      type: ExplorerDataType.TRANSACTION,
     })
-    throw new TransactionStepFailedError({
-      message: `Auto-claim failed: ${error instanceof Error ? error.message : String(error)}`,
-      step,
-      originalError: error instanceof Error ? error : new Error(String(error)),
-    })
+
+    popupRegistry.addPopup(
+      {
+        type: PopupType.Erc20ChainSwap,
+        id: claimTxHash,
+        fromChainId,
+        toChainId,
+        fromAsset: from,
+        toAsset: to,
+        status: LdsBridgeStatus.Confirmed,
+        url: explorerUrl,
+      },
+      claimTxHash,
+    )
+
+    if (onSuccess) {
+      yield* call(onSuccess)
+    }
   }
 }

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -13,8 +13,8 @@ import {
   fetchSubmarineTransactionsBySwapId,
   fetchSwapCurrentStatus,
   helpMeClaim,
+  sponsorClaimWalletBalance,
 } from 'uniswap/src/features/lds-bridge/api/client'
-import { fetchBlockTipHeight } from 'uniswap/src/features/lds-bridge/api/mempool'
 import { createLdsSocketClient } from 'uniswap/src/features/lds-bridge/api/socket'
 import { ChainSwapKeys, generateChainSwapKeys } from 'uniswap/src/features/lds-bridge/keys/chainSwapKeys'
 import type {
@@ -35,7 +35,6 @@ import {
   LdsSwapStatus,
   hasReachedStatus,
   swapStatusFinal,
-  swapStatusPending,
 } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
 import { StorageManager } from 'uniswap/src/features/lds-bridge/storage/StorageManager'
 import { prefix0x } from 'uniswap/src/features/lds-bridge/utils/hex'
@@ -51,6 +50,13 @@ export const ASSET_CHAIN_ID_MAP: Record<string, UniverseChainId> = {
   'JUSD_CITREA': UniverseChainId.CitreaMainnet,
   'BTC': UniverseChainId.Bitcoin,
   'WBTC_ETH': UniverseChainId.Mainnet,
+}
+
+export const minimumBalanceForSponsoredClaim: Partial<Record<UniverseChainId, number>> = {
+  [UniverseChainId.CitreaMainnet]: 0.0000001,
+  [UniverseChainId.CitreaTestnet]: 0.0000001,
+  [UniverseChainId.Mainnet]: 0.0001,
+  [UniverseChainId.Polygon]: 0.0001,
 }
 
 /* eslint-disable max-params, @typescript-eslint/no-non-null-assertion, consistent-return, @typescript-eslint/explicit-function-return-type, max-lines */
@@ -246,6 +252,21 @@ class LdsBridgeManager {
     this._subscribeToSwapUpdates(chainSwapResponse.id)
     await this.waitForSwapUntilState(chainSwapResponse.id, LdsSwapStatus.SwapCreated)
     return chainSwap
+  }
+
+  isSponsoredClaimWalletEligible = async (chainId: UniverseChainId): Promise<boolean> => {
+    try {
+      const minimum = minimumBalanceForSponsoredClaim[chainId]
+      if (minimum === undefined) {
+        return false
+      }
+      const balance = await sponsorClaimWalletBalance()
+      const walletBalance = parseFloat(balance.wallets[String(chainId)]?.balance ?? '0')
+      return walletBalance >= minimum
+    } catch (error) {
+      console.error('[LdsBridgeManager] Error checking sponsored claim wallet eligibility:', error)
+      return false
+    }
   }
 
   autoClaimSwap = async (swap: SomeSwap): Promise<HelpMeClaimResponse> => {

--- a/packages/uniswap/src/features/lds-bridge/api/client.ts
+++ b/packages/uniswap/src/features/lds-bridge/api/client.ts
@@ -17,6 +17,8 @@ import type {
   LightningBridgeSubmarineGetResponse,
   LightningBridgeSubmarineLockResponse,
   LockupCheckResponse,
+  SponsorClaimWalletBalanceResponse,
+  SponsorClaimWalletEntry,
 } from 'uniswap/src/features/lds-bridge/lds-types/api'
 import { LdsSwapStatus } from 'uniswap/src/features/lds-bridge/lds-types/websocket'
 
@@ -38,6 +40,8 @@ export type {
   LightningBridgeSubmarineGetResponse,
   LightningBridgeSubmarineLockResponse,
   LockupCheckResponse,
+  SponsorClaimWalletBalanceResponse,
+  SponsorClaimWalletEntry,
 }
 
 const LdsApiClient = createApiClient({
@@ -142,3 +146,6 @@ export async function fetchBoltzBalance(): Promise<BoltzBalanceItem[]> {
   return await LdsApiClient.get<BoltzBalanceItem[]>('/boltz/balance')
 }
 
+export async function sponsorClaimWalletBalance(): Promise<SponsorClaimWalletBalanceResponse> {
+  return await LdsApiClient.get<SponsorClaimWalletBalanceResponse>('/claim/wallet/all')
+}

--- a/packages/uniswap/src/features/lds-bridge/index.ts
+++ b/packages/uniswap/src/features/lds-bridge/index.ts
@@ -25,4 +25,4 @@ export * from './api/mempool'
 export * from './api/socket'
 
 // Manager
-export { getLdsBridgeManager } from './LdsBridgeManager'
+export { getLdsBridgeManager, minimumBalanceForSponsoredClaim } from './LdsBridgeManager'

--- a/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
+++ b/packages/uniswap/src/features/lds-bridge/lds-types/api.ts
@@ -7,6 +7,16 @@ export interface BoltzBalanceItem {
   direction?: 'incoming' | 'outgoing'
 }
 
+export interface SponsorClaimWalletEntry {
+  address: string
+  balance: string
+  error?: string
+}
+
+export interface SponsorClaimWalletBalanceResponse {
+  wallets: Record<string, SponsorClaimWalletEntry>
+}
+
 interface LightningBridgePairInfo {
   hash: string
   rate: number

--- a/packages/uniswap/src/features/lds-bridge/transactions/evm.ts
+++ b/packages/uniswap/src/features/lds-bridge/transactions/evm.ts
@@ -159,6 +159,31 @@ export async function claimErc20Swap(params: {
   const tx = await swapContract.claim(prefix0x(preimage), amount, tokenAddress, refundAddress, timelock)
 
   const receipt = await tx.wait()
+  
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return receipt.transactionHash
+}
+
+export async function claimCoinSwap(params: {
+  signer: Signer
+  contractAddress: string
+  preimage: string
+  amount: bigint
+  refundAddress: string
+  timelock: number
+}): Promise<string> {
+  const { signer, contractAddress, preimage, amount, refundAddress, timelock } = params
+
+  const contract = new EthersContract(contractAddress, COIN_SWAP_ABI, signer) as Contract
+
+  const tx = await contract['claim(bytes32,uint256,address,uint256)'](
+    prefix0x(preimage),
+    amount,
+    refundAddress,
+    timelock,
+  )
+
+  const receipt = await tx.wait()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return receipt.hash
 }

--- a/packages/uniswap/src/features/transactions/swap/hooks/useSwapWarnings/useSponsoredClaimWarning.ts
+++ b/packages/uniswap/src/features/transactions/swap/hooks/useSwapWarnings/useSponsoredClaimWarning.ts
@@ -1,0 +1,91 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Warning, WarningAction, WarningLabel, WarningSeverity } from 'uniswap/src/components/modals/WarningModal/types'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { getLdsBridgeManager, minimumBalanceForSponsoredClaim } from 'uniswap/src/features/lds-bridge'
+import { useOnChainNativeCurrencyBalance } from 'uniswap/src/features/portfolio/api'
+import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
+import {
+  isBitcoinBridge,
+  isErc20ChainSwap,
+  isLightningBridge,
+  isWbtcBridge,
+} from 'uniswap/src/features/transactions/swap/utils/routing'
+import type { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
+import { CurrencyField } from 'uniswap/src/types/currency'
+import { isWeb } from 'utilities/src/platform'
+
+function isBridgeWithEvmOutput(derivedSwapInfo: DerivedSwapInfo): UniverseChainId | undefined {
+  const trade = derivedSwapInfo.trade.trade
+  if (!trade) {
+    return undefined
+  }
+
+  const isBridge =
+    isLightningBridge(trade) || isBitcoinBridge(trade) || isErc20ChainSwap(trade) || isWbtcBridge(trade)
+  if (!isBridge) {
+    return undefined
+  }
+
+  const outputChainId = derivedSwapInfo.currencies[CurrencyField.OUTPUT]?.currency.chainId as
+    | UniverseChainId
+    | undefined
+  if (
+    outputChainId === undefined ||
+    outputChainId === UniverseChainId.Bitcoin ||
+    outputChainId === UniverseChainId.LightningNetwork
+  ) {
+    return undefined
+  }
+
+  return outputChainId
+}
+
+export function useSponsoredClaimWarning({
+  account,
+  derivedSwapInfo,
+}: {
+  account?: AccountDetails
+  derivedSwapInfo: DerivedSwapInfo
+}): Warning | undefined {
+  const { t } = useTranslation()
+  const outputChainId = isBridgeWithEvmOutput(derivedSwapInfo)
+  const enabled = outputChainId !== undefined
+  const { data: isSponsorEligible, isSuccess: sponsorQueryResolved } = useQuery({
+    queryKey: ['sponsored-claim-eligibility', outputChainId],
+    queryFn: () => getLdsBridgeManager().isSponsoredClaimWalletEligible(outputChainId!),
+    enabled,
+  })
+
+  const sponsorCanCoverFee = sponsorQueryResolved && isSponsorEligible
+
+  const { balance: userNativeBalance } = useOnChainNativeCurrencyBalance(
+    outputChainId ?? UniverseChainId.Mainnet,
+    enabled ? account?.address : undefined,
+  )
+
+  const minimumFee = outputChainId !== undefined ? minimumBalanceForSponsoredClaim[outputChainId] : undefined
+  const userCanCoverFee =
+    minimumFee !== undefined &&
+    userNativeBalance !== undefined &&
+    Number(userNativeBalance.toExact()) >= minimumFee
+
+  return useMemo(() => {
+    if (!enabled || sponsorCanCoverFee || userCanCoverFee) {
+      return undefined
+    }
+
+    const nativeSymbol = userNativeBalance?.currency.symbol ?? ''
+
+    return {
+      type: WarningLabel.InsufficientGasFunds,
+      severity: WarningSeverity.Medium,
+      action: WarningAction.DisableSubmit,
+      title: t('swap.warning.insufficientGas.title', { currencySymbol: nativeSymbol }),
+      buttonText: isWeb
+        ? t('swap.warning.insufficientGas.button', { currencySymbol: nativeSymbol })
+        : undefined,
+    }
+  }, [enabled, sponsorCanCoverFee, userCanCoverFee, userNativeBalance?.currency.symbol, t])
+}

--- a/packages/uniswap/src/features/transactions/swap/hooks/useSwapWarnings/useSwapWarnings.tsx
+++ b/packages/uniswap/src/features/transactions/swap/hooks/useSwapWarnings/useSwapWarnings.tsx
@@ -16,6 +16,7 @@ import { getFormIncompleteWarning } from 'uniswap/src/features/transactions/swap
 import { getPriceImpactWarning } from 'uniswap/src/features/transactions/swap/hooks/useSwapWarnings/getPriceImpactWarning'
 import { getSwapWarningFromError } from 'uniswap/src/features/transactions/swap/hooks/useSwapWarnings/getSwapWarningFromError'
 import { getTokenBlockedWarning } from 'uniswap/src/features/transactions/swap/hooks/useSwapWarnings/getTokenBlockedWarning'
+import { useSponsoredClaimWarning } from 'uniswap/src/features/transactions/swap/hooks/useSwapWarnings/useSponsoredClaimWarning'
 import { useSwapFormStore } from 'uniswap/src/features/transactions/swap/stores/swapFormStore/useSwapFormStore'
 import { useSwapTxStore } from 'uniswap/src/features/transactions/swap/stores/swapTxStore/useSwapTxStore'
 import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
@@ -105,10 +106,12 @@ export function useParsedSwapWarnings(): ParsedWarnings {
   const swapWarnings = useSwapWarnings(derivedSwapInfo)
 
   const gasWarning = useTransactionGasWarning({ account, derivedInfo: derivedSwapInfo, gasFee: gasFee.value })
+  const sponsoredClaimWarning = useSponsoredClaimWarning({ account, derivedSwapInfo })
 
   const allWarnings = useMemo(() => {
-    return !gasWarning ? swapWarnings : [...swapWarnings, gasWarning]
-  }, [gasWarning, swapWarnings])
+    const extras = [gasWarning, sponsoredClaimWarning].filter((w): w is Warning => w !== undefined)
+    return extras.length > 0 ? [...swapWarnings, ...extras] : swapWarnings
+  }, [gasWarning, sponsoredClaimWarning, swapWarnings])
 
   return useFormattedWarnings(allWarnings)
 }

--- a/packages/uniswap/src/features/transactions/swap/review/SwapReviewScreen/SwapErrorScreen.tsx
+++ b/packages/uniswap/src/features/transactions/swap/review/SwapReviewScreen/SwapErrorScreen.tsx
@@ -49,6 +49,7 @@ export function SwapErrorScreen({
       submissionError.step.type === TransactionStepType.BitcoinBridgeCitreaToBitcoinStep ||
       submissionError.step.type === TransactionStepType.LightningBridgeSubmarineStep ||
       submissionError.step.type === TransactionStepType.LightningBridgeReverseStep ||
+      submissionError.step.type === TransactionStepType.Erc20ChainSwapStep ||
       submissionError.step.type === TransactionStepType.WbtcBridgeStep)
 
   const isBridgeBackendAccepted = isBridgeError && (submissionError.step as BitcoinBridgeBitcoinToCitreaStep | BitcoinBridgeCitreaToBitcoinStep).backendAccepted


### PR DESCRIPTION
## Summary
- Check sponsor wallet eligibility (`isSponsoredClaimWalletEligible`) before attempting claims in all bridge sagas and the bridge-swaps page
- When sponsored claims are unavailable, prompt the user to sign the claim transaction directly using the correct contract (COIN_SWAP for native tokens like cBTC, ERC20_SWAP for ERC20 tokens like JUSD/USDT/WBTC)
- Add `useSponsoredClaimWarning` hook to disable the swap button with an insufficient-gas warning when neither the sponsor nor the user can cover the claim fee on the destination chain
- Add `claimCoinSwap` function for native token claims on EVM chains
- Update `useEvmClaim` hook to route between sponsored and user-signed claims, resolving preimage from multiple sources (lockup data, local swap, indexer)
- Switch wallet to the destination chain before executing user-signed claims in sagas

## Test plan
- [ ] Test sponsored claim path when sponsor wallet has sufficient balance
- [ ] Test user-signed claim fallback on bridge-swaps page (both COIN_SWAP and ERC20_SWAP contracts)
- [ ] Verify swap form shows insufficient gas warning when both sponsor and user lack funds
- [ ] Test all bridge directions: BTC→cBTC, LN→cBTC, ERC20 chain swaps, WBTC↔cBTC
- [ ] Verify chain switching works correctly before user-signed claims