### PR TITLE
fix: switch chain before user-signed claims in bridge sagas

### DIFF
--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
@@ -22,7 +22,7 @@ import { SetCurrentStepFn } from 'uniswap/src/features/transactions/swap/types/s
 import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 import type { Chain, Client, Transport } from 'viem'
-import { getConnectorClient } from 'wagmi/actions'
+import { getConnectorClient, switchChain } from 'wagmi/actions'
 
 interface HandleBitcoinBridgeBitcoinToCitreaParams {
   step: BitcoinBridgeBitcoinToCitreaStep
@@ -135,6 +135,8 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
       claimTxHash = claimResponse.txHash
     }
   } else {
+    yield* call(async () => switchChain(wagmiConfig, { chainId: citreaChainId as any }).catch(() => {}))
+
     const client = (yield* call(async () => getConnectorClient(wagmiConfig, { chainId: citreaChainId as any }))) as
       | Client<Transport, Chain>
       | undefined

--- a/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
+++ b/apps/web/src/state/sagas/transactions/lightningBridgeReverse.ts
@@ -24,7 +24,7 @@ import { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
 import type { Chain, Client, Transport } from 'viem'
-import { getConnectorClient } from 'wagmi/actions'
+import { getConnectorClient, switchChain } from 'wagmi/actions'
 
 interface HandleLightningBridgeReverseParams {
   step: LightningBridgeReverseStep
@@ -117,6 +117,8 @@ export function* handleLightningBridgeReverse(params: HandleLightningBridgeRever
       claimTxHash = claimResponse.txHash
     }
   } else {
+    yield* call(async () => switchChain(wagmiConfig, { chainId: citreaChainId as any }).catch(() => {}))
+
     const client = (yield* call(async () => getConnectorClient(wagmiConfig, { chainId: citreaChainId as any }))) as
       | Client<Transport, Chain>
       | undefined

--- a/packages/uniswap/src/features/lds-bridge/transactions/evm.ts
+++ b/packages/uniswap/src/features/lds-bridge/transactions/evm.ts
@@ -159,7 +159,7 @@ export async function claimErc20Swap(params: {
   const tx = await swapContract.claim(prefix0x(preimage), amount, tokenAddress, refundAddress, timelock)
 
   const receipt = await tx.wait()
-  
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return receipt.transactionHash
 }
@@ -185,7 +185,7 @@ export async function claimCoinSwap(params: {
 
   const receipt = await tx.wait()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return receipt.hash
+  return receipt.transactionHash
 }
 
 export async function refundCoinSwap(params: {
@@ -210,7 +210,7 @@ export async function refundCoinSwap(params: {
 
   const receipt = await tx.wait()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return receipt.hash
+  return receipt.transactionHash
 }
 
 export async function refundErc20Swap(params: {
@@ -239,5 +239,5 @@ export async function refundErc20Swap(params: {
 
   const receipt = await tx.wait()
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return receipt.hash
+  return receipt.transactionHash
 }


### PR DESCRIPTION
## Summary
- Add `switchChain` call before `getConnectorClient` in `bitcoinBridgeBitcoinToCitrea` and `lightningBridgeReverse` sagas to prevent `NETWORK_ERROR: underlying network changed` errors when the wallet is on a different chain than the claim destination
- Normalize `receipt.hash` to `receipt.transactionHash` across all EVM claim/refund functions for consistency

## Test plan
- [ ] Test LN → cBTC user-signed claim (wallet starts on non-Citrea chain)
- [ ] Test BTC → cBTC user-signed claim (wallet starts on non-Citrea chain)
- [ ] Verify chain switch prompt appears before claim transaction signing