### PR TITLE
fix(bridge): wait for server lockup on user RPC before claim

### DIFF
--- a/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
+++ b/apps/web/src/state/sagas/transactions/bitcoinBridgeBitcoinToCitrea.ts
@@ -3,6 +3,7 @@ import { popupRegistry } from 'components/Popups/registry'
 import { BitcoinBridgeDirection, LdsBridgeStatus, PopupType } from 'components/Popups/types'
 import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
 import { clientToProvider } from 'hooks/useEthersProvider'
+import { waitForServerLockupTx } from 'state/sagas/transactions/ldsClaimUtils'
 import { JuiceswapAuthFunctions } from 'state/sagas/transactions/swapSaga'
 import { call } from 'typed-redux-saga'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
@@ -145,6 +146,12 @@ export function* handleBitcoinBridgeBitcoinToCitrea(params: HandleBitcoinBridgeB
       throw new TransactionStepFailedError({ message: 'Failed to get provider for claim', step })
     }
     const signer = provider.getSigner(account.address)
+
+    yield* call(waitForServerLockupTx, {
+      provider,
+      swapId: chainSwap.id,
+      source: 'bitcoinBridgeBitcoinToCitrea',
+    })
 
     claimTxHash = yield* call(claimCoinSwap, {
       signer,

--- a/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
+++ b/apps/web/src/state/sagas/transactions/erc20ChainSwap.ts
@@ -4,6 +4,7 @@ import { LdsBridgeStatus, PopupType } from 'components/Popups/types'
 import { wagmiConfig } from 'components/Web3Provider/wagmiConfig'
 import { SWAP_CONTRACTS } from 'constants/ldsBridgeContracts'
 import { clientToProvider } from 'hooks/useEthersProvider'
+import { waitForServerLockupTx } from 'state/sagas/transactions/ldsClaimUtils'
 import { JuiceswapAuthFunctions } from 'state/sagas/transactions/swapSaga'
 import { call } from 'typed-redux-saga'
 import { Erc20ChainSwapDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
@@ -469,6 +470,12 @@ export function* handleErc20ChainSwap(params: HandleErc20ChainSwapParams) {
     const claimAmount =
       (BigInt(chainSwap.claimDetails.amount) * 10n ** BigInt(TOKEN_CONFIGS[to].decimals)) /
       10n ** BigInt(BOLTZ_DECIMALS)
+
+    yield* call(waitForServerLockupTx, {
+      provider: destProvider,
+      swapId: chainSwap.id,
+      source: 'erc20ChainSwap',
+    })
 
     claimTxHash = yield* call(claimErc20Swap, {
       signer: destSigner,

--- a/apps/web/src/state/sagas/transactions/ldsClaimUtils.ts
+++ b/apps/web/src/state/sagas/transactions/ldsClaimUtils.ts
@@ -1,0 +1,36 @@
+import type { Web3Provider } from '@ethersproject/providers'
+import { fetchChainTransactionsBySwapId } from 'uniswap/src/features/lds-bridge'
+import { logger } from 'utilities/src/logger/logger'
+
+// Even after the LDS server reports its lockup tx is confirmed, the user's RPC
+// node may not yet see that tx, which would make the claim's estimateGas
+// revert with "no tokens locked". Wait until the destination provider observes
+// the server lockup tx before signing the claim.
+//
+// Best-effort: never throws. If anything fails (timeout, network, missing
+// serverLock) we still attempt the claim and let the contract surface the real
+// error to the user.
+const SERVER_LOCKUP_WAIT_TIMEOUT_MS = 60_000
+const SERVER_LOCKUP_CONFIRMATIONS = 1
+
+export async function waitForServerLockupTx(params: {
+  provider: Web3Provider
+  swapId: string
+  source: string
+}): Promise<void> {
+  const { provider, swapId, source } = params
+  try {
+    const chainTxs = await fetchChainTransactionsBySwapId(swapId)
+    const serverLockTxId = chainTxs.serverLock?.transaction.id
+    if (!serverLockTxId) {
+      return
+    }
+    await provider.waitForTransaction(serverLockTxId, SERVER_LOCKUP_CONFIRMATIONS, SERVER_LOCKUP_WAIT_TIMEOUT_MS)
+  } catch (error) {
+    logger.warn(
+      source,
+      'waitForServerLockupTx',
+      `Failed waiting for server lockup tx: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/apps/web/src/state/sagas/transactions/wbtcBridge.ts
+++ b/apps/web/src/state/sagas/transactions/wbtcBridge.ts
@@ -5,6 +5,7 @@ import { SWAP_CONTRACTS } from 'constants/ldsBridgeContracts'
 import { DEFAULT_TXN_DISMISS_MS } from 'constants/misc'
 import { clientToProvider } from 'hooks/useEthersProvider'
 import { waitForNetwork } from 'state/sagas/transactions/chainSwitchUtils'
+import { waitForServerLockupTx } from 'state/sagas/transactions/ldsClaimUtils'
 import { JuiceswapAuthFunctions } from 'state/sagas/transactions/swapSaga'
 import { call } from 'typed-redux-saga'
 import { getFetchErrorMessage } from 'uniswap/src/data/apiClients/FetchError'
@@ -407,6 +408,12 @@ export function* handleWbtcBridge(params: HandleWbtcBridgeParams) {
         throw new TransactionStepFailedError({ message: 'Failed to get provider for claim', step })
       }
       const destSigner = destProvider.getSigner(account.address)
+
+      yield* call(waitForServerLockupTx, {
+        provider: destProvider,
+        swapId: chainSwap.id,
+        source: 'wbtcBridge',
+      })
 
       if (isWbtcToCbtc) {
         claimTxHash = yield* call(claimCoinSwap, {

--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -363,10 +363,15 @@ class LdsBridgeManager {
     const abortController = new AbortController()
     const { signal } = abortController
 
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timed out waiting for swap ${swapId} to reach state ${state}`)), timeoutMs)
+    )
+
     try {
       await Promise.race([
         this.waitViaWebSocket(swapId, state, signal),
         this.pollUntilState(swapId, state, signal),
+        timeout,
       ])
     } finally {
       abortController.abort()
@@ -405,9 +410,15 @@ class LdsBridgeManager {
           return
         }
         if (swapStatusFinal.includes(status.status)) {
+          // Terminal failure — re-throw so the race rejects instead of swallowing silently
           throw new Error(`Swap reached final state ${status.status} before ${state}`)
         }
       } catch (error) {
+        if ((error as Error).message?.includes('final state')) {
+          // Re-throw terminal state errors — do not swallow them
+          throw error
+        }
+        // Only swallow transient network errors
         // eslint-disable-next-line no-console
         console.error('[LdsBridgeManager] Error polling status:', error)
       }


### PR DESCRIPTION
Avoid sending the claim transaction before the user's node connection confirms the lock is confirmed onchain