### PR TITLE
chore(bridge): refetch pair info every 10 minutes

### DIFF
--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -15,6 +15,7 @@ import DarkModeQueryParamReader from 'theme/components/DarkModeQueryParamReader'
 import { useSporeColors } from 'ui/src'
 import { initializeScrollWatcher } from 'uniswap/src/components/modals/ScrollLock'
 import Trace from 'uniswap/src/features/telemetry/Trace'
+import { useWarmBridgePairInfo } from 'uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits'
 import { isPathBlocked } from 'utils/blockedPaths'
 import { MICROSITE_LINK } from 'utils/openDownloadApp'
 import { getCurrentPageFromLocation } from 'utils/urlRoutes'
@@ -31,6 +32,7 @@ export default function App() {
   useFeatureFlagUrlOverrides()
   useCrossChainSwapsEnabled() // Handle ?cross-chain-swaps=true/false URL parameter
   useSyncBridgeSwaps() // Sync bridge swaps with GraphQL data on app init
+  useWarmBridgePairInfo()
 
   useEffect(() => {
     initializeScrollWatcher()

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -36,6 +36,7 @@ const useChainBridge = (params?: { enabled: boolean }): ReturnType<typeof useQue
     queryKey: ['chain-bridge'],
     queryFn: () => ldsBridge.getChainPairs(),
     enabled: params?.enabled,
+    refetchInterval: 600000,
   })
 }
 
@@ -47,6 +48,7 @@ const useReverseBridge = (params?: {
     queryKey: ['reverse-bridge'],
     queryFn: () => ldsBridge.getReversePairs(),
     enabled: params?.enabled,
+    refetchInterval: 600000,
   })
 }
 
@@ -58,6 +60,7 @@ const useSubmarineBridge = (params?: {
     queryKey: ['submarine-bridge'],
     queryFn: () => ldsBridge.getSubmarinePairs(),
     enabled: params?.enabled,
+    refetchInterval: 600000,
   })
 }
 

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -64,6 +64,13 @@ const useSubmarineBridge = (params?: {
   })
 }
 
+/** Prefetches Boltz/LDS pair config into the React Query cache so bridge limits resolve faster on first open. */
+export function useWarmBridgePairInfo(): void {
+  useChainBridge({ enabled: true })
+  useReverseBridge({ enabled: true })
+  useSubmarineBridge({ enabled: true })
+}
+
 const isChainBridge = ({ currencyIn, currencyOut }: BridgeLimitsQueryParams): boolean => {
   return currencyIn?.chainId === UniverseChainId.Bitcoin || currencyOut?.chainId === UniverseChainId.Bitcoin
 }


### PR DESCRIPTION
## Summary

- Set `refetchInterval: 600000` (10 minutes) on the three React Query hooks that load Boltz/LDS pair config (`chain-bridge`, `reverse-bridge`, `submarine-bridge`) in `useBridgeLimits`.

## Motivation

Pair metadata changes infrequently; 10s polling was unnecessary load on the LDS API.

## Test plan

- [ ] Open swap with a bridge pair; verify limits still load on first paint
- [ ] Leave swap open >10m (optional): verify queries refetch without errors