### PR TITLE
fix(bridge): do not block limits on balance query loading flags

### DIFF
--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -174,19 +174,19 @@ export function useBridgeLimits(params: BridgeLimitsQueryParams): BridgeLimitsIn
   const pairInfo = usePairInfo(params)
   const { currencyIn, currencyOut } = params
 
-  const { data: boltzBalance, isLoading: isBoltzBalanceLoading } = useQuery({
+  const { data: boltzBalance } = useQuery({
     queryKey: ['boltz-balance'],
     queryFn: fetchBoltzBalance,
     enabled: !!currencyIn && !!currencyOut && !!pairInfo,
   })
 
-  const { data: onChainOut, isLoading: isOnChainOutLoading } = useQuery({
+  const { data: onChainOut } = useQuery({
     queryKey: ['lds-onchain-balance', currencyOut?.chainId, currencyOut?.symbol],
     queryFn: () => fetchLdsOnChainBalance(currencyOut!.chainId, currencyOut!.symbol ?? ''),
     enabled: !!currencyOut?.chainId && !!currencyOut?.symbol && !!pairInfo,
   })
 
-  if (!currencyIn || !currencyOut || !pairInfo || isBoltzBalanceLoading || isOnChainOutLoading) {
+  if (!currencyIn || !currencyOut || !pairInfo) {
     return undefined
   }
 


### PR DESCRIPTION
## Summary

- Remove the early return in `useBridgeLimits` that depended on `isBoltzBalanceLoading` and `isOnChainOutLoading`.
- Limits still require resolvable output liquidity (`effectiveBalanceOut`); that path already returns `undefined` until balances can be combined.

## Motivation

React Query loading flags can keep the hook in a no-limits state even when `data` is already usable for one side, delaying min/max display.

## Test plan

- [ ] Open a bridge pair: limits appear once Boltz + on-chain (or Boltz-only where applicable) can be computed
- [ ] No regression: routes that truly lack balance data still show no limits until data exists