### PR TITLE
chore(bridge): refetch balance queries every 10 seconds

### DIFF
--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -178,12 +178,14 @@ export function useBridgeLimits(params: BridgeLimitsQueryParams): BridgeLimitsIn
     queryKey: ['boltz-balance'],
     queryFn: fetchBoltzBalance,
     enabled: !!currencyIn && !!currencyOut && !!pairInfo,
+    refetchInterval: 10000,
   })
 
   const { data: onChainOut } = useQuery({
     queryKey: ['lds-onchain-balance', currencyOut?.chainId, currencyOut?.symbol],
     queryFn: () => fetchLdsOnChainBalance(currencyOut!.chainId, currencyOut!.symbol ?? ''),
     enabled: !!currencyOut?.chainId && !!currencyOut?.symbol && !!pairInfo,
+    refetchInterval: 10000,
   })
 
   if (!currencyIn || !currencyOut || !pairInfo) {


### PR DESCRIPTION
## Summary
- Set `refetchInterval` to 10s for both the `boltz-balance` and `lds-onchain-balance` queries in `useBridgeLimits` so bridge limits stay fresh while the swap form is mounted.

## Test plan
- [ ] Open the bridge swap form and confirm balances refresh roughly every 10s without manual interaction.
- [ ] Verify no excessive network traffic / regressions in performance.