### PR TITLE
fix: build error + always-real-API points

### DIFF
--- a/apps/web/src/components/AccountDrawer/Points/api.ts
+++ b/apps/web/src/components/AccountDrawer/Points/api.ts
@@ -1,4 +1,8 @@
-import { MIN_LIQUIDITY_USD, POINTS_PER_LIQUIDITY_DAY, POINTS_PER_SWAP } from 'components/AccountDrawer/Points/constants'
+import {
+  MIN_LIQUIDITY_USD,
+  POINTS_PER_LIQUIDITY_DAY,
+  POINTS_PER_SWAP,
+} from 'components/AccountDrawer/Points/constants'
 import { PointsBreakdown } from 'components/AccountDrawer/Points/types'
 import {
   LEADERBOARD_MAX_ENTRIES,
@@ -25,16 +29,18 @@ import {
  *   - Detect and exclude wash-trading patterns (same EOA via different routers,
  *     A→B→A round-trips, etc.).
  *
- * Expected endpoints (ponder service):
+ * Endpoints (ponder service):
  *   GET {BASE}/points/{address}      -> PointsApiResponse
  *   GET {BASE}/points/leaderboard    -> LeaderboardApiResponse
  *
- * BASE is read from REACT_APP_PONDER_JUICESWAP_URL.
- * Toggle with REACT_APP_JUICE_POINTS_API_ENABLED=true (defaults to mock).
+ * BASE comes from REACT_APP_PONDER_JUICESWAP_URL (primary, prod ponder).
+ * REACT_APP_PONDER_FALLBACK_JUICESWAP_URL (dev ponder) is tried if the
+ * primary fails — same pattern as `packages/uniswap/src/data/apiClients/ponderApi`.
  *
- * Until the backend ships these endpoints the fetchers fall back to a deterministic
- * mock (see `mockPoints` / `mockLeaderboard`) so the UI is fully functional during
- * development.
+ * On total API failure we return zeros (NOT mock random data) so the UI
+ * never lies about a wallet's standing. Set
+ * `REACT_APP_JUICE_POINTS_DEV_MOCK=true` to opt into the deterministic
+ * mock for fully offline development.
  */
 
 interface PointsApiResponse {
@@ -63,14 +69,13 @@ interface LeaderboardApiResponse {
   updatedAt: number
 }
 
-const POINTS_API_BASE = process.env.REACT_APP_PONDER_JUICESWAP_URL || ''
-const POINTS_API_ENABLED = process.env.REACT_APP_JUICE_POINTS_API_ENABLED === 'true'
+const PRIMARY_BASE = process.env.REACT_APP_PONDER_JUICESWAP_URL || 'https://ponder.juiceswap.com'
+const FALLBACK_BASE =
+  process.env.REACT_APP_PONDER_FALLBACK_JUICESWAP_URL || 'https://dev.ponder.juiceswap.com'
+const DEV_MOCK_ENABLED = process.env.REACT_APP_JUICE_POINTS_DEV_MOCK === 'true'
 const REQUEST_TIMEOUT_MS = 5_000
 
-async function safeFetch<T>(url: string): Promise<T | undefined> {
-  if (!POINTS_API_ENABLED || !POINTS_API_BASE) {
-    return undefined
-  }
+async function tryFetch<T>(url: string): Promise<T | undefined> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
   try {
@@ -85,6 +90,53 @@ async function safeFetch<T>(url: string): Promise<T | undefined> {
     clearTimeout(timer)
   }
 }
+
+async function fetchWithFallback<T>(path: string): Promise<T | undefined> {
+  for (const base of [PRIMARY_BASE, FALLBACK_BASE]) {
+    if (!base) {
+      continue
+    }
+    const result = await tryFetch<T>(`${base}${path}`)
+    if (result !== undefined) {
+      return result
+    }
+  }
+  return undefined
+}
+
+const ZERO_POINTS: PointsBreakdown = {
+  total: 0,
+  swaps: { count: 0, points: 0 },
+  liquidity: { days: 0, points: 0, currentUsdValue: 0, meetsMinimum: false },
+}
+
+export async function fetchPointsForAddress(address: string): Promise<PointsBreakdown> {
+  const apiResponse = await fetchWithFallback<PointsApiResponse>(`/points/${address.toLowerCase()}`)
+  if (apiResponse) {
+    return apiResponse
+  }
+  if (DEV_MOCK_ENABLED) {
+    return mockPoints(address)
+  }
+  return ZERO_POINTS
+}
+
+export async function fetchLeaderboard(): Promise<LeaderboardData> {
+  const apiResponse = await fetchWithFallback<LeaderboardApiResponse>('/points/leaderboard')
+  if (apiResponse) {
+    return {
+      entries: apiResponse.entries,
+      total: apiResponse.entries.length,
+      updatedAt: apiResponse.updatedAt,
+    }
+  }
+  if (DEV_MOCK_ENABLED) {
+    return mockLeaderboard()
+  }
+  return { entries: [], total: 0, updatedAt: Date.now() }
+}
+
+// ---- Optional offline-dev mock (only used when REACT_APP_JUICE_POINTS_DEV_MOCK=true) ----
 
 function pseudoRandomFromAddress(address: string, max: number): number {
   let hash = 0
@@ -108,13 +160,6 @@ function mockPoints(address: string): PointsBreakdown {
       points: liquidityPoints,
       currentUsdValue,
       meetsMinimum: currentUsdValue >= MIN_LIQUIDITY_USD,
-    },
-    bonuses: {
-      memeTokenCreated: false,
-      memeTokenPoints: 0,
-      memeTokenGraduated: false,
-      memeTokenGraduatedPoints: 0,
-      points: 0,
     },
   }
 }
@@ -147,24 +192,4 @@ function mockLeaderboard(): LeaderboardData {
     points: entry.points,
   }))
   return { entries, total: entries.length, updatedAt: Date.now() }
-}
-
-export async function fetchPointsForAddress(address: string): Promise<PointsBreakdown> {
-  const apiResponse = await safeFetch<PointsApiResponse>(`${POINTS_API_BASE}/points/${address.toLowerCase()}`)
-  if (apiResponse) {
-    return apiResponse
-  }
-  return mockPoints(address)
-}
-
-export async function fetchLeaderboard(): Promise<LeaderboardData> {
-  const apiResponse = await safeFetch<LeaderboardApiResponse>(`${POINTS_API_BASE}/points/leaderboard`)
-  if (apiResponse) {
-    return {
-      entries: apiResponse.entries,
-      total: apiResponse.entries.length,
-      updatedAt: apiResponse.updatedAt,
-    }
-  }
-  return mockLeaderboard()
 }


### PR DESCRIPTION
Two related fixes; both unblock real Juice Points data on \`dev.juiceswap.com\`.

## 1. Build (oxc) error

Develop's Build Check failed on \`17bbd29\` with:

\`\`\`
[plugin vite:oxc] apps/web/src/pages/Leaderboard/Leaderboard.tsx
Error: Unexpected token
const rankVariant = entry.rank as MedalRank <= 3 ? entry.rank as MedalRank : undefined
                                              ^
\`\`\`

The \`as Type <= number ? as Type : undefined\` ternary parses fine in vite-dev (esbuild) but \`@vitejs/plugin-react-oxc\` in production rejects it even with parens. Replaced with a tiny \`toMedalRank(rank): MedalRank | undefined\` type-guard. Same runtime, no \`as\` involved.

## 2. Real API was never being hit

Live dev wallet had two real swaps but the UI showed **1,400 JP** — the deterministic mock was still firing because:

- \`REACT_APP_JUICE_POINTS_API_ENABLED\` wasn't set in the dev build → the gate stopped the API call.
- Even with it set, the URL was hardcoded to the prod ponder, which returns 404 for \`/points\` (only dev.ponder has those endpoints right now).

\`apps/web/src/components/AccountDrawer/Points/api.ts\` now:

- **Drops the binary enable-gate.** The fetcher always tries the real API.
- **Tries two bases** (same pattern as \`packages/uniswap/src/data/apiClients/ponderApi\`):
  - \`PRIMARY_BASE\`  ← \`REACT_APP_PONDER_JUICESWAP_URL\`           (default \`ponder.juiceswap.com\`)
  - \`FALLBACK_BASE\` ← \`REACT_APP_PONDER_FALLBACK_JUICESWAP_URL\` (default \`dev.ponder.juiceswap.com\`)
- **On total failure returns zeros** (NOT random mock data) so the UI never fakes points for a wallet that has none.
- **Random mock now only activates** with explicit \`REACT_APP_JUICE_POINTS_DEV_MOCK=true\` for fully offline dev.

## Pairs with

JuiceSwapxyz/ponder#138 — fixes the \`/points\` endpoints' 500 errors so the API actually returns data.

## Test plan

- [ ] Build Check goes green
- [ ] After ponder#138 merge + redeploy, on \`dev.juiceswap.com\`:
  - Wallet with 0 swaps shows \`0 JP\`
  - Wallet with 2 finalized swaps shows \`200 JP\`
  - Leaderboard shows real wallets
- [ ] Without backend reachable: card shows \`0 JP\` (no fake numbers)