### PR TITLE
fix(leaderboard): unbreak vite/oxc build for podium rank cast

### DIFF
--- a/apps/web/src/pages/Leaderboard/Leaderboard.tsx
+++ b/apps/web/src/pages/Leaderboard/Leaderboard.tsx
@@ -230,11 +230,6 @@ const PageButton = styled(Flex, {
 })
 
 type MedalRank = 1 | 2 | 3
-const MEDAL_KEY: Record<MedalRank, 'gold' | 'silver' | 'bronze'> = {
-  1: 'gold',
-  2: 'silver',
-  3: 'bronze',
-}
 
 function medalKeyForRank(rank: number): 'gold' | 'silver' | 'bronze' | 'none' {
   if (rank === 1) {
@@ -270,7 +265,8 @@ function formatRefreshAge(updatedAt?: number): string {
 
 function PodiumEntry({ entry, isUser }: { entry: LeaderboardEntry; isUser: boolean }) {
   const medal = medalKeyForRank(entry.rank)
-  const rankVariant = (entry.rank as MedalRank) <= 3 ? (entry.rank as MedalRank) : undefined
+  const rank = entry.rank as MedalRank
+  const rankVariant = rank <= 3 ? rank : undefined
   const avatarSize = 72
   const ringSize = avatarSize + 10
   return (
@@ -334,10 +330,7 @@ export default function Leaderboard() {
     return data.entries.find((e) => e.address.toLowerCase() === userAddress)
   }, [data, userAddress])
 
-  const totalPoints = useMemo(
-    () => data?.entries.reduce((sum, e) => sum + e.points, 0) ?? 0,
-    [data],
-  )
+  const totalPoints = useMemo(() => data?.entries.reduce((sum, e) => sum + e.points, 0) ?? 0, [data])
 
   const podium = useMemo(() => data?.entries.slice(0, 3) ?? [], [data])
   const rest = useMemo(() => data?.entries.slice(3) ?? [], [data])
@@ -360,11 +353,7 @@ export default function Leaderboard() {
         <HeaderBlock>
           <HeaderGlow />
           <HeaderInner>
-            <Text
-              variant="body3"
-              color={POINTS_BRAND_COLOR}
-              style={{ letterSpacing: 3, textTransform: 'uppercase' }}
-            >
+            <Text variant="body3" color={POINTS_BRAND_COLOR} style={{ letterSpacing: 3, textTransform: 'uppercase' }}>
               <Trans i18nKey="leaderboard.eyebrow" />
             </Text>
             <Text variant="heading1" color="$neutral1" fontWeight="800">
@@ -462,10 +451,7 @@ export default function Leaderboard() {
             <RowDivider />
             {visible.map((entry, i) => (
               <Fragment key={entry.rank}>
-                <Row
-                  entry={entry}
-                  isUser={!!userAddress && entry.address.toLowerCase() === userAddress}
-                />
+                <Row entry={entry} isUser={!!userAddress && entry.address.toLowerCase() === userAddress} />
                 {i < visible.length - 1 && <RowDivider />}
               </Fragment>
             ))}


### PR DESCRIPTION
## Summary

- Build Check (vite/oxc) has been red on `develop` since the leaderboard merge (#738) on 2026-05-07. Every PR opened against `develop` inherits this failure.
- Root cause: the Tamagui static extractor strips parentheses around `(entry.rank as MedalRank) <= 3`, leaving an ambiguous TS cast expression that oxc rejects with `Unexpected token`.
- Fix: extract the cast to a local so Tamagui has no comparison-with-cast expression to mangle.
- Drive-by: the same file declared an unused `MEDAL_KEY` constant (only the imperative `medalKeyForRank` helper is referenced). Removed to satisfy lint-staged on the touched file.

## Notes for reviewer

- **Auto-formatting:** lint-staged ran `prettier --write` on the touched file and collapsed three pre-existing multi-line expressions (`useMemo`, a `<Text>` element, a `<Row>` element). No semantic change — formatting only.
- **Tamagui limitation:** any future code of the form `(x as T) <op> y` in a file Tamagui statically extracts will hit the same parse error. Worth tracking upstream; the workaround pattern (extract the cast to a local) is the cheapest mitigation today.
- **Pre-existing latent bug not fixed (out of scope):** `entry.rank as MedalRank` is a type assertion, not a runtime check. For `rank = 0` or negatives the cast is a lie and `<PodiumCard rank={0}>` would render with no matching variant. Behavior preserved 1:1 with the original; a follow-up could replace the cast with a type guard.

## Test plan

- [x] `yarn build:production` from `apps/web` succeeds locally
- [x] `eslint --fix` clean on the touched file (lint-staged hook passed)
- [x] CI `Can Build` green on this branch