### PR TITLE
feat(swap): wire SATSUMA routing through the swap-tx pipeline

### DIFF
--- a/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
@@ -84,7 +84,12 @@ import {
 import { getChainInfo } from 'uniswap/src/features/chains/chainInfo'
 import { FeatureFlags } from 'uniswap/src/features/gating/flags'
 import { getFeatureFlag } from 'uniswap/src/features/gating/hooks'
-import { getLdsBridgeManager, LdsSwapStatus, SomeSwap, UserClaimsAndRefundsResponse } from 'uniswap/src/features/lds-bridge'
+import {
+  LdsSwapStatus,
+  SomeSwap,
+  UserClaimsAndRefundsResponse,
+  getLdsBridgeManager,
+} from 'uniswap/src/features/lds-bridge'
 import { getSpenderAddress } from 'uniswap/src/utils/approvalCalldata'
 import { isCrossChainSwapsEnabled } from 'uniswap/src/utils/featureFlags'
 
@@ -153,6 +158,48 @@ export type GatewayJusdQuoteResponse = {
   requestId: string
   quote: GatewayJusdQuote
   routing: GatewayJusdRoutingType
+  permitData: null
+}
+
+// SATSUMA is a custom routing type for the Satsuma USDC.e/ctUSD pool on
+// Citrea Mainnet — the routing string is not in the generated Routing enum
+// so we mirror the GATEWAY_JUSD pattern. The quote shape mirrors what the
+// api emits: classic-style fields (route, routeString, quote*, gas*) plus an
+// `_internal` block carrying the Satsuma router/pool addresses.
+export type SatsumaQuote = {
+  blockNumber?: string
+  amount: string
+  amountDecimals: string
+  quote: string
+  quoteDecimals: string
+  quoteGasAdjusted: string
+  quoteGasAdjustedDecimals: string
+  gasUseEstimate: string
+  gasUseEstimateUSD: string
+  gasPriceWei: string
+  route: Array<
+    Array<{
+      type: string
+      address: string
+      router?: string
+      tokenIn: { chainId: number; decimals: string; address: string; symbol: string }
+      tokenOut: { chainId: number; decimals: string; address: string; symbol: string }
+      amountIn?: string
+      amountOut?: string
+    }>
+  >
+  routeString: string
+  quoteId: string
+  hitsCachedRoutes: boolean
+  priceImpact: string
+  swapper?: string
+  _internal?: { routingType: 'SATSUMA'; pool: string; router: string }
+}
+
+export type SatsumaQuoteResponse = {
+  requestId: string
+  quote: SatsumaQuote
+  routing: 'SATSUMA'
   permitData: null
 }
 
@@ -1334,7 +1381,9 @@ export const saveBridgeSwap = async (params: CreateBridgeSwapRequest): Promise<C
   })
 }
 
-export const fetchBridgeSwaps = async (params: { statuses?: LdsSwapStatus[] }): Promise<GetBridgeSwapsByUserResponse> => {
+export const fetchBridgeSwaps = async (params: {
+  statuses?: LdsSwapStatus[]
+}): Promise<GetBridgeSwapsByUserResponse> => {
   const statusFilter = params.statuses?.length
     ? params.statuses.map((s) => `status=${encodeURIComponent(s)}`).join('&')
     : ''

--- a/packages/uniswap/src/features/transactions/swap/analytics.ts
+++ b/packages/uniswap/src/features/transactions/swap/analytics.ts
@@ -23,6 +23,7 @@ import { SwapEventType, timestampTracker } from 'uniswap/src/features/transactio
 import { getSwapFeeUsd } from 'uniswap/src/features/transactions/swap/utils/getSwapFeeUsd'
 import {
   GATEWAY_JUSD_ROUTING,
+  SATSUMA_ROUTING,
   TradeRouting,
   isClassic,
   isUniswapX,
@@ -386,6 +387,9 @@ export function tradeRoutingToFillType({
   // Handle custom routing types first
   if (routing === GATEWAY_JUSD_ROUTING) {
     return 'classic' // GATEWAY_JUSD is a same-chain swap, report as classic
+  }
+  if (routing === SATSUMA_ROUTING) {
+    return 'classic' // SATSUMA is a same-chain direct swap via Algebra pool, report as classic
   }
 
   switch (routing) {

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
@@ -22,6 +22,7 @@ import { usePresignPermit } from 'uniswap/src/features/transactions/swap/review/
 import { createDecorateSwapTxInfoServiceWithEVMLogging } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/logging'
 import { createGatewayJusdSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/gateway/gatewayJusdSwapTxAndGasInfoService'
 import { createLightningBridgeSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/lightning/lightningBridgeSwapTxAndGasInfoService'
+import { createSatsumaSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService'
 import type {
   RoutingServicesMap,
   SwapTxAndGasInfoParameters,
@@ -41,6 +42,7 @@ import {
   GATEWAY_JUICE_IN_ROUTING,
   GATEWAY_JUICE_OUT_ROUTING,
   GATEWAY_JUSD_ROUTING,
+  SATSUMA_ROUTING,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { useWallet } from 'uniswap/src/features/wallet/hooks/useWallet'
 import { CurrencyField } from 'uniswap/src/types/currency'
@@ -147,6 +149,13 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
     })
   }, [swapConfig.gasStrategy, transactionSettings])
 
+  const satsumaSwapTxInfoService = useMemo(() => {
+    return createSatsumaSwapTxAndGasInfoService({
+      gasStrategy: swapConfig.gasStrategy,
+      transactionSettings,
+    })
+  }, [swapConfig.gasStrategy, transactionSettings])
+
   const services = useMemo(() => {
     return {
       [Routing.CLASSIC]: classicSwapTxInfoService,
@@ -167,6 +176,8 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
       [GATEWAY_JUSD_ROUTING]: gatewayJusdSwapTxInfoService as unknown as SwapTxAndGasInfoService,
       [GATEWAY_JUICE_IN_ROUTING]: gatewayJusdSwapTxInfoService as unknown as SwapTxAndGasInfoService,
       [GATEWAY_JUICE_OUT_ROUTING]: gatewayJusdSwapTxInfoService as unknown as SwapTxAndGasInfoService,
+      // Satsuma direct routing (USDC.e/ctUSD on Citrea Mainnet)
+      [SATSUMA_ROUTING]: satsumaSwapTxInfoService as unknown as SwapTxAndGasInfoService,
     } satisfies RoutingServicesMap
   }, [
     classicSwapTxInfoService,
@@ -177,6 +188,7 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
     lightningBridgeSwapTxInfoService,
     erc20ChainSwapTxInfoService,
     gatewayJusdSwapTxInfoService,
+    satsumaSwapTxInfoService,
   ])
 
   return useMemo(() => {

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts
@@ -1,0 +1,98 @@
+import { ADDRESS_ZERO } from '@juiceswapxyz/v3-sdk'
+import { fetchSwap } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
+import { getTradeSettingsDeadline } from 'uniswap/src/data/apiClients/tradingApi/utils/getTradeSettingsDeadline'
+import type { CreateSwapRequest } from 'uniswap/src/data/tradingApi/__generated__'
+import { Routing } from 'uniswap/src/data/tradingApi/__generated__'
+import type { GasStrategy } from 'uniswap/src/data/tradingApi/types'
+import { convertGasFeeToDisplayValue } from 'uniswap/src/features/gas/hooks'
+import type { TransactionSettings } from 'uniswap/src/features/transactions/components/settings/types'
+import type {
+  SwapTxAndGasInfoParameters,
+  SwapTxAndGasInfoService,
+} from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService'
+import {
+  createApprovalFields,
+  createGasFields,
+  type TransactionRequestInfo,
+} from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/utils'
+import type {
+  ClassicSwapTxAndGasInfo,
+  SwapTxAndGasInfo,
+} from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
+import type { ClassicTrade, SatsumaTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { SATSUMA_ROUTING } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { validateTransactionRequests } from 'uniswap/src/features/transactions/swap/utils/trade'
+
+/**
+ * Satsuma swap service — handles direct Satsuma USDC.e/ctUSD swaps.
+ *
+ * Mirrors the Gateway service: the JuiceSwap api builds the calldata
+ * server-side via /v1/swap and we wrap it as a ClassicSwapTxAndGasInfo so
+ * downstream consumers (review screen, submit pipeline) treat it like a
+ * normal token-token swap. Only the routing tag and the target router
+ * address differ from CLASSIC.
+ */
+export function createSatsumaSwapTxAndGasInfoService(ctx: {
+  gasStrategy: GasStrategy
+  transactionSettings: TransactionSettings
+}): SwapTxAndGasInfoService<SatsumaTrade> {
+  const { gasStrategy, transactionSettings } = ctx
+
+  const service: SwapTxAndGasInfoService<SatsumaTrade> = {
+    async getSwapTxAndGasInfo(params: SwapTxAndGasInfoParameters<SatsumaTrade>): Promise<SwapTxAndGasInfo> {
+      const { trade, approvalTxInfo } = params
+
+      const currencyIn = trade.inputAmount.currency
+      const currencyOut = trade.outputAmount.currency
+      const customSwapData = {
+        chainId: currencyIn.chainId,
+        tokenInChainId: currencyIn.chainId,
+        tokenInAddress: currencyIn.isNative ? ADDRESS_ZERO : currencyIn.address,
+        tokenInDecimals: currencyIn.decimals,
+        tokenOutChainId: currencyOut.chainId,
+        tokenOutAddress: currencyOut.isNative ? ADDRESS_ZERO : currencyOut.address,
+        tokenOutDecimals: currencyOut.decimals,
+        slippageTolerance: transactionSettings.customSlippageTolerance?.toString() ?? '5',
+      }
+      const deadline = getTradeSettingsDeadline(transactionSettings.customDeadline)
+
+      // The api's /v1/swap endpoint detects routing=SATSUMA and emits Algebra
+      // SwapRouter exactInputSingle calldata.
+      const swapResponse = await fetchSwap({
+        quote: trade.quote.quote as unknown as CreateSwapRequest['quote'],
+        deadline,
+        customSwapData,
+      })
+
+      const swapTxInfo: TransactionRequestInfo = {
+        txRequests: [swapResponse.swap],
+        gasFeeResult: {
+          value: swapResponse.gasFee,
+          displayValue: convertGasFeeToDisplayValue(swapResponse.gasFee, gasStrategy),
+          isLoading: false,
+          error: null,
+        },
+        gasEstimate: {},
+        swapRequestArgs: undefined,
+      }
+
+      const txRequests = validateTransactionRequests(swapTxInfo.txRequests)
+
+      const result: ClassicSwapTxAndGasInfo = {
+        routing: SATSUMA_ROUTING as unknown as Routing.CLASSIC,
+        trade: trade as unknown as ClassicTrade,
+        ...createGasFields({ swapTxInfo, approvalTxInfo }),
+        ...createApprovalFields({ approvalTxInfo }),
+        txRequests,
+        permit: undefined,
+        swapRequestArgs: undefined,
+        unsigned: false,
+        includesDelegation: false,
+      }
+
+      return result
+    },
+  }
+
+  return service
+}

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService.ts
@@ -3,7 +3,7 @@ import type { ApprovalTxInfo } from 'uniswap/src/features/transactions/swap/revi
 import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
 import type { SwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
 import type { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
-import type { GatewayJusdRouting } from 'uniswap/src/features/transactions/swap/utils/routing'
+import type { GatewayJusdRouting, SatsumaRouting } from 'uniswap/src/features/transactions/swap/utils/routing'
 
 export type SwapTxAndGasInfoParameters<T extends Trade = Trade> = {
   derivedSwapInfo: DerivedSwapInfo
@@ -16,14 +16,16 @@ export interface SwapTxAndGasInfoService<T extends Trade = Trade> {
   getSwapTxAndGasInfo: (ctx: SwapTxAndGasInfoParameters<T>) => Promise<SwapTxAndGasInfo>
 }
 
-// Include both Routing enum values and custom routing types like GATEWAY_JUSD
+// Include both Routing enum values and custom routing types like GATEWAY_JUSD and SATSUMA
 export type RoutingServicesMap = { [K in Routing]: SwapTxAndGasInfoService<Trade & { routing: K }> } & {
   [K in GatewayJusdRouting]: SwapTxAndGasInfoService<Trade & { routing: K }>
+} & {
+  [K in SatsumaRouting]: SwapTxAndGasInfoService<Trade & { routing: K }>
 }
 
 export function createSwapTxAndGasInfoService(ctx: { services: RoutingServicesMap }): SwapTxAndGasInfoService<Trade> {
   function getServiceForTrade<T extends Trade>(trade: T): SwapTxAndGasInfoService<T> {
-    const service = ctx.services[trade.routing as Routing | GatewayJusdRouting]
+    const service = ctx.services[trade.routing as Routing | GatewayJusdRouting | SatsumaRouting]
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!service) {
       throw new Error(`Unsupported routing: ${trade.routing}`)

--- a/packages/uniswap/src/features/transactions/swap/types/trade.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/trade.ts
@@ -1,13 +1,30 @@
 /* eslint-disable max-lines */
 import { MixedRouteSDK, Trade as RouterSDKTrade, ZERO_PERCENT } from '@juiceswapxyz/router-sdk'
 import { Currency, CurrencyAmount, Percent, Price, TradeType } from '@juiceswapxyz/sdk-core'
-import { UnsignedV2DutchOrderInfo, V2DutchOrderTrade, PriorityOrderTrade as IPriorityOrderTrade, UnsignedPriorityOrderInfo, V3DutchOrderTrade, UnsignedV3DutchOrderInfo } from '@uniswap/uniswapx-sdk'
 import { Route as V2RouteSDK } from '@juiceswapxyz/v2-sdk'
 import { Route as V3RouteSDK } from '@juiceswapxyz/v3-sdk'
 import { Route as V4RouteSDK } from '@juiceswapxyz/v4-sdk'
-import { BridgeQuoteResponse, ClassicQuoteResponse, DutchQuoteResponse, DutchV3QuoteResponse, GatewayJusdQuoteResponse, PriorityQuoteResponse, WrapQuoteResponse } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
+import {
+  PriorityOrderTrade as IPriorityOrderTrade,
+  UnsignedPriorityOrderInfo,
+  UnsignedV2DutchOrderInfo,
+  UnsignedV3DutchOrderInfo,
+  V2DutchOrderTrade,
+  V3DutchOrderTrade,
+} from '@uniswap/uniswapx-sdk'
 import { BigNumber, providers } from 'ethers/lib/ethers'
 import { PollingInterval } from 'uniswap/src/constants/misc'
+import { MAX_AUTO_SLIPPAGE_TOLERANCE } from 'uniswap/src/constants/transactions'
+import {
+  BridgeQuoteResponse,
+  ClassicQuoteResponse,
+  DutchQuoteResponse,
+  DutchV3QuoteResponse,
+  GatewayJusdQuoteResponse,
+  PriorityQuoteResponse,
+  SatsumaQuoteResponse,
+  WrapQuoteResponse,
+} from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
 import {
   ClassicInput,
   ClassicOutput,
@@ -17,15 +34,18 @@ import {
   QuoteResponse,
   Routing,
 } from 'uniswap/src/data/tradingApi/__generated__/index'
-import { getCurrencyAmount, ValueType } from 'uniswap/src/features/tokens/getCurrencyAmount'
-import { FrontendSupportedProtocol } from 'uniswap/src/features/transactions/swap/utils/protocols'
-import { MAX_AUTO_SLIPPAGE_TOLERANCE } from 'uniswap/src/constants/transactions'
-import { getSwapFee } from 'uniswap/src/features/transactions/swap/types/getSwapFee'
 import { GasEstimate } from 'uniswap/src/data/tradingApi/types'
-import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
+import { ValueType, getCurrencyAmount } from 'uniswap/src/features/tokens/getCurrencyAmount'
+import { getSwapFee } from 'uniswap/src/features/transactions/swap/types/getSwapFee'
 import { slippageToleranceToPercent } from 'uniswap/src/features/transactions/swap/utils/format'
+import { FrontendSupportedProtocol } from 'uniswap/src/features/transactions/swap/utils/protocols'
+import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 
-type QuoteResponseWithAggregatedOutputs = ClassicQuoteResponse | DutchQuoteResponse | DutchV3QuoteResponse | PriorityQuoteResponse
+type QuoteResponseWithAggregatedOutputs =
+  | ClassicQuoteResponse
+  | DutchQuoteResponse
+  | DutchV3QuoteResponse
+  | PriorityQuoteResponse
 
 /**
  * Calculates the total output amount from a quote by summing all aggregated outputs.
@@ -38,7 +58,10 @@ type QuoteResponseWithAggregatedOutputs = ClassicQuoteResponse | DutchQuoteRespo
  * const quote = { quote: { aggregatedOutputs: [{ amount: '100' }, { amount: '200' }] } }
  * const amount = getQuoteOutputAmount(quote, USDC) // Returns 300 USDC
  */
-function getQuoteOutputAmount<T extends QuoteResponseWithAggregatedOutputs>(quote: T | undefined, outputCurrency: Currency): CurrencyAmount<Currency> {
+function getQuoteOutputAmount<T extends QuoteResponseWithAggregatedOutputs>(
+  quote: T | undefined,
+  outputCurrency: Currency,
+): CurrencyAmount<Currency> {
   if (!quote) {
     return CurrencyAmount.fromRawAmount(outputCurrency, '0')
   }
@@ -51,15 +74,19 @@ function getQuoteOutputAmount<T extends QuoteResponseWithAggregatedOutputs>(quot
 
     if (outputAmount) {
       // Ensure we use the integer value, not the decimal string
-      const amountString = typeof outputAmount === 'string' && !outputAmount.includes('.')
-        ? outputAmount
-        : outputAmount.toString()
+      const amountString =
+        typeof outputAmount === 'string' && !outputAmount.includes('.') ? outputAmount : outputAmount.toString()
 
       return CurrencyAmount.fromRawAmount(outputCurrency, amountString)
     }
   }
 
-  return quote.quote.aggregatedOutputs?.reduce((acc, output) => acc.add(CurrencyAmount.fromRawAmount(outputCurrency, output.amount ?? '0')), CurrencyAmount.fromRawAmount(outputCurrency, '0')) ?? CurrencyAmount.fromRawAmount(outputCurrency, '0')
+  return (
+    quote.quote.aggregatedOutputs?.reduce(
+      (acc, output) => acc.add(CurrencyAmount.fromRawAmount(outputCurrency, output.amount ?? '0')),
+      CurrencyAmount.fromRawAmount(outputCurrency, '0'),
+    ) ?? CurrencyAmount.fromRawAmount(outputCurrency, '0')
+  )
 }
 
 /**
@@ -91,7 +118,9 @@ function getQuoteOutputAmountUserWillReceive<T extends QuoteResponseWithAggregat
   }
 
   const output = quote.quote.aggregatedOutputs?.find((out) => out.recipient === recipient)
-  return output ? CurrencyAmount.fromRawAmount(outputCurrency, output.minAmount ?? '0') : CurrencyAmount.fromRawAmount(outputCurrency, '0')
+  return output
+    ? CurrencyAmount.fromRawAmount(outputCurrency, output.minAmount ?? '0')
+    : CurrencyAmount.fromRawAmount(outputCurrency, '0')
 }
 
 export type UniswapXTrade = UniswapXV2Trade | UniswapXV3Trade | PriorityOrderTrade
@@ -184,8 +213,8 @@ export class UniswapXV3Trade extends V3DutchOrderTrade<Currency, Currency, Trade
     tradeType: TradeType
   }) {
     const orderInfo = transformToV3DutchOrderInfo(quote.quote.orderInfo)
-    const { expectedAmountIn, expectedAmountOut} = quote.quote
-    const expectedAmounts = expectedAmountIn && expectedAmountOut ? { expectedAmountIn, expectedAmountOut  } : undefined
+    const { expectedAmountIn, expectedAmountOut } = quote.quote
+    const expectedAmounts = expectedAmountIn && expectedAmountOut ? { expectedAmountIn, expectedAmountOut } : undefined
 
     super({ currencyIn, currenciesOut: [currencyOut], orderInfo, tradeType, expectedAmounts })
 
@@ -255,8 +284,8 @@ export class PriorityOrderTrade extends IPriorityOrderTrade<Currency, Currency, 
     tradeType: TradeType
   }) {
     const orderInfo = transformToPriorityOrderInfo(quote.quote.orderInfo)
-    const { expectedAmountIn, expectedAmountOut} = quote.quote
-    const expectedAmounts = expectedAmountIn && expectedAmountOut ? { expectedAmountIn, expectedAmountOut  } : undefined
+    const { expectedAmountIn, expectedAmountOut } = quote.quote
+    const expectedAmounts = expectedAmountIn && expectedAmountOut ? { expectedAmountIn, expectedAmountOut } : undefined
 
     super({ currencyIn, currenciesOut: [currencyOut], orderInfo, tradeType, expectedAmounts })
 
@@ -376,7 +405,9 @@ export class ClassicTrade<
   public get priceImpact(): Percent {
     if (!this._cachedPriceImpact) {
       const quotePriceImpact = this.quote.quote.priceImpact
-      this._cachedPriceImpact = quotePriceImpact ? new Percent(Math.round(quotePriceImpact * 100), 10000) : super.priceImpact
+      this._cachedPriceImpact = quotePriceImpact
+        ? new Percent(Math.round(quotePriceImpact * 100), 10000)
+        : super.priceImpact
     }
     return this._cachedPriceImpact
   }
@@ -398,7 +429,16 @@ export type Trade<
   TInput extends Currency = Currency,
   TOutput extends Currency = Currency,
   TTradeType extends TradeType = TradeType,
-> = ClassicTrade<TInput, TOutput, TTradeType> | UniswapXTrade | BridgeTrade | GatewayJusdTrade | BitcoinBridgeTrade | LightningBridgeTrade | WrapTrade | UnwrapTrade
+> =
+  | ClassicTrade<TInput, TOutput, TTradeType>
+  | UniswapXTrade
+  | BridgeTrade
+  | GatewayJusdTrade
+  | SatsumaTrade
+  | BitcoinBridgeTrade
+  | LightningBridgeTrade
+  | WrapTrade
+  | UnwrapTrade
 
 export type TradeWithSlippage = Exclude<Trade, BridgeTrade | BitcoinBridgeTrade | LightningBridgeTrade>
 
@@ -455,19 +495,20 @@ export enum ApprovalAction {
 
 export type TokenApprovalInfo =
   | {
-    action: ApprovalAction.None | ApprovalAction.Unknown
-    txRequest: null
-    cancelTxRequest: null
+      action: ApprovalAction.None | ApprovalAction.Unknown
+      txRequest: null
+      cancelTxRequest: null
     }
   | {
-    action: ApprovalAction.Permit2Approve
-    txRequest: providers.TransactionRequest
-    cancelTxRequest: null
-  } | {
-    action: ApprovalAction.RevokeAndPermit2Approve
-    txRequest: providers.TransactionRequest
-    cancelTxRequest: providers.TransactionRequest
-  }
+      action: ApprovalAction.Permit2Approve
+      txRequest: providers.TransactionRequest
+      cancelTxRequest: null
+    }
+  | {
+      action: ApprovalAction.RevokeAndPermit2Approve
+      txRequest: providers.TransactionRequest
+      cancelTxRequest: providers.TransactionRequest
+    }
 
 // Converts from BE type to SDK type
 function transformToV2DutchOrderInfo(orderInfo: DutchOrderInfoV2): UnsignedV2DutchOrderInfo {
@@ -532,19 +573,18 @@ function transformToPriorityOrderInfo(orderInfo: PriorityOrderInfo): UnsignedPri
     input: {
       token: orderInfo.input.token,
       amount: BigNumber.from(orderInfo.input.amount),
-      mpsPerPriorityFeeWei:  BigNumber.from(orderInfo.input.mpsPerPriorityFeeWei),
+      mpsPerPriorityFeeWei: BigNumber.from(orderInfo.input.mpsPerPriorityFeeWei),
     },
     outputs: orderInfo.outputs.map((output) => ({
       token: output.token,
       amount: BigNumber.from(output.amount),
-      mpsPerPriorityFeeWei:  BigNumber.from(output.mpsPerPriorityFeeWei),
+      mpsPerPriorityFeeWei: BigNumber.from(output.mpsPerPriorityFeeWei),
       recipient: output.recipient,
     })),
     baselinePriorityFeeWei: BigNumber.from(orderInfo.baselinePriorityFeeWei),
     auctionStartBlock: BigNumber.from(orderInfo.auctionStartBlock),
   }
 }
-
 
 export type ValidatedIndicativeQuoteResponse = QuoteResponse & {
   input: Required<ClassicInput>
@@ -558,8 +598,12 @@ export function validateIndicativeQuoteResponse(response: QuoteResponse): Valida
     if (!input || !output) {
       return undefined
     }
-    if (input.amount  && input.token && output.amount  && output.token && output.recipient)  {
-      return { ...response, input:  { amount: input.amount, token: input.token }, output: { amount: output.amount, token: output.token, recipient: output.recipient }}
+    if (input.amount && input.token && output.amount && output.token && output.recipient) {
+      return {
+        ...response,
+        input: { amount: input.amount, token: input.token },
+        output: { amount: output.amount, token: output.token, recipient: output.recipient },
+      }
     }
   }
   return undefined
@@ -576,11 +620,29 @@ export class IndicativeTrade {
   slippageTolerance?: number
   readonly indicative = true
 
-  constructor({ quote, currencyIn, currencyOut, slippageTolerance }: { quote: ValidatedIndicativeQuoteResponse, currencyIn: Currency, currencyOut: Currency, slippageTolerance?: number }) {
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    slippageTolerance,
+  }: {
+    quote: ValidatedIndicativeQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    slippageTolerance?: number
+  }) {
     this.quote = quote
 
-    const inputAmount = getCurrencyAmount({ value: this.quote.input.amount, valueType: ValueType.Raw, currency: currencyIn })
-    const outputAmount = getCurrencyAmount({ value: this.quote.output.amount, valueType: ValueType.Raw, currency: currencyOut })
+    const inputAmount = getCurrencyAmount({
+      value: this.quote.input.amount,
+      valueType: ValueType.Raw,
+      currency: currencyIn,
+    })
+    const outputAmount = getCurrencyAmount({
+      value: this.quote.output.amount,
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
 
     if (!inputAmount || !outputAmount) {
       throw new Error('Error parsing indicative quote currency amounts')
@@ -619,7 +681,17 @@ export class BridgeTrade {
   readonly priceImpact: undefined
   readonly deadline: undefined
 
-  constructor({ quote, currencyIn, currencyOut, tradeType }: { quote: BridgeQuoteResponse, currencyIn: Currency, currencyOut: Currency, tradeType: TradeType }) {
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: BridgeQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
     this.quote = quote
     this.routing = quote.routing as Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP | Routing.WBTC_BRIDGE
     this.swapFee = getSwapFee(quote)
@@ -631,7 +703,11 @@ export class BridgeTrade {
     }
 
     const inputAmount = getCurrencyAmount({ value: quoteInputAmount, valueType: ValueType.Raw, currency: currencyIn })
-    const outputAmount = getCurrencyAmount({ value: quoteOutputAmount, valueType: ValueType.Raw, currency: currencyOut })
+    const outputAmount = getCurrencyAmount({
+      value: quoteOutputAmount,
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
     if (!inputAmount || !outputAmount) {
       throw new Error('Error parsing bridge quote currency amounts')
     }
@@ -651,7 +727,13 @@ export class BridgeTrade {
   }
 
   public get quoteOutputAmountUserWillReceive(): CurrencyAmount<Currency> {
-    const swapFeeAmount = this.swapFee ? getCurrencyAmount({ value: this.swapFee.amount, valueType: ValueType.Raw, currency: this.outputAmount.currency }) : undefined
+    const swapFeeAmount = this.swapFee
+      ? getCurrencyAmount({
+          value: this.swapFee.amount,
+          valueType: ValueType.Raw,
+          currency: this.outputAmount.currency,
+        })
+      : undefined
 
     if (swapFeeAmount) {
       return this.outputAmount.add(swapFeeAmount)
@@ -685,7 +767,17 @@ export class GatewayJusdTrade {
   readonly priceImpact: undefined
   readonly deadline: undefined
 
-  constructor({ quote, currencyIn, currencyOut, tradeType }: { quote: GatewayJusdQuoteResponse, currencyIn: Currency, currencyOut: Currency, tradeType: TradeType }) {
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: GatewayJusdQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
     this.quote = quote
 
     const quoteInputAmount = quote.quote.input.amount
@@ -695,7 +787,11 @@ export class GatewayJusdTrade {
     }
 
     const inputAmount = getCurrencyAmount({ value: quoteInputAmount, valueType: ValueType.Raw, currency: currencyIn })
-    const outputAmount = getCurrencyAmount({ value: quoteOutputAmount, valueType: ValueType.Raw, currency: currencyOut })
+    const outputAmount = getCurrencyAmount({
+      value: quoteOutputAmount,
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
     if (!inputAmount || !outputAmount) {
       throw new Error('Error parsing Gateway JUSD quote currency amounts')
     }
@@ -707,6 +803,78 @@ export class GatewayJusdTrade {
     this.slippageTolerance = quote.quote.slippage ?? 0
 
     /* Gateway trades use slippage from the underlying swap */
+    this.maxAmountIn = this.inputAmount
+    this.minAmountOut = this.outputAmount
+  }
+
+  public get quoteOutputAmount(): CurrencyAmount<Currency> {
+    return this.outputAmount
+  }
+
+  public get quoteOutputAmountUserWillReceive(): CurrencyAmount<Currency> {
+    return this.outputAmount
+  }
+}
+
+/**
+ * SatsumaTrade handles direct swaps via the Satsuma USDC.e/ctUSD pool.
+ * The api emits a Classic-shaped quote (with route/routeString/quote fields)
+ * tagged `routing: 'SATSUMA'`. We parse the same input/output amount fields
+ * as Classic but keep the routing tag distinct so the swap-tx-builder
+ * targets the Satsuma SwapRouter instead of SwapRouter02.
+ */
+export class SatsumaTrade {
+  readonly quote: SatsumaQuoteResponse
+  readonly inputAmount: CurrencyAmount<Currency>
+  readonly outputAmount: CurrencyAmount<Currency>
+  readonly maxAmountIn: CurrencyAmount<Currency>
+  readonly minAmountOut: CurrencyAmount<Currency>
+  readonly executionPrice: Price<Currency, Currency>
+
+  readonly tradeType: TradeType
+  // Custom literal type to keep this distinct from ClassicTrade in unions
+  readonly routing = 'SATSUMA' as const
+  readonly indicative = false
+  readonly swapFee?: SwapFee
+  readonly inputTax: Percent = ZERO_PERCENT
+  readonly outputTax: Percent = ZERO_PERCENT
+
+  readonly slippageTolerance: number
+  readonly priceImpact: undefined
+  readonly deadline: undefined
+
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: SatsumaQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
+    this.quote = quote
+
+    const inputRaw = quote.quote.amount
+    const outputRaw = quote.quote.quote
+    if (!inputRaw || !outputRaw) {
+      throw new Error('Error parsing Satsuma quote currency amounts')
+    }
+
+    const inputAmount = getCurrencyAmount({ value: inputRaw, valueType: ValueType.Raw, currency: currencyIn })
+    const outputAmount = getCurrencyAmount({ value: outputRaw, valueType: ValueType.Raw, currency: currencyOut })
+    if (!inputAmount || !outputAmount) {
+      throw new Error('Error parsing Satsuma quote currency amounts')
+    }
+
+    this.inputAmount = inputAmount
+    this.outputAmount = outputAmount
+    this.executionPrice = new Price(currencyIn, currencyOut, inputRaw, outputRaw)
+    this.tradeType = tradeType
+    this.slippageTolerance = 0
+
+    // Satsuma trades use slippage applied at /v1/swap submit time
     this.maxAmountIn = this.inputAmount
     this.minAmountOut = this.outputAmount
   }
@@ -739,7 +907,17 @@ export class BitcoinBridgeTrade {
   readonly priceImpact: undefined
   readonly deadline: undefined
 
-  constructor({ quote, currencyIn, currencyOut, tradeType }: { quote: BridgeQuoteResponse, currencyIn: Currency, currencyOut: Currency, tradeType: TradeType }) {
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: BridgeQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
     this.quote = quote
     this.swapFee = getSwapFee(quote)
 
@@ -750,7 +928,11 @@ export class BitcoinBridgeTrade {
     }
 
     const inputAmount = getCurrencyAmount({ value: quoteInputAmount, valueType: ValueType.Raw, currency: currencyIn })
-    const outputAmount = getCurrencyAmount({ value: quoteOutputAmount, valueType: ValueType.Raw, currency: currencyOut })
+    const outputAmount = getCurrencyAmount({
+      value: quoteOutputAmount,
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
     if (!inputAmount || !outputAmount) {
       throw new Error('Error parsing Bitcoin bridge quote currency amounts')
     }
@@ -769,7 +951,13 @@ export class BitcoinBridgeTrade {
   }
 
   public get quoteOutputAmountUserWillReceive(): CurrencyAmount<Currency> {
-    const swapFeeAmount = this.swapFee ? getCurrencyAmount({ value: this.swapFee.amount, valueType: ValueType.Raw, currency: this.outputAmount.currency }) : undefined
+    const swapFeeAmount = this.swapFee
+      ? getCurrencyAmount({
+          value: this.swapFee.amount,
+          valueType: ValueType.Raw,
+          currency: this.outputAmount.currency,
+        })
+      : undefined
 
     if (swapFeeAmount) {
       return this.outputAmount.add(swapFeeAmount)
@@ -798,7 +986,17 @@ export class LightningBridgeTrade {
   readonly priceImpact: undefined
   readonly deadline: undefined
 
-  constructor({ quote, currencyIn, currencyOut, tradeType }: { quote: BridgeQuoteResponse, currencyIn: Currency, currencyOut: Currency, tradeType: TradeType }) {
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: BridgeQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
     this.quote = quote
     this.swapFee = getSwapFee(quote)
 
@@ -809,7 +1007,11 @@ export class LightningBridgeTrade {
     }
 
     const inputAmount = getCurrencyAmount({ value: quoteInputAmount, valueType: ValueType.Raw, currency: currencyIn })
-    const outputAmount = getCurrencyAmount({ value: quoteOutputAmount, valueType: ValueType.Raw, currency: currencyOut })
+    const outputAmount = getCurrencyAmount({
+      value: quoteOutputAmount,
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
     if (!inputAmount || !outputAmount) {
       throw new Error('Error parsing Lightning bridge quote currency amounts')
     }
@@ -828,7 +1030,13 @@ export class LightningBridgeTrade {
   }
 
   public get quoteOutputAmountUserWillReceive(): CurrencyAmount<Currency> {
-    const swapFeeAmount = this.swapFee ? getCurrencyAmount({ value: this.swapFee.amount, valueType: ValueType.Raw, currency: this.outputAmount.currency }) : undefined
+    const swapFeeAmount = this.swapFee
+      ? getCurrencyAmount({
+          value: this.swapFee.amount,
+          valueType: ValueType.Raw,
+          currency: this.outputAmount.currency,
+        })
+      : undefined
 
     if (swapFeeAmount) {
       return this.outputAmount.add(swapFeeAmount)
@@ -854,7 +1062,17 @@ abstract class BaseWrapTrade<TWrapType extends Routing.WRAP | Routing.UNWRAP> {
   readonly slippageTolerance = 0
   readonly priceImpact: undefined
   readonly deadline: undefined
-  constructor({ quote, currencyIn, currencyOut, tradeType }: { quote: WrapQuoteResponse<TWrapType>, currencyIn: Currency, currencyOut: Currency, tradeType: TradeType}) {
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: WrapQuoteResponse<TWrapType>
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
     this.quote = quote
     const quoteInputAmount = quote.quote.input?.amount
     const quoteOutputAmount = quote.quote.output?.amount
@@ -862,7 +1080,11 @@ abstract class BaseWrapTrade<TWrapType extends Routing.WRAP | Routing.UNWRAP> {
       throw new Error('Error parsing wrap/unwrap quote currency amounts')
     }
     const inputAmount = getCurrencyAmount({ value: quoteInputAmount, valueType: ValueType.Raw, currency: currencyIn })
-    const outputAmount = getCurrencyAmount({ value: quoteOutputAmount, valueType: ValueType.Raw, currency: currencyOut })
+    const outputAmount = getCurrencyAmount({
+      value: quoteOutputAmount,
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
     if (!inputAmount || !outputAmount) {
       throw new Error('Error parsing wrap/unwrap quote currency amounts')
     }
@@ -890,4 +1112,3 @@ export class WrapTrade extends BaseWrapTrade<Routing.WRAP> {
 export class UnwrapTrade extends BaseWrapTrade<Routing.UNWRAP> {
   readonly routing = Routing.UNWRAP
 }
-

--- a/packages/uniswap/src/features/transactions/swap/utils/routing.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/routing.ts
@@ -7,10 +7,16 @@ export const GATEWAY_JUSD_ROUTING = 'GATEWAY_JUSD' as const
 export const GATEWAY_JUICE_IN_ROUTING = 'GATEWAY_JUICE_IN' as const
 export const GATEWAY_JUICE_OUT_ROUTING = 'GATEWAY_JUICE_OUT' as const
 
+// Satsuma direct routing — used when the JuiceSwap Quote API picks the
+// Satsuma USDC.e/ctUSD pool over the thin JuiceSwap V3 Classic pool.
+export const SATSUMA_ROUTING = 'SATSUMA' as const
+
 export type GatewayJusdRouting =
   | typeof GATEWAY_JUSD_ROUTING
   | typeof GATEWAY_JUICE_IN_ROUTING
   | typeof GATEWAY_JUICE_OUT_ROUTING
+
+export type SatsumaRouting = typeof SATSUMA_ROUTING
 
 // All Gateway routing variants
 // Note: SUSD is routed through Gateway via registerBridgedToken() - no separate routing type needed
@@ -21,7 +27,7 @@ export const GATEWAY_ROUTING_VARIANTS = [
 ] as const
 
 // TradeRouting encompasses all routing types including custom ones not in the Routing enum
-export type TradeRouting = Routing | GatewayJusdRouting
+export type TradeRouting = Routing | GatewayJusdRouting | SatsumaRouting
 
 export const UNISWAPX_ROUTING_VARIANTS = [
   Routing.DUTCH_V2,
@@ -43,10 +49,16 @@ export function isGatewayJusd<T extends { routing: TradeRouting }>(obj: T): obj 
   return GATEWAY_ROUTING_VARIANTS.includes(obj.routing as GatewayJusdRouting)
 }
 
+export function isSatsuma<T extends { routing: TradeRouting }>(obj: T): obj is T & { routing: SatsumaRouting } {
+  return obj.routing === SATSUMA_ROUTING
+}
+
 export function isBridge<T extends { routing: TradeRouting }>(
   obj: T,
 ): obj is T & { routing: Routing.BRIDGE | Routing.ERC20_CHAIN_SWAP | Routing.WBTC_BRIDGE } {
-  return obj.routing === Routing.BRIDGE || obj.routing === Routing.ERC20_CHAIN_SWAP || obj.routing === Routing.WBTC_BRIDGE
+  return (
+    obj.routing === Routing.BRIDGE || obj.routing === Routing.ERC20_CHAIN_SWAP || obj.routing === Routing.WBTC_BRIDGE
+  )
 }
 
 export function isBitcoinBridge<T extends { routing: TradeRouting }>(
@@ -67,9 +79,7 @@ export function isErc20ChainSwap<T extends { routing: TradeRouting }>(
   return obj.routing === Routing.ERC20_CHAIN_SWAP
 }
 
-export function isWbtcBridge<T extends { routing: TradeRouting }>(
-  obj: T,
-): obj is T & { routing: Routing.WBTC_BRIDGE } {
+export function isWbtcBridge<T extends { routing: TradeRouting }>(obj: T): obj is T & { routing: Routing.WBTC_BRIDGE } {
   return obj.routing === Routing.WBTC_BRIDGE
 }
 

--- a/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
@@ -56,7 +56,7 @@ import {
 } from 'uniswap/src/features/transactions/swap/types/trade'
 import type { FrontendSupportedProtocol } from 'uniswap/src/features/transactions/swap/utils/protocols'
 import { DEFAULT_PROTOCOL_OPTIONS, useProtocolsForChain } from 'uniswap/src/features/transactions/swap/utils/protocols'
-import { isClassic } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { isClassic, isSatsuma } from 'uniswap/src/features/transactions/swap/utils/routing'
 import type { CurrencyField } from 'uniswap/src/types/currency'
 import { areAddressesEqual } from 'uniswap/src/utils/addresses'
 import { currencyAddress, currencyId } from 'uniswap/src/utils/currencyId'
@@ -459,6 +459,13 @@ export function getClassicQuoteFromResponse(
 ): ClassicQuote | undefined {
   if (quote && isClassic(quote)) {
     return quote.quote
+  }
+  // Satsuma quotes are emitted by the api with the same field shape as
+  // Classic quotes (quoteId, gasUseEstimate, routeString, …) — surfacing
+  // them here lets transaction-history and analytics treat SATSUMA swaps
+  // exactly like Classic.
+  if (quote && isSatsuma(quote)) {
+    return quote.quote as unknown as ClassicQuote
   }
   return undefined
 }

--- a/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
@@ -11,6 +11,7 @@ import { nativeOnChain } from 'uniswap/src/constants/tokens'
 import type {
   BridgeQuoteResponse,
   GatewayJusdQuoteResponse,
+  SatsumaQuoteResponse,
 } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
 import {
   ClassicQuoteResponse,
@@ -47,6 +48,7 @@ import {
   GatewayJusdTrade,
   LightningBridgeTrade,
   PriorityOrderTrade,
+  SatsumaTrade,
   UniswapXV2Trade,
   UniswapXV3Trade,
   UnwrapTrade,
@@ -157,6 +159,16 @@ export function transformTradingApiResponseToTrade(params: TradingApiResponseToT
       if (unknownData && gatewayRoutingTypes.includes(routingType)) {
         return new GatewayJusdTrade({
           quote: unknownData as unknown as GatewayJusdQuoteResponse,
+          currencyIn,
+          currencyOut,
+          tradeType,
+        })
+      }
+
+      // Handle Satsuma direct routing (USDC.e/ctUSD on Citrea)
+      if (unknownData && routingType === 'SATSUMA') {
+        return new SatsumaTrade({
+          quote: unknownData as unknown as SatsumaQuoteResponse,
           currencyIn,
           currencyOut,
           tradeType,
@@ -439,7 +451,11 @@ export function toTradingApiSupportedChainId(chainId: Maybe<number>): TradingApi
 }
 
 export function getClassicQuoteFromResponse(
-  quote?: ClassicQuoteResponse | { routing: Exclude<Routing, Routing.CLASSIC> } | GatewayJusdQuoteResponse,
+  quote?:
+    | ClassicQuoteResponse
+    | { routing: Exclude<Routing, Routing.CLASSIC> }
+    | GatewayJusdQuoteResponse
+    | SatsumaQuoteResponse,
 ): ClassicQuote | undefined {
   if (quote && isClassic(quote)) {
     return quote.quote

--- a/packages/uniswap/src/utils/approvalCalldata.ts
+++ b/packages/uniswap/src/utils/approvalCalldata.ts
@@ -9,10 +9,15 @@ const ERC20_APPROVE_SELECTOR = '0x095ea7b3'
 const GATEWAY_ROUTING_VARIANTS = ['GATEWAY_JUSD', 'GATEWAY_JUICE_IN', 'GATEWAY_JUICE_OUT'] as const
 type GatewayRoutingVariant = (typeof GATEWAY_ROUTING_VARIANTS)[number]
 
+// Satsuma SwapRouter on Citrea Mainnet — kept local to avoid circular dependency.
+// Source of truth: api/src/services/SatsumaPoolService.ts
+const SATSUMA_SWAP_ROUTER_CITREA_MAINNET = '0x3012e9049d05b4b5369d690114d5a5861ebb85cb'
+
 /**
  * Determines the appropriate spender address for swaps
  * Uses sdk-core as single source of truth for router addresses
  * For Gateway swaps (including SUSD), returns JuiceSwapGateway address
+ * For Satsuma direct swaps, returns the Satsuma SwapRouter address
  */
 export function getSpenderAddress(chainId: UniverseChainId, routing?: string): string {
   // For Gateway swaps (JUSD abstraction, JUICE equity, SUSD bridging), use JuiceSwapGateway as spender
@@ -22,6 +27,14 @@ export function getSpenderAddress(chainId: UniverseChainId, routing?: string): s
       throw new Error(`No JuiceSwapGateway address for chainId ${chainId}`)
     }
     return gatewayAddress
+  }
+
+  // For Satsuma direct swaps the router is a separate Algebra contract.
+  if (routing === 'SATSUMA') {
+    if (chainId !== UniverseChainId.CitreaMainnet) {
+      throw new Error(`Satsuma routing is only supported on Citrea Mainnet (got ${chainId})`)
+    }
+    return SATSUMA_SWAP_ROUTER_CITREA_MAINNET
   }
 
   return SWAP_ROUTER_02_ADDRESSES(chainId)


### PR DESCRIPTION
## Summary

Teach the frontend to handle the new \`routing: 'SATSUMA'\` quote that the JuiceSwap api emits for USDC.e ↔ ctUSD trades when the Satsuma Algebra pool prices better than the thin JuiceSwap V3 pool. (Backend: JuiceSwapxyz/api#258.)

This is a Gateway-style pattern clone — narrow vertical, no new UI components, picks up the existing review/approval/submit plumbing.

## Why

For USDC.e ↔ ctUSD on Citrea Mainnet the JuiceSwap V3 pool holds ~$5k each side; the Satsuma Algebra pool 0x172d2ab5… holds ~$1.4M and prices virtually 1:1 up to six-figure trades. Without this PR the frontend ignores the better Satsuma quote returned by the api and the user's swap goes through the catastrophic Classic route.

## Changes

- \`packages/uniswap/src/features/transactions/swap/utils/routing.ts\` — new \`SATSUMA_ROUTING\` constant, \`SatsumaRouting\` type, \`isSatsuma\` type guard, extended \`TradeRouting\` union.
- \`packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts\` — new \`SatsumaQuote\` and \`SatsumaQuoteResponse\` types, mirrored on the \`GatewayJusdQuoteResponse\` pattern.
- \`packages/uniswap/src/features/transactions/swap/types/trade.ts\` — new \`SatsumaTrade\` class, added to the \`Trade\` union.
- \`packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts\` — \`transformTradingApiResponseToTrade\` recognises \`routing === 'SATSUMA'\` and instantiates a \`SatsumaTrade\`.
- \`packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts\` — **new** service. Calls \`/v1/swap\`, wraps the response as a \`ClassicSwapTxAndGasInfo\` (same trick the Gateway service uses) so the review screen and submit pipeline don't need any other changes.
- \`packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts\` — register the Satsuma service in the routing dispatcher.
- \`packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService.ts\` — extend \`RoutingServicesMap\` to include the SATSUMA key.
- \`packages/uniswap/src/utils/approvalCalldata.ts\` — when routing is \`'SATSUMA'\`, return the Satsuma SwapRouter (\`0x3012e904…\`) as the spender so token approvals target the right contract.

## Scope (intentionally narrow)

- One chain: Citrea Mainnet
- One token pair: USDC.e ↔ ctUSD
- Exact-input only
- No new UI surface — review screen and approval modal pick up the new routing automatically via the existing pipelines.

## Test plan

- [x] \`yarn typecheck\` — adds zero new errors vs. develop baseline (89 pre-existing)
- [x] \`yarn build:production\` from \`apps/web\` succeeds locally
- [ ] CI \`Can Build\` green on this branch (depends on api#258 being live for end-to-end manual checks; type check / build don't depend on it)
- [ ] Manual: with api#258 deployed to dev, run a 3,000 USDC.e → ctUSD swap on \`dev.bapp.juiceswap.com\`. Expect: routing badge says SATSUMA, approval goes to \`0x3012e904…\`, swap submits via Algebra SwapRouter, output ≈ 2,999.47 ctUSD.
- [ ] Manual: small-amount swaps (≤100 USDC.e) still go through GATEWAY_JUSD as before.