### PR TITLE
feat(web): enable JUICE_POINTS_PROGRAM flag for DEV builds

### DIFF
--- a/apps/web/.env.development
+++ b/apps/web/.env.development
@@ -18,6 +18,9 @@ REACT_APP_LDS_API_URL=https://lightning.space/v1
 REACT_APP_CITREA_MAINNET_EXPLORER_URL=https://citreascan.com
 REACT_APP_CITREA_TESTNET_EXPLORER_URL=https://testnet.citreascan.com
 
+# Feature Flags (DEV-only enablement; see PR #747 + issue #748)
+REACT_APP_JUICE_POINTS_PROGRAM=true
+
 # Optional: Add your own Infura key to avoid rate limits
 # Get one for free at: https://infura.io/
 # REACT_APP_INFURA_KEY="your_infura_key_here"


### PR DESCRIPTION
Enables the Juice Points program (Points UI, Leaderboard route, NFT PFP) for DEV builds by setting \`REACT_APP_JUICE_POINTS_PROGRAM=true\` in \`apps/web/.env.development\`.

PRD builds keep the default OFF (\`.env.production\` does not set the var; runtime fallback in \`constants/featureFlags.ts\` is \`false\`).

## Why .env.development and not docker-compose?

Vite bakes \`REACT_APP_*\` into the production bundle at build time, so a runtime \`environment:\` in the dfx/server compose for the \`jsw-dapp\` container would never reach the bundle. Vite's standard pattern is \`.env.{mode}\` files, which the existing DEV/PRD URL split already uses. See PR #747 for context.

## Test plan

- [ ] Push triggers \`JuiceSwap Web DEV CI/CD\` workflow, rebuilds \`juiceswap/dapp:beta\` with the flag baked in
- [ ] Deploy script restarts \`jsw-dapp\` on dfxdev
- [ ] On dev.bapp.juiceswap.com: \`/leaderboard\` loads, points UI visible in drawer + header, NFT cards show "Set PFP" pill
- [ ] PRD (bapp.juiceswap.com) unchanged — features stay dark

## Re-enablement tracking

This is step 1 of issue #748. PRD enablement remains gated until the feature is fully validated.