### PR TITLE
fix(swap): wire Satsuma routing through the swap-tx pipeline

### DIFF
--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService.ts
@@ -25,10 +25,11 @@ import {
   BridgeTrade,
   ClassicTrade,
   GatewayJusdTrade,
+  SatsumaTrade,
   UnwrapTrade,
   WrapTrade,
 } from 'uniswap/src/features/transactions/swap/types/trade'
-import { isGatewayJusd } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { isGatewayJusd, isSatsuma } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { tradingApiToUniverseChainId } from 'uniswap/src/features/transactions/swap/utils/tradingApi'
 
 type SwapInstructions =
@@ -59,7 +60,7 @@ interface EVMSwapInstructionsServiceContext {
 }
 
 export const getCustomSwapTokenData = (
-  trade: ClassicTrade | BridgeTrade | WrapTrade | UnwrapTrade | GatewayJusdTrade | undefined,
+  trade: ClassicTrade | BridgeTrade | WrapTrade | UnwrapTrade | GatewayJusdTrade | SatsumaTrade | undefined,
   transactionSettings?: TransactionSettings,
 ): CustomSwapDataForRequest | undefined => {
   if (!trade) {
@@ -84,8 +85,9 @@ export const getCustomSwapTokenData = (
   }
 
   if (trade.routing === Routing.WRAP || trade.routing === Routing.UNWRAP) {
-    const currencyIn = trade.inputAmount.currency
-    const currencyOut = trade.outputAmount.currency
+    const wrapTrade = trade as WrapTrade | UnwrapTrade
+    const currencyIn = wrapTrade.inputAmount.currency
+    const currencyOut = wrapTrade.outputAmount.currency
 
     return {
       chainId: currencyIn.chainId,
@@ -95,12 +97,18 @@ export const getCustomSwapTokenData = (
       tokenOutChainId: currencyOut.chainId,
       tokenOutAddress: currencyOut.isNative ? ZERO_ADDRESS : currencyOut.address,
       tokenOutDecimals: currencyOut.decimals,
-      amount: trade.quote.quote.input?.amount,
-      type: trade.routing,
+      amount: wrapTrade.quote.quote.input?.amount,
+      type: wrapTrade.routing,
     }
   }
 
-  if (isGatewayJusd(trade)) {
+  if (isGatewayJusd(trade) || isSatsuma(trade)) {
+    // Gateway-JUSD and Satsuma are structurally the same at this layer: both
+    // hit /v1/swap with the user's slippage and the parsed token info; the
+    // backend infers the actual router (JuiceSwapGateway vs Satsuma) from the
+    // routing tag carried on the quote. Without this branch, Satsuma swaps
+    // would fall through to `return undefined` and fetchSwap would default
+    // slippage to 5% instead of using the user's setting.
     const currencyIn = trade.inputAmount.currency
     const currencyOut = trade.outputAmount.currency
 

--- a/packages/uniswap/src/features/transactions/swap/review/stores/swapReviewTransactionStore/SwapReviewTransactionStoreContextProvider.tsx
+++ b/packages/uniswap/src/features/transactions/swap/review/stores/swapReviewTransactionStore/SwapReviewTransactionStoreContextProvider.tsx
@@ -13,6 +13,7 @@ import {
   isErc20ChainSwap,
   isGatewayJusd,
   isLightningBridge,
+  isSatsuma,
   isUniswapX,
   isWbtcBridge,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
@@ -54,7 +55,7 @@ export const SwapReviewTransactionStoreContextProvider = ({
   const tokenWarningProps = getRelevantTokenWarningSeverity(acceptedDerivedSwapInfo)
 
   const txSimulationErrors = useMemo(() => {
-    if (!trade || (!isClassic(trade) && !isGatewayJusd(trade))) {
+    if (!trade || (!isClassic(trade) && !isGatewayJusd(trade) && !isSatsuma(trade))) {
       return undefined
     }
     return (trade.quote.quote as { txFailureReasons?: TransactionFailureReason[] }).txFailureReasons

--- a/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useSwapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useSwapTxAndGasInfo.ts
@@ -22,7 +22,7 @@ import type {
   UniswapXTrade,
   WrapTrade,
 } from 'uniswap/src/features/transactions/swap/types/trade'
-import { isGatewayJusd } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { isGatewayJusd, isSatsuma } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 import { CurrencyField } from 'uniswap/src/types/currency'
 
@@ -66,9 +66,14 @@ export function useSwapTxAndGasInfo({
       return getFallbackSwapTxAndGasInfo({ swapTxInfo, approvalTxInfo })
     }
 
-    // Handle Gateway JUSD routing (uses string literal, not Routing enum)
-    // Gateway trades use the same structure as classic swaps for tx info
-    if (isGatewayJusd(trade)) {
+    // Handle Gateway JUSD and Satsuma routing (string literals, not in the
+    // Routing enum). Both go through the JuiceSwap API /swap endpoint and
+    // produce a single ERC20-router call, so downstream we wrap them as a
+    // Classic swap context. Without this branch, Satsuma trades fall through
+    // to `getFallbackSwapTxAndGasInfo` *and* `useTransactionRequestInfo`
+    // never fires `/v1/swap` for them, so `txRequests` stays undefined and
+    // the review button is stuck on "Loading quote..." forever.
+    if (isGatewayJusd(trade) || isSatsuma(trade)) {
       return getClassicSwapTxAndGasInfo({
         trade: trade as unknown as ClassicTrade,
         swapTxInfo,

--- a/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useTransactionRequestInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useTransactionRequestInfo.ts
@@ -26,6 +26,7 @@ import {
   isBridge,
   isClassic,
   isGatewayJusd,
+  isSatsuma,
   isUniswapX,
   isWrap,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
@@ -50,17 +51,24 @@ function useSwapTransactionRequestInfo({
 
   const swapQuoteResponse = useMemo(() => {
     const quote = derivedSwapInfo.trade.trade?.quote
-    // Gateway JUSD quotes use a separate request params path (see gatewaySwapRequestParams below)
+    // Gateway JUSD and Satsuma quotes use a separate request params path
+    // (see gatewaySwapRequestParams below) because they don't go through the
+    // Universal-Router / Permit2 flow and `fetchSwap` builds the request body
+    // directly from the quote object.
     if (quote && (isClassic(quote) || isBridge(quote) || isBitcoinBridge(quote) || isWrap(quote))) {
       return quote
     }
     return undefined
   }, [derivedSwapInfo.trade.trade?.quote])
 
-  // Separate handling for Gateway JUSD quotes which have a different structure
+  // Separate handling for Gateway JUSD and Satsuma quotes. Both have a
+  // non-Universal-Router structure and call the JuiceSwap API /swap endpoint
+  // directly; `fetchSwap` discriminates between Gateway-shape (`input`/
+  // `output` on the quote) and Satsuma-shape (`route` on the quote) at
+  // request time, so the same upstream params apply to both.
   const gatewayQuoteResponse = useMemo(() => {
     const quote = derivedSwapInfo.trade.trade?.quote
-    if (quote && isGatewayJusd(quote)) {
+    if (quote && (isGatewayJusd(quote) || isSatsuma(quote))) {
       return quote
     }
     return undefined

--- a/packages/uniswap/src/features/transactions/swap/types/swapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/swapTxAndGasInfo.ts
@@ -2,7 +2,7 @@ import { Routing, CreateSwapRequest } from "uniswap/src/data/tradingApi/__genera
 import { GasEstimate } from "uniswap/src/data/tradingApi/types"
 import { GasFeeResult, ValidatedGasFeeResult, validateGasFeeResult } from "uniswap/src/features/gas/types"
 import { BridgeTrade, BitcoinBridgeTrade, LightningBridgeTrade, ClassicTrade, GatewayJusdTrade, UniswapXTrade, UnwrapTrade, WrapTrade } from "uniswap/src/features/transactions/swap/types/trade"
-import { isBridge, isBitcoinBridge, isErc20ChainSwap, isLightningBridge, isClassic, isGatewayJusd, isUniswapX, isWrap, isWbtcBridge, GatewayJusdRouting } from "uniswap/src/features/transactions/swap/utils/routing"
+import { isBridge, isBitcoinBridge, isErc20ChainSwap, isLightningBridge, isClassic, isGatewayJusd, isSatsuma, isUniswapX, isWrap, isWbtcBridge, GatewayJusdRouting } from "uniswap/src/features/transactions/swap/utils/routing"
 import { isInterface } from "utilities/src/platform"
 import { Prettify } from "viem"
 import { ValidatedPermit } from "uniswap/src/features/transactions/swap/utils/trade"
@@ -196,9 +196,16 @@ function validateSwapTxContext(swapTxContext: SwapTxAndGasInfo): ValidatedSwapTx
       return validateClassicStyleSwap<ClassicSwapTxAndGasInfo, ValidatedClassicSwapTxAndGasInfo>({
         swapTxContext, context: swapTxContext, gasFee
       })
-    } else if (isGatewayJusd(swapTxContext)) {
+    } else if (isGatewayJusd(swapTxContext) || isSatsuma(swapTxContext)) {
+      // Satsuma trades take the same validation path as Gateway-JUSD: both are
+      // string-literal routing variants that go through the JuiceSwap API
+      // /swap endpoint and produce a single ERC20-router call. There is no
+      // dedicated SatsumaSwapTxAndGasInfo type — `getClassicSwapTxAndGasInfo`
+      // (called from useSwapTxAndGasInfo) builds a ClassicSwapTxAndGasInfo-
+      // shaped object with the trade's routing carried through, so the cast
+      // here is structurally sound at runtime.
       return validateClassicStyleSwap<GatewayJusdSwapTxAndGasInfo, ValidatedGatewayJusdSwapTxAndGasInfo>({
-        swapTxContext, context: swapTxContext as GatewayJusdSwapTxAndGasInfo, gasFee
+        swapTxContext, context: swapTxContext as unknown as GatewayJusdSwapTxAndGasInfo, gasFee
       })
     } else if (isBitcoinBridge(swapTxContext)) {
       const { trade, txRequests, includesDelegation, destinationAddress } = swapTxContext

--- a/packages/uniswap/src/features/transactions/swap/utils/generateSwapTransactionSteps.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/generateSwapTransactionSteps.ts
@@ -1,4 +1,7 @@
-import { Erc20ChainSwapDirection, WbtcBridgeDirection } from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
+import {
+  Erc20ChainSwapDirection,
+  WbtcBridgeDirection,
+} from 'uniswap/src/data/apiClients/tradingApi/utils/isBitcoinBridge'
 import { BridgeQuote } from 'uniswap/src/data/tradingApi/__generated__'
 import { BitcoinBridgeDirection, LightningBridgeDirection } from 'uniswap/src/data/tradingApi/types'
 import { createApprovalTransactionStep } from 'uniswap/src/features/transactions/steps/approve'
@@ -9,7 +12,6 @@ import { TransactionStep } from 'uniswap/src/features/transactions/steps/types'
 import { createBitcoinBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/bitcoinBridge'
 import { orderClassicSwapSteps } from 'uniswap/src/features/transactions/swap/steps/classicSteps'
 import { createErc20ChainSwapStep } from 'uniswap/src/features/transactions/swap/steps/erc20ChainSwap'
-import { createWbtcBridgeStep } from 'uniswap/src/features/transactions/swap/steps/wbtcBridge'
 import { createLightningBridgeTransactionStep } from 'uniswap/src/features/transactions/swap/steps/lightningBridge'
 import { createSignUniswapXOrderStep } from 'uniswap/src/features/transactions/swap/steps/signOrder'
 import {
@@ -18,6 +20,7 @@ import {
   createSwapTransactionStepBatched,
 } from 'uniswap/src/features/transactions/swap/steps/swap'
 import { orderUniswapXSteps } from 'uniswap/src/features/transactions/swap/steps/uniswapxSteps'
+import { createWbtcBridgeStep } from 'uniswap/src/features/transactions/swap/steps/wbtcBridge'
 import {
   ClassicSwapTxAndGasInfo,
   GatewayJusdSwapTxAndGasInfo,
@@ -31,6 +34,7 @@ import {
   isErc20ChainSwap,
   isGatewayJusd,
   isLightningBridge,
+  isSatsuma,
   isUniswapX,
   isWbtcBridge,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
@@ -45,8 +49,10 @@ export function generateSwapTransactionSteps(txContext: SwapTxAndGasInfo, _v4Ena
     const revocation = createRevocationTransactionStep(revocationTxRequest, trade.inputAmount.currency.wrapped)
     const approval = createApprovalTransactionStep({ txRequest: approveTxRequest, amountIn: trade.inputAmount })
 
-    if (isClassic(txContext) || isGatewayJusd(txContext)) {
-      // Cast to the union type since TypeScript has trouble narrowing with || on complex unions
+    if (isClassic(txContext) || isGatewayJusd(txContext) || isSatsuma(txContext)) {
+      // Cast to the union type since TypeScript has trouble narrowing with || on complex unions.
+      // Satsuma rides the same shape as Gateway here (single ERC20-router call, no Permit2 sign);
+      // see validateSwapTxContext in swapTxAndGasInfo.ts for the matching validation branch.
       const classicContext = txContext as ClassicSwapTxAndGasInfo | GatewayJusdSwapTxAndGasInfo
       const { swapRequestArgs } = classicContext
 


### PR DESCRIPTION
## Summary

The "Loading quote…" surfaced by #746 was permanent for **any USDC.e/ctUSD swap that the Quote API routes via Satsuma** — e.g. `ctUSD → USDC.e` for amounts large enough that the Satsuma Algebra pool beats the V3 Classic pool. The Quote API resolved the route, the `/v1/swap` endpoint builds the calldata, but the legacy swap-tx pipeline did not recognise the `SATSUMA` routing tag at all:

- **`useTransactionRequestInfo`** only flagged Classic / Bridge / Wrap and Gateway JUSD quotes as `/v1/swap` targets. Satsuma quotes fell through both filters, `swapRequestParams` stayed `undefined`, the `useTradingApiSwapQuery` was skipped, and `swapTxInfo.txRequests` stayed `undefined` forever.
- **`useSwapTxAndGasInfo`** short-circuited only Gateway trades into the classic-style context builder. Satsuma trades fell to `getFallbackSwapTxAndGasInfo`, which produced an empty context for the same reason.

Net effect: `isValidSwapTxContext` returned `false` permanently for every Satsuma trade, so #746 correctly labelled it "Loading quote…" — but no request was ever in flight.

## Verification

Reproduced end-to-end against the dev backend with the user's real wallet as `swapper`:

| Call | Result |
|---|---|
| `POST /v1/quote` (154 550 ctUSD → USDC.e) | `routing: "SATSUMA"`, `_internal.routingType: "SATSUMA"` |
| `POST /v1/swap` (same quote) | 200 OK, `_routingType: "SATSUMA"`, calldata for Satsuma SwapRouter `0x3012e9049d05b4b5369d690114d5a5861ebb85cb` |

So the backend was always ready. The bug was 100% on the frontend's quote-routing recognition.

## The Fix

Treat Satsuma alongside Gateway JUSD in both hooks. `fetchSwap` already discriminates between the two quote shapes (`input`/`output` vs. `route[0][0].tokenIn`) when it builds the `/v1/swap` body, so the same upstream params plumbing applies to both.

- `useTransactionRequestInfo`: extend the "gateway-shape" quote-response filter to also accept Satsuma.
- `useSwapTxAndGasInfo`: extend the Gateway short-circuit to also catch Satsuma, wrapping it as a classic-style context.

## Scope

Strictly the two hooks that bridge "Quote API response → SwapTxContext". The `createSatsumaSwapTxAndGasInfoService` service that already exists is **only reachable via the experimental `ServiceBasedSwapTransactionInfo` Statsig flag**, which is always `false` in this fork, so the service-based path never ran in production. This PR fixes the legacy path that's actually in use.

## Test plan

- [ ] On dev: ctUSD → USDC.e on Citrea Mainnet — review screen now resolves, button enables (or transitions to "Approve and swap" if approval needed).
- [ ] On dev: USDC.e → ctUSD — still works (Gateway path was already handled, nothing should regress).
- [ ] CI green.