### PR TITLE
fix(bridge): bump Citrea Mainnet sponsored-claim minimum to 0.0001

### DIFF
--- a/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
+++ b/packages/uniswap/src/features/lds-bridge/LdsBridgeManager.ts
@@ -53,7 +53,7 @@ export const ASSET_CHAIN_ID_MAP: Record<string, UniverseChainId> = {
 }
 
 export const minimumBalanceForSponsoredClaim: Partial<Record<UniverseChainId, number>> = {
-  [UniverseChainId.CitreaMainnet]: 0.0000001,
+  [UniverseChainId.CitreaMainnet]: 0.0001,
   [UniverseChainId.CitreaTestnet]: 0.0000001,
   [UniverseChainId.Mainnet]: 0.0001,
   [UniverseChainId.Polygon]: 0.0001,


### PR DESCRIPTION
## Summary
- Raise `minimumBalanceForSponsoredClaim[UniverseChainId.CitreaMainnet]` from `0.0000001` to `0.0001`.
- Brings Citrea Mainnet in line with the other mainnet thresholds (Ethereum, Polygon); `0.0000001` was a testnet-style value that almost any wallet trivially exceeded.

## Test plan
- [ ] On Citrea Mainnet with a balance < 0.0001, confirm the sponsored-claim path is no longer offered and the user is routed through the normal claim flow.
- [ ] On Citrea Mainnet with a balance ≥ 0.0001, confirm sponsored-claim still triggers as before.
- [ ] Citrea Testnet behavior unchanged (still 0.0000001).