### PR TITLE
fix(chains): reduce Polygon RPC polling rate to spare the public endpoint

### DIFF
--- a/packages/uniswap/src/features/chains/evm/info/polygon.ts
+++ b/packages/uniswap/src/features/chains/evm/info/polygon.ts
@@ -72,5 +72,5 @@ export const POLYGON_CHAIN_INFO = {
     decimals: 18,
     address: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
   },
-  tradingApiPollingIntervalMs: 250,
+  tradingApiPollingIntervalMs: 1000,
 } as const satisfies UniverseChainInfo


### PR DESCRIPTION
## Summary

- Bumps Polygon's `tradingApiPollingIntervalMs` from **250 ms → 1000 ms** in [polygon.ts:75](packages/uniswap/src/features/chains/evm/info/polygon.ts#L75).
- Polygon's primary RPC is the unauthenticated public endpoint `https://polygon-rpc.com/` (see comment at [polygon.ts:62](packages/uniswap/src/features/chains/evm/info/polygon.ts#L62)).

## Why

That single field drives three RPC-traffic-generating loops:

1. viem client `pollingInterval` → every `useBlockNumber({watch})`, `useWaitForTransactionReceipt`, balance/contract watcher ([wagmiConfig.ts:78](apps/web/src/components/Web3Provider/wagmiConfig.ts#L78))
2. Activity polling ([transactions.ts:143](apps/web/src/state/activity/polling/transactions.ts#L143))
3. Wallet tx watcher saga ([watchTransactionSaga.ts:100](packages/wallet/src/features/transactions/watcher/watchTransactionSaga.ts#L100))

At 250 ms × 3 loops, every user with Polygon active hits the public RPC roughly **12 times per second** — wasteful and a real rate-limit/ban risk. Polygon block time is ~2.1 s, so 250 ms means ~8 `eth_blockNumber` polls per block.

At 1000 ms that drops to ~2 polls per block, which is plenty: tx receipts still confirm within ~1 block on average, and quote refresh cadence is well within Polygon's block time. ~4× less traffic to the public endpoint.

Other chains were left alone — they're either on Quicknode (`Public` slot) or the public endpoint already matches block-time-appropriate cadence.

## Test plan

- [ ] Type check passes (`yarn g:typecheck`)
- [ ] Lint passes (`yarn g:lint`)
- [ ] Manual: swap on Polygon and confirm tx receipt resolves promptly (≤ a few seconds)
- [ ] Manual: open DevTools Network tab, filter for `polygon-rpc.com`, confirm `eth_blockNumber` cadence drops from ~4/s to ~1/s