### PR TITLE
fix(chains): switch Polygon RPC to Alchemy

### DIFF
--- a/.github/workflows/web-dev.yaml
+++ b/.github/workflows/web-dev.yaml
@@ -44,6 +44,7 @@ jobs:
           build-args: |
             BUILD_MODE=development
             COMMIT_HASH=${{ github.sha }}
+            REACT_APP_ALCHEMY_API_KEY=${{ secrets.REACT_APP_ALCHEMY_API_KEY }}
 
       - name: Install cloudflared
         run: |

--- a/.github/workflows/web-prd.yaml
+++ b/.github/workflows/web-prd.yaml
@@ -44,6 +44,7 @@ jobs:
           build-args: |
             BUILD_MODE=production
             COMMIT_HASH=${{ github.sha }}
+            REACT_APP_ALCHEMY_API_KEY=${{ secrets.REACT_APP_ALCHEMY_API_KEY }}
 
       - name: Install cloudflared
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,10 @@ RUN yarn g:prepare
 # Build (production or development mode)
 ARG BUILD_MODE=production
 ARG COMMIT_HASH=unknown
+ARG REACT_APP_ALCHEMY_API_KEY
 ENV NODE_ENV=production
 ENV COMMIT_HASH=${COMMIT_HASH}
+ENV REACT_APP_ALCHEMY_API_KEY=${REACT_APP_ALCHEMY_API_KEY}
 RUN yarn web build:${BUILD_MODE}
 
 # --- Serve with nginx ---

--- a/packages/uniswap/src/features/chains/evm/info/polygon.ts
+++ b/packages/uniswap/src/features/chains/evm/info/polygon.ts
@@ -1,6 +1,6 @@
 import { POLYGON_LOGO } from 'ui/src/assets'
+import { config } from 'uniswap/src/config'
 import { Chain as BackendChainId } from 'uniswap/src/data/graphql/uniswap-data-api/__generated__/types-and-hooks'
-import { getQuicknodeEndpointUrl } from 'uniswap/src/features/chains/evm/rpc'
 import { buildChainTokens } from 'uniswap/src/features/chains/evm/tokens'
 import {
   GqlChainId,
@@ -56,11 +56,10 @@ export const POLYGON_CHAIN_INFO = {
   networkLayer: NetworkLayer.L1,
   pendingTransactionsRetryOptions: undefined,
   rpcUrls: {
-    [RPCType.Public]: { http: [getQuicknodeEndpointUrl(UniverseChainId.Polygon)] },
-    [RPCType.PublicAlt]: { http: ['https://polygon-rpc.com/'] },
-    [RPCType.Default]: { http: ['https://polygon-rpc.com/'] },
-    // Use public RPC instead of Infura to avoid API key issues
-    [RPCType.Interface]: { http: ['https://polygon-rpc.com/'] },
+    [RPCType.Public]: { http: [`https://polygon-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`] },
+    [RPCType.PublicAlt]: { http: [`https://polygon-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`] },
+    [RPCType.Default]: { http: [`https://polygon-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`] },
+    [RPCType.Interface]: { http: [`https://polygon-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`] },
   },
   tokens,
   statusPage: undefined,


### PR DESCRIPTION
## Summary

- All four Polygon `RPCType` slots (Public, PublicAlt, Default, Interface) now point at the paid Alchemy endpoint via `config.alchemyApiKey`, mirroring the pattern already used for Soneium ([soneium.ts:66/68](packages/uniswap/src/features/chains/evm/info/soneium.ts#L66)).
- Wires `REACT_APP_ALCHEMY_API_KEY` through `Dockerfile` (ARG + ENV) and both deploy workflows (`web-dev.yaml`, `web-prd.yaml`) as a Docker build-arg sourced from the repo secret.

## Why

The public `polygon-rpc.com` endpoint started returning **HTTP 401** for our traffic. Three of the four Polygon RPC slots in [polygon.ts](packages/uniswap/src/features/chains/evm/info/polygon.ts) pointed there, including `RPCType.Interface` — the slot the web app uses for on-chain reads. With every interface call failing, conditional UI driven by chain state (e.g. the refund button on swap activity) never appeared.

PR #754 reduced polling pressure but didn't replace the broken endpoint, so the underlying outage stayed unresolved. This PR is the actual fix: route Polygon through the paid Alchemy account.

Quicknode was not used here because the chain-wide preference in this codebase for paid endpoints is Alchemy (already provisioned for Soneium), and Alchemy is the account we pay for explicitly for Polygon.

## Required before merge

The repo secret **`REACT_APP_ALCHEMY_API_KEY`** must be set in GitHub Actions secrets. Without it the build-arg resolves to empty and Polygon URLs become `https://polygon-mainnet.g.alchemy.com/v2/` — same failure mode as today, just on a different host.

## Test plan

- [ ] `REACT_APP_ALCHEMY_API_KEY` secret added to GitHub Actions
- [ ] DEV deploy succeeds and `bapp.juiceswap.com` (DEV) loads with no 401s on Polygon RPC in DevTools Network
- [ ] Manual: open swap activity with a Polygon refund eligible — refund button visible
- [ ] PRD release PR merged after DEV is validated