### PR TITLE
ci(deploy): split Alchemy key per environment

### DIFF
--- a/.github/workflows/web-dev.yaml
+++ b/.github/workflows/web-dev.yaml
@@ -44,7 +44,7 @@ jobs:
           build-args: |
             BUILD_MODE=development
             COMMIT_HASH=${{ github.sha }}
-            REACT_APP_ALCHEMY_API_KEY=${{ secrets.REACT_APP_ALCHEMY_API_KEY }}
+            REACT_APP_ALCHEMY_API_KEY=${{ secrets.REACT_APP_ALCHEMY_API_KEY_DEV }}
 
       - name: Install cloudflared
         run: |

--- a/.github/workflows/web-prd.yaml
+++ b/.github/workflows/web-prd.yaml
@@ -44,7 +44,7 @@ jobs:
           build-args: |
             BUILD_MODE=production
             COMMIT_HASH=${{ github.sha }}
-            REACT_APP_ALCHEMY_API_KEY=${{ secrets.REACT_APP_ALCHEMY_API_KEY }}
+            REACT_APP_ALCHEMY_API_KEY=${{ secrets.REACT_APP_ALCHEMY_API_KEY_PRD }}
 
       - name: Install cloudflared
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #755. Splits the single Alchemy key into per-environment keys so DEV and PRD each call their own Alchemy app:

- `web-dev.yaml` reads from `REACT_APP_ALCHEMY_API_KEY_DEV`
- `web-prd.yaml` reads from `REACT_APP_ALCHEMY_API_KEY_PRD`

## Why

Two separate Alchemy apps are already provisioned, each with its own origin-allowlist (`dev.bapp.juiceswap.com` / `bapp.juiceswap.com`). A shared key would fail in DEV because the PRD key only allows the PRD origin (and vice versa). Each environment needs its own key.

The shared `REACT_APP_ALCHEMY_API_KEY` secret introduced in #755 is now obsolete and can be deleted after this merges.

## Repo state

The `_DEV` and `_PRD` secrets are already set in GitHub Actions secrets. After merge:
- DEV deploy picks up `_DEV` automatically (next push to develop)
- PRD deploy picks up `_PRD` on the next release

## Test plan

- [ ] DEV deploy succeeds on `bapp.juiceswap.com` (DEV instance)
- [ ] DevTools Network on `dev.bapp.juiceswap.com`: polygon-mainnet.g.alchemy.com calls return 200, no 401
- [ ] After PRD release: same check on `bapp.juiceswap.com`
- [ ] Refund button visible on a Polygon swap with eligible refund
- [ ] Delete obsolete `REACT_APP_ALCHEMY_API_KEY` secret in repo settings