### PR TITLE
fix(chains): switch Ethereum + Sepolia RPC to Alchemy

### DIFF
--- a/packages/uniswap/src/features/chains/evm/info/mainnet.ts
+++ b/packages/uniswap/src/features/chains/evm/info/mainnet.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_MS_BEFORE_WARNING,
   DEFAULT_NATIVE_ADDRESS_LEGACY,
   getPlaywrightRpcUrls,
-  getQuicknodeEndpointUrl,
 } from 'uniswap/src/features/chains/evm/rpc'
 import { buildChainTokens } from 'uniswap/src/features/chains/evm/tokens'
 import {
@@ -74,16 +73,16 @@ export const MAINNET_CHAIN_INFO = {
           http: ['https://rpc.mevblocker.io/?referrer=uniswapwallet'],
         },
         [RPCType.Public]: {
-          http: [getQuicknodeEndpointUrl(UniverseChainId.Mainnet)],
+          http: [`https://eth-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`],
         },
         [RPCType.Default]: {
-          http: [getQuicknodeEndpointUrl(UniverseChainId.Mainnet)],
+          http: [`https://eth-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`],
         },
         [RPCType.Fallback]: {
-          http: ['https://rpc.ankr.com/eth', 'https://eth-mainnet.public.blastapi.io'],
+          http: [`https://eth-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`],
         },
         [RPCType.Interface]: {
-          http: [`https://mainnet.infura.io/v3/${config.infuraKey}`, getQuicknodeEndpointUrl(UniverseChainId.Mainnet)],
+          http: [`https://eth-mainnet.g.alchemy.com/v2/${config.alchemyApiKey}`],
         },
       },
   urlParam: 'ethereum',
@@ -141,22 +140,17 @@ export const SEPOLIA_CHAIN_INFO = {
   pendingTransactionsRetryOptions: undefined,
   rpcUrls: {
     [RPCType.Public]: {
-      http: [getQuicknodeEndpointUrl(UniverseChainId.Sepolia)],
+      http: [`https://eth-sepolia.g.alchemy.com/v2/${config.alchemyApiKey}`],
     },
     [RPCType.Default]: {
-      http: ['https://eth-sepolia.g.alchemy.com/v2/D41tT-VNane_JyxuXN6lI'],
+      http: [`https://eth-sepolia.g.alchemy.com/v2/${config.alchemyApiKey}`],
     },
     [RPCType.Fallback]: {
-      http: [
-        'https://eth-sepolia.g.alchemy.com/v2/D41tT-VNane_JyxuXN6lI',
-        'https://rpc2.sepolia.org/',
-        'https://rpc.sepolia.online/',
-        'https://www.sepoliarpc.space/',
-        'https://rpc-sepolia.rockx.com/',
-        'https://rpc.bordel.wtf/sepolia',
-      ],
+      http: [`https://eth-sepolia.g.alchemy.com/v2/${config.alchemyApiKey}`],
     },
-    [RPCType.Interface]: { http: [`https://sepolia.infura.io/v3/${config.infuraKey}`] },
+    [RPCType.Interface]: {
+      http: [`https://eth-sepolia.g.alchemy.com/v2/${config.alchemyApiKey}`],
+    },
   },
   spotPriceStablecoinAmountOverride: CurrencyAmount.fromRawAmount(testnetTokens.USDC, 100e6),
   tokens: testnetTokens,


### PR DESCRIPTION
## Summary

Same pattern as #755 (Polygon) — point Ethereum Mainnet and Sepolia at our paid Alchemy account instead of the Uniswap-upstream RPC endpoints inherited from the fork.

- Ethereum Mainnet (`mainnet.ts:70-88`): all five `RPCType` slots → Alchemy (Private slot stays on MEV blocker for the existing privacy guarantee)
- Sepolia (`mainnet.ts:142-155`): all four `RPCType` slots → Alchemy (Default/Fallback consolidated; the hardcoded `D41tT-VN…` free-tier key and the six public sepolia RPCs are removed)

## Why

Sepolia is core DEX functionality — currently it relies on `https://eth-sepolia.g.alchemy.com/v2/D41tT-VNane_JyxuXN6lI`, an Alchemy free-tier key shipped by Uniswap upstream. If Alchemy throttles or revokes it, Sepolia swaps stop working. Same `polygon-rpc.com` story, different chain.

Ethereum Mainnet is used by interchain swap flows (claim/refund). Same exposure as Polygon before #755.

## Infra setup (already done)

- Both Alchemy apps now have `ETH_MAINNET` + `ETH_SEPOLIA` enabled on top of `MATIC_MAINNET`:
  - `JuiceSwap DEV` — `btf781m76wzuano0`
  - `JuiceSwap PRD` — `anz50klco2a1z0yg`
- Origin allowlists already correct: `https://dev.juiceswap.com` / `https://juiceswap.com`
- GitHub secrets unchanged: `REACT_APP_ALCHEMY_API_KEY_DEV` / `_PRD`

## Test plan

- [ ] CI Build Check passes
- [ ] After merge — DevTools on `dev.juiceswap.com`: ETH + Sepolia calls hit `eth-mainnet.g.alchemy.com` / `eth-sepolia.g.alchemy.com` with 200
- [ ] After PRD release — same check on `juiceswap.com`
- [ ] No more references to `D41tT-VN…` or `infura.io` in the Mainnet/Sepolia config bundle