### PR TITLE
fix(chains): align Polygon, Ethereum & Sepolia RPC polling with block time

### DIFF
--- a/packages/uniswap/src/features/chains/evm/info/mainnet.ts
+++ b/packages/uniswap/src/features/chains/evm/info/mainnet.ts
@@ -97,7 +97,7 @@ export const MAINNET_CHAIN_INFO = {
     decimals: 18,
     address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   },
-  tradingApiPollingIntervalMs: 500,
+  tradingApiPollingIntervalMs: 4000,
 } as const satisfies UniverseChainInfo
 
 const testnetTokens = buildChainTokens({
@@ -169,5 +169,5 @@ export const SEPOLIA_CHAIN_INFO = {
     decimals: 18,
     address: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',
   },
-  tradingApiPollingIntervalMs: 500,
+  tradingApiPollingIntervalMs: 4000,
 } as const satisfies UniverseChainInfo

--- a/packages/uniswap/src/features/chains/evm/info/polygon.ts
+++ b/packages/uniswap/src/features/chains/evm/info/polygon.ts
@@ -71,5 +71,5 @@ export const POLYGON_CHAIN_INFO = {
     decimals: 18,
     address: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
   },
-  tradingApiPollingIntervalMs: 1000,
+  tradingApiPollingIntervalMs: 2000,
 } as const satisfies UniverseChainInfo


### PR DESCRIPTION
## Summary

Follow-up to #754. Reduces redundant RPC block polling on chains where the configured interval was much faster than the chain's block time:

| Chain | `tradingApiPollingIntervalMs` | Block time | Polls per block (before → after) |
|---|---|---|---|
| Polygon | 1000 → **2000** ms | ~2.1 s | ~1.7 → ~1 |
| Ethereum | 500 → **4000** ms | ~12 s | ~19 → ~3 |
| Sepolia  | 500 → **4000** ms | ~12 s | ~19 → ~3 |

## Evidence

**Polygon HAR** (59 s on Alchemy, swap page Polygon → Citrea):

| Method | Count | Cadence |
|---|---|---|
| `eth_blockNumber` | 48 | ~1.17 s per poll (1000 ms interval + RTT) |
| `eth_chainId` | 20 | viem preflight |
| `eth_call` | 16 | clustered every ~6.5 s (portfolio refresh) |
| `eth_getBalance` | 9 | same cluster |

→ ~1.7 polls per Polygon block, so ~half the block-number traffic is redundant.

**Mainnet HAR** (~7.5 min, swap page on Ethereum):

| Host | Method | Count |
|---|---|---|
| Infura | `eth_blockNumber` | **370** (~one every ~800 ms) |
| Quicknode | `eth_blockNumber` | **370** (~one every ~800 ms, ~160 ms offset from Infura) |
| Quicknode | `eth_chainId` | 98 |
| Quicknode | `eth_call` | 51 |
| Quicknode | `eth_getBalance` | 48 |

→ ~19 polls per Ethereum block on Infura alone. Bumping to 4000 ms cuts Infura compute units ~8× per active mainnet user with no meaningful UX regression — tx receipts still resolve within ~1 block on average (viem's receipt watcher uses the same `pollingInterval`).

## Out of scope (separate follow-up)

The mainnet HAR also revealed that **two block-number pollers run in parallel** on Ethereum — wagmi/viem hitting Infura (the `Interface` slot's first URL) and `RPC_PROVIDERS` / `AppJsonRpcProvider` hitting Quicknode (second URL) at the same ~800 ms cadence. The line that used to disable inner ethers polling has been commented out in [AppJsonRpcProvider.ts:75-76](apps/web/src/rpc/AppJsonRpcProvider.ts#L75-L76), which is the likely cause. That's a separate bug and will be addressed in its own PR — this change only adjusts the configured intervals.

## Test plan

- [ ] Type check + lint pass
- [ ] Swap on Polygon — receipt resolves in ≤ a few seconds
- [ ] Swap on Ethereum — receipt resolves in ≤ a few seconds
- [ ] Re-capture HAR per chain and confirm `eth_blockNumber` cadence drops to ~once per block