### PR TITLE
fix(rpc): stop inner ethers providers from polling

### DIFF
--- a/apps/web/src/rpc/AppJsonRpcProvider.ts
+++ b/apps/web/src/rpc/AppJsonRpcProvider.ts
@@ -73,7 +73,7 @@ export default class AppJsonRpcProvider extends ConfiguredJsonRpcProvider {
     }
     super({ networkish: providers[0].network })
     // AppJsonRpcProvider configures its own pollingInterval, so the encapsulated providers do not need to poll.
-    // providers.forEach((provider) => (provider.pollingInterval = Infinity))
+    providers.forEach((provider) => (provider.pollingInterval = Infinity))
     this.providers = providers.map((provider) => ({ provider, controller: new Controller(minimumBackoffTime) }))
   }
 


### PR DESCRIPTION
## Summary

Uncomments a single line in `AppJsonRpcProvider.ts:75-76` that disables the internal poll loop on each encapsulated `ConfiguredJsonRpcProvider`. Implements the behavior the existing comment already describes.

```diff
     // AppJsonRpcProvider configures its own pollingInterval, so the encapsulated providers do not need to poll.
-    // providers.forEach((provider) => (provider.pollingInterval = Infinity))
+    providers.forEach((provider) => (provider.pollingInterval = Infinity))
```

## Why

Addresses the out-of-scope item noted in #759 (parallel `eth_blockNumber` pollers).

`AppJsonRpcProvider` is a router: `perform()` dispatches to one inner provider at a time, and the *outer* drives polling. Each inner provider, however, is a full `StaticJsonRpcProvider` configured with its own `pollingInterval` (default `AVERAGE_L1_BLOCK_TIME_MS` via `ConfiguredJsonRpcProvider`). When ethers internals attach listeners to the inner providers — e.g. via `waitForTransaction`, `provider.once('block', …)` — each inner starts its own poll loop on top of the outer. Result: duplicate `eth_blockNumber` traffic per chain.

PR #759 captured a HAR on Mainnet showing this clearly:

| Host | Method | Count over 7.5 min |
|---|---|---|
| Infura  | `eth_blockNumber` | 370 |
| Quicknode | `eth_blockNumber` | 370 (~160 ms offset) |

Two parallel pollers, same cadence. After this fix the inner providers stop polling entirely; only viem (via `wagmiConfig.pollingInterval = tradingApiPollingIntervalMs`) and the outer `AppJsonRpcProvider` poll. With #758 routing all chains through Alchemy, eliminating the duplicate roughly halves our Alchemy compute-unit consumption on Mainnet.

## History

The line has been inert since `9a511c8544` (Uniswap Labs, April 2024) when the current `AppJsonRpcProvider` shape was introduced. The accompanying comment makes the intended behavior explicit, so this is restoring the documented design rather than introducing new behavior.

## Test plan

- [x] `yarn web build:production` passes
- [x] Lint passes
- [ ] After merge — capture HAR on `dev.juiceswap.com` (Mainnet swap page) and confirm `eth_blockNumber` cadence on Alchemy collapses from ~2× per `tradingApiPollingIntervalMs` window to ~1× per window
- [ ] Swap on Mainnet — transaction receipt still resolves promptly (viem's poll loop is unaffected)
- [ ] Swap on Polygon — same
- [ ] ENS resolution (`useFetchListCallback`) still works (uses `RPC_PROVIDERS[Mainnet]` directly)