### PR TITLE
docs(e2e): watch-only debugging harness against live Trading API

### DIFF
--- a/apps/web/e2e/watch-only/README.md
+++ b/apps/web/e2e/watch-only/README.md
@@ -37,13 +37,15 @@ System tools — install once:
 
 ```bash
 # macOS
-brew install node                  # node is required everywhere in the harness
+brew install node                  # ≥ 18 — the helper scripts use top-level await
 xcode-select --install             # ships curl + unzip + dev tools (usually already present)
 brew install gh && gh auth login   # OPTIONAL — fetch-rabby.sh uses gh when available
                                    # for higher GitHub API rate limits; otherwise it
                                    # falls back to anonymous curl, which is fine for
                                    # one-shot use.
 ```
+
+The repo's `.nvmrc` pins the working Node version. `nvm use` (or `fnm use`, etc.) picks it up; the harness needs Node ≥ 14.8 in absolute terms, the repo's pin is higher.
 
 Repo tooling:
 

--- a/apps/web/e2e/watch-only/README.md
+++ b/apps/web/e2e/watch-only/README.md
@@ -37,8 +37,12 @@ System tools — install once:
 
 ```bash
 # macOS
-brew install gh node     # gh is needed by fetch-rabby.sh, node for everything
-xcode-select --install   # for unzip + dev tools (usually already present)
+brew install node                  # node is required everywhere in the harness
+xcode-select --install             # ships curl + unzip + dev tools (usually already present)
+brew install gh && gh auth login   # OPTIONAL — fetch-rabby.sh uses gh when available
+                                   # for higher GitHub API rate limits; otherwise it
+                                   # falls back to anonymous curl, which is fine for
+                                   # one-shot use.
 ```
 
 Repo tooling:
@@ -47,17 +51,10 @@ Repo tooling:
 yarn install             # MUST succeed — populates ~/.cache/puppeteer/chrome
 ```
 
-If `~/.cache/puppeteer/chrome/mac_arm-*` is empty after `yarn install`, puppeteer skipped its postinstall. Re-run with `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=` (no value) explicitly, or trigger a manual download:
+If `~/.cache/puppeteer/chrome/mac_arm-*` is empty after `yarn install`, puppeteer skipped its postinstall. Trigger the download manually:
 
 ```bash
 node -e "require('puppeteer-core/internal/node/Browser').install({ browser: 'chrome' })"
-```
-
-GitHub auth (for `fetch-rabby.sh`):
-
-```bash
-gh auth status           # if not authenticated:
-gh auth login
 ```
 
 A short-lived `chrome-rabby-profile` is created under `~/.cache/`. It is disposable; delete it to reset Rabby (see [Reset / cleanup](#reset--cleanup)).
@@ -102,10 +99,10 @@ What `onboard.sh` does:
 
 - launches Chrome for Testing if it isn't already up
 - opens Rabby's welcome page
-- clears `chrome.storage.local` to guarantee a clean first-run
-- creates a throwaway HD wallet (the seed phrase never leaves the disposable profile)
-- sets a predictable password (`TestPass123!`, override via `PASSWORD=…`)
-- jumps to `#/import/watch-address` and adds your address
+- checks `chrome.storage.local` for an existing `keyringState`:
+  - **First run** — clears storage, creates a throwaway HD wallet (seed phrase never leaves the disposable profile), and sets password `TestPass123!` (override via `PASSWORD=…`)
+  - **Re-runs** — skips the wallet/password step; the existing keystore is reused
+- jumps to `#/import/watch-address` and adds your address (Rabby refuses duplicates silently, so re-running with the same `WATCH_ADDR` is a no-op)
 
 > **Why a throwaway HD wallet?** Rabby's first-run flow refuses to proceed without a "real" first account. Watch-only is only available *after* a seed/private-key/hardware wallet exists. The throwaway wallet exists only in `~/.cache/chrome-rabby-profile/` and has no balance anywhere; we never touch it again.
 
@@ -115,7 +112,7 @@ After step 3, both wallets are visible in Rabby. The watch-only one is selected 
 
 ```bash
 # Tab 1: dev server
-yarn web dev    # serves on http://localhost:3001 (or 3000)
+yarn web dev    # serves on http://localhost:3001 (port hard-coded in apps/web/vite.config.mts)
 
 # Tab 2: launch Chrome for Testing with the prepared profile + Rabby
 apps/web/e2e/watch-only/scripts/launch-chrome.sh
@@ -162,12 +159,13 @@ Two files contain locale-specific strings:
 - `helpers/rabby.mjs` → top of the file, the `LABELS` object
 - `helpers/onboard.mjs` → the literal strings inside `clickByText('…')` calls (welcome flow + password step)
 
-Replace them with the labels Rabby shows on your machine. Inspect Rabby with:
+Replace them with the labels Rabby shows on your machine. After `launch-chrome.sh`, navigate to Rabby's UI in the already-running window — in the address bar, type:
 
-```bash
-# After launch-chrome.sh, open the Rabby UI tab and check the buttons:
-open -a "Google Chrome for Testing" chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/index.html
 ```
+chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/index.html
+```
+
+(The puppeteer-shipped Chrome for Testing isn't registered with macOS Launch Services, so `open -a` can't find it. The address-bar route works.)
 
 Common mappings (English ↔ German):
 
@@ -222,7 +220,9 @@ The puppeteer-cached Chrome for Testing under `~/.cache/puppeteer/chrome/` is sh
 If a Rabby UI change makes `onboard.mjs` fail, you can drive the first-run by hand:
 
 1. `apps/web/e2e/watch-only/scripts/launch-chrome.sh`
-2. In the Chrome window, click the Rabby toolbar icon (yellow Rabby dog)
+2. In the Chrome window's address bar, paste:
+   `chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/index.html`
+   (Chrome for Testing started with `--enable-automation` hides the extension toolbar pin by default, so the address-bar route is the reliable one.)
 3. Welcome → "Get Started" → "Create a new address" → set any password
 4. Once the dashboard appears, click the wallet selector (top-left) → "Add Address" → "Watch-only Address" → paste the address → "Confirm"
 
@@ -230,8 +230,7 @@ The persistent profile remembers the state, so subsequent `launch-chrome.sh` run
 
 ## Caveats
 
-- **Locale dependency** — see [Changing the UI locale](#changing-the-ui-locale) above.
-- **The "Loading quote…" / "Approve and swap" labels** are i18n keys defined in `packages/uniswap/src/i18n/locales/source/en-US.json`. Your assertions should match whichever locale `Accept-Language` was using for the page.
+- **Two independent locales** — Rabby inherits the OS locale (German on the dev machine; see [Changing the UI locale](#changing-the-ui-locale)). The dApp itself respects the `Accept-Language` header / its own language setting and resolves text against `packages/uniswap/src/i18n/locales/source/en-US.json`. Examples that assert on app text (`"Loading quote…"`, `"Approve and swap"`) match those source-language keys; if your browser negotiated a different dApp locale, update the assertions.
 - **Rate limits** — the live Quote API rate-limits aggressive polling. Don't loop your tests at >1Hz.
 - **Watch-only signing** — any `eth_sendTransaction` / `eth_signTypedData_v4` call from the page will be rejected by Rabby. That's the point — debugging ends one step before the wallet popup.
 - **Chain switching** — Citrea Mainnet (chainId 4114) is not in the default wallet's chain list. The example calls `window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x1012' }] })` after connect; Rabby's popup auto-accepts it via the helper.
@@ -249,6 +248,6 @@ The persistent profile remembers the state, so subsequent `launch-chrome.sh` run
 | `window.ethereum` is undefined when probed via `chrome-devtools-mcp` | MCP runs scripts in the isolated world; injected providers live in the main world | Probe via `playwright-core` `page.evaluate(…)` instead — it executes in the main world |
 | `[ ]` returned from `/json/list` on port 9223 | Chrome for Testing has no open tabs; the harness needs at least one | Open one with `curl -X PUT "http://localhost:9223/json/new?http://localhost:3001/"` or use `playwright` to create it |
 | `onboard.mjs` throws `could not find … button — wrong locale?` | Rabby UI is not in German | Update the label strings in `helpers/onboard.mjs`; see [Changing the UI locale](#changing-the-ui-locale) |
-| `gh: command not found` from `fetch-rabby.sh` | GitHub CLI missing | `brew install gh` then `gh auth login` |
+| `fetch-rabby.sh` fails with `API rate limit exceeded` | Hit GitHub's anonymous rate limit (60/hr per IP) | `brew install gh && gh auth login` — the script auto-uses gh when available for the 5000/hr authenticated limit |
 | `Port 9223 is busy. Killing existing…` then nothing connects | A previous Chrome instance is wedged on the port | `pkill -9 -f chrome-rabby-profile`; if that fails, reboot Chrome state with `rm -rf ~/.cache/chrome-rabby-profile/SingletonLock` |
 | Helpers attach but `app` is `null` | No `http://localhost:3001/…` tab is open | Open the dApp manually first, or call `ctx.newPage()` and `goto()` it (see `examples/swap-flow.mjs`) |

--- a/apps/web/e2e/watch-only/README.md
+++ b/apps/web/e2e/watch-only/README.md
@@ -20,6 +20,48 @@ Designed for the class of bug that:
 - For anything that requires signing — watch-only addresses cannot.
 - For tests that need to assert deterministic on-chain state — use Anvil fixtures instead.
 
+## Platform support
+
+**Tier 1 (tested):** macOS arm64.
+
+The launch script picks a Chrome for Testing build from `~/.cache/puppeteer/chrome/mac_arm-*/chrome-mac-arm64/Google Chrome for Testing.app/…`. For other platforms you need to change:
+
+- `scripts/launch-chrome.sh` — the `mac_arm-*` glob and the `chrome-mac-arm64` subdirectory
+- Possibly the binary name (`Google Chrome for Testing` vs `chrome` vs `chrome.exe`)
+
+Everything else (Rabby unpack, profile layout, helpers) is platform-independent. PRs welcome.
+
+## Prerequisites
+
+System tools — install once:
+
+```bash
+# macOS
+brew install gh node     # gh is needed by fetch-rabby.sh, node for everything
+xcode-select --install   # for unzip + dev tools (usually already present)
+```
+
+Repo tooling:
+
+```bash
+yarn install             # MUST succeed — populates ~/.cache/puppeteer/chrome
+```
+
+If `~/.cache/puppeteer/chrome/mac_arm-*` is empty after `yarn install`, puppeteer skipped its postinstall. Re-run with `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=` (no value) explicitly, or trigger a manual download:
+
+```bash
+node -e "require('puppeteer-core/internal/node/Browser').install({ browser: 'chrome' })"
+```
+
+GitHub auth (for `fetch-rabby.sh`):
+
+```bash
+gh auth status           # if not authenticated:
+gh auth login
+```
+
+A short-lived `chrome-rabby-profile` is created under `~/.cache/`. It is disposable; delete it to reset Rabby (see [Reset / cleanup](#reset--cleanup)).
+
 ## Why a separate Chrome
 
 Stable Google Chrome 130+ **silently rejects `--load-extension`** in non-developer builds. The exact log line from Chrome is:
@@ -32,31 +74,42 @@ This harness uses **Chrome for Testing** (the variant Puppeteer ships with `pupp
 
 `chrome-devtools-mcp` (Chrome DevTools MCP server) launches Chrome with `--disable-extensions` as a default Puppeteer arg and also filters `chrome-extension://` pages out of `list_pages`, so it cannot drive Rabby's UI directly. We attach **playwright-core via CDP** to a Chrome instance we launch ourselves.
 
-## Prerequisites
+## The Rabby extension ID
 
-- macOS arm64 (the scripts assume this; trivial to adapt)
-- A working `puppeteer-core` install in the repo — it carries Chrome for Testing in its cache
-- An on-chain address you want to *observe* — e.g. one from a bug report
+You'll see `acmacodkjbdgmoleebolmdjonilkdbch` hardcoded in the helpers. That's the Chrome Web Store ID for Rabby Wallet — every signed Chrome extension has one, derived from the developer's public key in the manifest. You can verify the same ID at <https://chromewebstore.google.com/detail/rabby-wallet/acmacodkjbdgmoleebolmdjonilkdbch>.
 
-A short-lived `chrome-rabby-profile` is created under `~/.cache/`. It is disposable; delete it to reset Rabby.
+The unsigned `.zip` from GitHub releases ships the same `key` field in its manifest, so when loaded unpacked it ends up at the same extension ID. That's why `chrome.storage.local` and Rabby's internal URLs are stable across re-installs.
 
-## Setup (one-time)
+## First-time setup (copy-paste-able)
+
+Three commands, from the repo root:
 
 ```bash
 # 1. Make sure puppeteer cache has Chrome for Testing
 yarn install
 
-# 2. Fetch + extract the latest Rabby release
+# 2. Fetch + extract the latest Rabby release into ~/.cache/chrome-extensions/rabby/
 apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+# Expected last line: ✓ Rabby unpacked at /Users/<you>/.cache/chrome-extensions/rabby
+#                     Version: 0.93.x
 
 # 3. Onboard Rabby (creates a throwaway HD wallet + adds your watch-only address)
 WATCH_ADDR=0xYourAddressHere apps/web/e2e/watch-only/scripts/onboard.sh
+# Expected last line: ✓ watch-only address added
 ```
 
-`fetch-rabby.sh` downloads the Rabby release zip from GitHub and unpacks it to
-`~/.cache/chrome-extensions/rabby/`. `onboard.sh` launches Chrome for Testing,
-walks Rabby through its first-run flow, and adds your address as a watch-only
-account. The profile persists at `~/.cache/chrome-rabby-profile`.
+What `onboard.sh` does:
+
+- launches Chrome for Testing if it isn't already up
+- opens Rabby's welcome page
+- clears `chrome.storage.local` to guarantee a clean first-run
+- creates a throwaway HD wallet (the seed phrase never leaves the disposable profile)
+- sets a predictable password (`TestPass123!`, override via `PASSWORD=…`)
+- jumps to `#/import/watch-address` and adds your address
+
+> **Why a throwaway HD wallet?** Rabby's first-run flow refuses to proceed without a "real" first account. Watch-only is only available *after* a seed/private-key/hardware wallet exists. The throwaway wallet exists only in `~/.cache/chrome-rabby-profile/` and has no balance anywhere; we never touch it again.
+
+After step 3, both wallets are visible in Rabby. The watch-only one is selected by default when the dApp calls `eth_requestAccounts` (the order it was added in).
 
 ## Run a debug session
 
@@ -66,6 +119,7 @@ yarn web dev    # serves on http://localhost:3001 (or 3000)
 
 # Tab 2: launch Chrome for Testing with the prepared profile + Rabby
 apps/web/e2e/watch-only/scripts/launch-chrome.sh
+# Expected: ✓ CDP up at http://localhost:9223
 
 # Tab 3: drive Rabby + the app
 node apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -79,40 +133,122 @@ endpoints.
 Use it as a template: copy `examples/swap-flow.mjs`, change the URL / amounts /
 assertions for whatever bug you're chasing.
 
+## What you should see
+
+On a successful first run, a Chrome for Testing window opens (yellow Chrome-for-Testing logo, not the regular blue one), with two tabs:
+
+1. The dApp at `localhost:3001/swap?…`
+2. Rabby's UI (`chrome-extension://acmaco…/index.html`)
+
+The Rabby toolbar icon shows the throwaway-wallet address by default. After running `connectRabby` and accepting the popup, the dApp's header shows the **watch-only** address (`0xb126…` in the example) along with whatever balance the chain returns. The chainId in the wallet status badge should be `4114 (Citrea)` after the example runs.
+
+If the dApp's wallet modal only shows WalletConnect + Coinbase (no "Rabby Wallet Detected"), Rabby announced its provider too late and the dApp didn't see it. Hard-reload the page; the dApp re-broadcasts `eip6963:requestProvider` on mount.
+
 ## How it works under the hood
 
 | Layer | What it does | File |
 |---|---|---|
 | `launch-chrome.sh` | Starts Chrome for Testing with `--load-extension=…rabby` and `--remote-debugging-port=9223` against the persistent profile | `scripts/launch-chrome.sh` |
-| `onboard.sh` | Resets `chrome.storage`, walks the welcome → create-seed → password → success flow, then jumps to `#/import/watch-address` and registers the watch-only address | `scripts/onboard.sh` |
+| `onboard.sh` / `onboard.mjs` | Resets `chrome.storage`, walks welcome → create-seed → password → success, then jumps to `#/import/watch-address` and registers the watch-only address | `scripts/onboard.sh` + `helpers/onboard.mjs` |
 | `helpers/rabby.mjs` | Reusable `connectOverCDP` + popup handlers (auto-click `Verbinden` / `Alle ignorieren` / `Bestätigen`) | `helpers/rabby.mjs` |
 | Example | Imports the helpers, drives one user-visible flow, asserts on visible button text | `examples/swap-flow.mjs` |
 
+## Changing the UI locale
+
+The shipped scripts target Rabby's **German** UI because that's the system locale we developed against (Chrome inherits the OS locale). If your machine is in English, French, etc., you'll see different button labels and the helpers will fail to find them.
+
+Two files contain locale-specific strings:
+
+- `helpers/rabby.mjs` → top of the file, the `LABELS` object
+- `helpers/onboard.mjs` → the literal strings inside `clickByText('…')` calls (welcome flow + password step)
+
+Replace them with the labels Rabby shows on your machine. Inspect Rabby with:
+
+```bash
+# After launch-chrome.sh, open the Rabby UI tab and check the buttons:
+open -a "Google Chrome for Testing" chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/index.html
+```
+
+Common mappings (English ↔ German):
+
+| English | German |
+|---|---|
+| `Connect` | `Verbinden` |
+| `Confirm` | `Bestätigen` |
+| `Ignore all` | `Alle ignorieren` |
+| `Switch` | `Wechseln` |
+| `Allow` | `Erlauben` |
+| `Done` | `Erledigt` |
+| `Create a new address` | `Erstellen Sie eine neue Adresse` |
+
+## Reset / cleanup
+
+To start with a completely fresh Rabby (forgets all wallets, password, settings):
+
+```bash
+# stop Chrome for Testing
+pkill -f "chrome-rabby-profile"
+
+# nuke the profile
+rm -rf ~/.cache/chrome-rabby-profile
+
+# re-onboard
+WATCH_ADDR=0x… apps/web/e2e/watch-only/scripts/onboard.sh
+```
+
+To update Rabby to the latest release (keeping the existing wallets):
+
+```bash
+apps/web/e2e/watch-only/scripts/fetch-rabby.sh   # downloads new version
+pkill -f "chrome-rabby-profile"                  # so the launch script reloads it
+apps/web/e2e/watch-only/scripts/launch-chrome.sh # ← picks up the new extension
+```
+
+Rabby auto-migrates `chrome.storage.local` across versions; your throwaway wallet and watch-only address survive.
+
+To remove everything this harness created:
+
+```bash
+pkill -f "chrome-rabby-profile"
+rm -rf ~/.cache/chrome-rabby-profile
+rm -rf ~/.cache/chrome-extensions/rabby
+rm -f  /tmp/chrome-rabby.log
+```
+
+The puppeteer-cached Chrome for Testing under `~/.cache/puppeteer/chrome/` is shared with other repo tooling — leave it.
+
+## Manual fallback (if automation breaks)
+
+If a Rabby UI change makes `onboard.mjs` fail, you can drive the first-run by hand:
+
+1. `apps/web/e2e/watch-only/scripts/launch-chrome.sh`
+2. In the Chrome window, click the Rabby toolbar icon (yellow Rabby dog)
+3. Welcome → "Get Started" → "Create a new address" → set any password
+4. Once the dashboard appears, click the wallet selector (top-left) → "Add Address" → "Watch-only Address" → paste the address → "Confirm"
+
+The persistent profile remembers the state, so subsequent `launch-chrome.sh` runs skip onboarding.
+
 ## Caveats
 
-- **Rabby's UI strings are locale-dependent.** The shipped scripts target the
-  German UI (`Verbinden`, `Alle ignorieren`, `Bestätigen`) because Chrome
-  inherits the system locale. If you're on a different system locale, replace
-  the labels in `helpers/rabby.mjs` — there's a single map at the top.
-- **The "Loading quote…" / "Approve and swap" labels** are i18n keys defined in
-  `packages/uniswap/src/i18n/locales/source/en-US.json`. Your assertions
-  should match whichever locale `Accept-Language` was using for the page.
-- **Rate limits.** The live Quote API rate-limits aggressive polling.
-  Don't loop your tests at >1Hz.
-- **Watch-only signing.** Any `eth_sendTransaction` / `eth_signTypedData_v4`
-  call from the page will be rejected by Rabby. That's the point — debugging
-  ends one step before the wallet popup.
-- **Chain switching.** Citrea Mainnet (chainId 4114) is not in the default
-  wallet's chain list. The example calls
-  `window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x1012' }] })`
-  after connect; Rabby's popup auto-accepts it via the helper.
+- **Locale dependency** — see [Changing the UI locale](#changing-the-ui-locale) above.
+- **The "Loading quote…" / "Approve and swap" labels** are i18n keys defined in `packages/uniswap/src/i18n/locales/source/en-US.json`. Your assertions should match whichever locale `Accept-Language` was using for the page.
+- **Rate limits** — the live Quote API rate-limits aggressive polling. Don't loop your tests at >1Hz.
+- **Watch-only signing** — any `eth_sendTransaction` / `eth_signTypedData_v4` call from the page will be rejected by Rabby. That's the point — debugging ends one step before the wallet popup.
+- **Chain switching** — Citrea Mainnet (chainId 4114) is not in the default wallet's chain list. The example calls `window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x1012' }] })` after connect; Rabby's popup auto-accepts it via the helper.
+- **Chrome for Testing window is visible by default.** Add `--headless=new` to the Chrome args in `launch-chrome.sh` if you want it invisible — but headless Chrome 130+ blocks extensions even harder, so you might need to keep it windowed.
+- **`/tmp/chrome-rabby.log`** captures Chrome stdout/stderr. If something looks off (extension didn't load, etc.) check `tail -50 /tmp/chrome-rabby.log` first.
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `--load-extension is not allowed in Google Chrome, ignoring.` in stderr | You're using stable Chrome, not Chrome for Testing | Run `launch-chrome.sh` which picks the puppeteer binary, not `/Applications/Google Chrome.app` |
+| `--load-extension is not allowed in Google Chrome, ignoring.` in `/tmp/chrome-rabby.log` | You're using stable Chrome, not Chrome for Testing | Run `launch-chrome.sh` which picks the puppeteer binary, not `/Applications/Google Chrome.app` |
+| `ERROR: puppeteer cache not found at …` from `launch-chrome.sh` | `yarn install` didn't run or skipped chromium download | See [Prerequisites](#prerequisites) — re-run `yarn install` or trigger the manual download command |
 | Rabby modal in the app only shows WalletConnect + Coinbase | The page loaded before Rabby announced via EIP-6963 | Hard-reload the page after Rabby loads; the dispatched `eip6963:announceProvider` events are not buffered |
-| Connection popup hangs at "Bitte bearbeiten Sie zuerst den Risiko-Hinweis" | Rabby's risk-warning row was not dismissed | The helper clicks `Alle ignorieren` before `Verbinden`; check that label is correct for your locale |
+| Connection popup hangs at "Bitte bearbeiten Sie zuerst den Risiko-Hinweis" | Rabby's risk-warning row was not dismissed | The helper clicks `Alle ignorieren` before `Verbinden`; check that label is correct for your locale (see [Changing the UI locale](#changing-the-ui-locale)) |
 | `window.ethereum` is undefined when probed via `chrome-devtools-mcp` | MCP runs scripts in the isolated world; injected providers live in the main world | Probe via `playwright-core` `page.evaluate(…)` instead — it executes in the main world |
 | `[ ]` returned from `/json/list` on port 9223 | Chrome for Testing has no open tabs; the harness needs at least one | Open one with `curl -X PUT "http://localhost:9223/json/new?http://localhost:3001/"` or use `playwright` to create it |
+| `onboard.mjs` throws `could not find … button — wrong locale?` | Rabby UI is not in German | Update the label strings in `helpers/onboard.mjs`; see [Changing the UI locale](#changing-the-ui-locale) |
+| `gh: command not found` from `fetch-rabby.sh` | GitHub CLI missing | `brew install gh` then `gh auth login` |
+| `Port 9223 is busy. Killing existing…` then nothing connects | A previous Chrome instance is wedged on the port | `pkill -9 -f chrome-rabby-profile`; if that fails, reboot Chrome state with `rm -rf ~/.cache/chrome-rabby-profile/SingletonLock` |
+| Helpers attach but `app` is `null` | No `http://localhost:3001/…` tab is open | Open the dApp manually first, or call `ctx.newPage()` and `goto()` it (see `examples/swap-flow.mjs`) |

--- a/apps/web/e2e/watch-only/README.md
+++ b/apps/web/e2e/watch-only/README.md
@@ -139,7 +139,7 @@ On a successful first run, a Chrome for Testing window opens (yellow Chrome-for-
 1. The dApp at `localhost:3001/swap?…`
 2. Rabby's UI (`chrome-extension://acmaco…/index.html`)
 
-The Rabby toolbar icon shows the throwaway-wallet address by default. After running `connectRabby` and accepting the popup, the dApp's header shows the **watch-only** address (`0xb126…` in the example) along with whatever balance the chain returns. The chainId in the wallet status badge should be `4114 (Citrea)` after the example runs.
+The Rabby toolbar icon shows the throwaway-wallet address by default. After running `connectRabby` and accepting the popup, the dApp's header shows the **watch-only** address you onboarded with along with whatever balance the chain returns. The chainId in the wallet status badge should be `4114 (Citrea)` after the example runs.
 
 If the dApp's wallet modal only shows WalletConnect + Coinbase (no "Rabby Wallet Detected"), Rabby announced its provider too late and the dApp didn't see it. Hard-reload the page; the dApp re-broadcasts `eip6963:requestProvider` on mount.
 
@@ -251,5 +251,6 @@ The persistent profile remembers the state, so subsequent `launch-chrome.sh` run
 | `[ ]` returned from `/json/list` on port 9223 | Chrome for Testing has no open tabs; the harness needs at least one | Open one with `curl -X PUT "http://localhost:9223/json/new?http://localhost:3001/"` or use `playwright` to create it |
 | `onboard.mjs` throws `could not find … button — wrong locale?` | Rabby UI is not in German | Update the label strings in `helpers/onboard.mjs`; see [Changing the UI locale](#changing-the-ui-locale) |
 | `fetch-rabby.sh` fails with `API rate limit exceeded` | Hit GitHub's anonymous rate limit (60/hr per IP) | `brew install gh && gh auth login` — the script auto-uses gh when available for the 5000/hr authenticated limit |
-| `Port 9223 is busy. Killing existing…` then nothing connects | A previous Chrome instance is wedged on the port | `pkill -9 -f chrome-rabby-profile`; if that fails, reboot Chrome state with `rm -rf ~/.cache/chrome-rabby-profile/SingletonLock` |
+| `ERROR: port 9223 is busy and not held by this harness.` | Another process (a stale stable Chrome, another tool's debug port) is on the port | Either free port 9223 yourself (`lsof -ti :9223` to find the PID) or re-run with `DEBUG_PORT=9224 apps/web/e2e/watch-only/scripts/launch-chrome.sh` |
+| `Reusing port 9223: stopping the previous Chrome for Testing…` then nothing connects | The previous Chrome for Testing was wedged and the `SingletonLock` cleanup wasn't enough | Force-kill with `pkill -9 -f chrome-rabby-profile` and remove the lock by hand: `rm -f ~/.cache/chrome-rabby-profile/SingletonLock` |
 | Helpers attach but `app` is `null` | No `http://localhost:3001/…` tab is open | Open the dApp manually first, or call `ctx.newPage()` and `goto()` it (see `examples/swap-flow.mjs`) |

--- a/apps/web/e2e/watch-only/README.md
+++ b/apps/web/e2e/watch-only/README.md
@@ -1,0 +1,118 @@
+# Watch-only debugging harness
+
+A reproducible setup for debugging the web app against the **live** Trading API with a **watch-only Rabby wallet** — no private keys, no signed transactions, no test fixtures.
+
+Designed for the class of bug that:
+
+- Only shows up with a real connected wallet (e.g. the swap-review screen)
+- Depends on real Quote/Swap API responses, real token decimals, real routing
+- Cannot be hit by the existing `apps/web/e2e/metamask/` suite, which uses a seeded test wallet against Anvil + mocked endpoints
+
+## When to use this
+
+- "Loading quote…" sticks forever for some token pair / amount and you need to see the actual `/v1/quote` and `/v1/swap` traffic
+- A wallet balance / approval state on Citrea Mainnet matters and Anvil-fixtures don't reproduce it
+- You want to drive the **same address** another user is reporting issues with — without holding their private key
+
+## When NOT to use this
+
+- For CI-stable test suites. The harness depends on the live backend; failures are not always reproducible.
+- For anything that requires signing — watch-only addresses cannot.
+- For tests that need to assert deterministic on-chain state — use Anvil fixtures instead.
+
+## Why a separate Chrome
+
+Stable Google Chrome 130+ **silently rejects `--load-extension`** in non-developer builds. The exact log line from Chrome is:
+
+```
+WARNING:chrome/browser/extensions/extension_service.cc] --load-extension is not allowed in Google Chrome, ignoring.
+```
+
+This harness uses **Chrome for Testing** (the variant Puppeteer ships with `puppeteer-core`), which still honours `--load-extension`. The binary lives under `~/.cache/puppeteer/chrome/mac_arm-<version>/chrome-mac-arm64/`.
+
+`chrome-devtools-mcp` (Chrome DevTools MCP server) launches Chrome with `--disable-extensions` as a default Puppeteer arg and also filters `chrome-extension://` pages out of `list_pages`, so it cannot drive Rabby's UI directly. We attach **playwright-core via CDP** to a Chrome instance we launch ourselves.
+
+## Prerequisites
+
+- macOS arm64 (the scripts assume this; trivial to adapt)
+- A working `puppeteer-core` install in the repo — it carries Chrome for Testing in its cache
+- An on-chain address you want to *observe* — e.g. one from a bug report
+
+A short-lived `chrome-rabby-profile` is created under `~/.cache/`. It is disposable; delete it to reset Rabby.
+
+## Setup (one-time)
+
+```bash
+# 1. Make sure puppeteer cache has Chrome for Testing
+yarn install
+
+# 2. Fetch + extract the latest Rabby release
+apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+
+# 3. Onboard Rabby (creates a throwaway HD wallet + adds your watch-only address)
+WATCH_ADDR=0xYourAddressHere apps/web/e2e/watch-only/scripts/onboard.sh
+```
+
+`fetch-rabby.sh` downloads the Rabby release zip from GitHub and unpacks it to
+`~/.cache/chrome-extensions/rabby/`. `onboard.sh` launches Chrome for Testing,
+walks Rabby through its first-run flow, and adds your address as a watch-only
+account. The profile persists at `~/.cache/chrome-rabby-profile`.
+
+## Run a debug session
+
+```bash
+# Tab 1: dev server
+yarn web dev    # serves on http://localhost:3001 (or 3000)
+
+# Tab 2: launch Chrome for Testing with the prepared profile + Rabby
+apps/web/e2e/watch-only/scripts/launch-chrome.sh
+
+# Tab 3: drive Rabby + the app
+node apps/web/e2e/watch-only/examples/swap-flow.mjs
+```
+
+The example navigates to the swap page, connects Rabby (auto-dismissing the
+risk-warning popup), switches to Citrea Mainnet, types in an amount, clicks
+Review, and dumps the submit-button label + a network log of the relevant
+endpoints.
+
+Use it as a template: copy `examples/swap-flow.mjs`, change the URL / amounts /
+assertions for whatever bug you're chasing.
+
+## How it works under the hood
+
+| Layer | What it does | File |
+|---|---|---|
+| `launch-chrome.sh` | Starts Chrome for Testing with `--load-extension=…rabby` and `--remote-debugging-port=9223` against the persistent profile | `scripts/launch-chrome.sh` |
+| `onboard.sh` | Resets `chrome.storage`, walks the welcome → create-seed → password → success flow, then jumps to `#/import/watch-address` and registers the watch-only address | `scripts/onboard.sh` |
+| `helpers/rabby.mjs` | Reusable `connectOverCDP` + popup handlers (auto-click `Verbinden` / `Alle ignorieren` / `Bestätigen`) | `helpers/rabby.mjs` |
+| Example | Imports the helpers, drives one user-visible flow, asserts on visible button text | `examples/swap-flow.mjs` |
+
+## Caveats
+
+- **Rabby's UI strings are locale-dependent.** The shipped scripts target the
+  German UI (`Verbinden`, `Alle ignorieren`, `Bestätigen`) because Chrome
+  inherits the system locale. If you're on a different system locale, replace
+  the labels in `helpers/rabby.mjs` — there's a single map at the top.
+- **The "Loading quote…" / "Approve and swap" labels** are i18n keys defined in
+  `packages/uniswap/src/i18n/locales/source/en-US.json`. Your assertions
+  should match whichever locale `Accept-Language` was using for the page.
+- **Rate limits.** The live Quote API rate-limits aggressive polling.
+  Don't loop your tests at >1Hz.
+- **Watch-only signing.** Any `eth_sendTransaction` / `eth_signTypedData_v4`
+  call from the page will be rejected by Rabby. That's the point — debugging
+  ends one step before the wallet popup.
+- **Chain switching.** Citrea Mainnet (chainId 4114) is not in the default
+  wallet's chain list. The example calls
+  `window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0x1012' }] })`
+  after connect; Rabby's popup auto-accepts it via the helper.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `--load-extension is not allowed in Google Chrome, ignoring.` in stderr | You're using stable Chrome, not Chrome for Testing | Run `launch-chrome.sh` which picks the puppeteer binary, not `/Applications/Google Chrome.app` |
+| Rabby modal in the app only shows WalletConnect + Coinbase | The page loaded before Rabby announced via EIP-6963 | Hard-reload the page after Rabby loads; the dispatched `eip6963:announceProvider` events are not buffered |
+| Connection popup hangs at "Bitte bearbeiten Sie zuerst den Risiko-Hinweis" | Rabby's risk-warning row was not dismissed | The helper clicks `Alle ignorieren` before `Verbinden`; check that label is correct for your locale |
+| `window.ethereum` is undefined when probed via `chrome-devtools-mcp` | MCP runs scripts in the isolated world; injected providers live in the main world | Probe via `playwright-core` `page.evaluate(…)` instead — it executes in the main world |
+| `[ ]` returned from `/json/list` on port 9223 | Chrome for Testing has no open tabs; the harness needs at least one | Open one with `curl -X PUT "http://localhost:9223/json/new?http://localhost:3001/"` or use `playwright` to create it |

--- a/apps/web/e2e/watch-only/examples/swap-flow.mjs
+++ b/apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -9,6 +9,12 @@
 //   yarn web dev                                                # in a separate terminal
 //   apps/web/e2e/watch-only/scripts/launch-chrome.sh            # one-shot
 //   node apps/web/e2e/watch-only/examples/swap-flow.mjs
+//
+// Optional env (defaults are the values we developed against):
+//   APP_PREFIX   dApp origin (default: http://localhost:3001 — vite.config.mts pin)
+//   AMOUNTS      comma-separated input amounts to sweep
+//                (default: 100,1000,10000,50000 — covers below + above the
+//                 50000-threshold edge case)
 
 import {
   attach,

--- a/apps/web/e2e/watch-only/examples/swap-flow.mjs
+++ b/apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -82,8 +82,10 @@ for (const amount of AMOUNTS) {
   await sleep(4000)
 
   const reviewBtn = app.locator('button[data-testid="review-swap"]').first()
+  // Sweep continues across amounts; if the Review button isn't on the page yet
+  // (e.g. for an amount where the dApp is still loading), we log "?" rather
+  // than aborting — the bug we're chasing is precisely "Review never enables".
   const reviewText = (await reviewBtn.innerText().catch(() => '?')).replace(/\s+/g, ' ').trim()
-
   await reviewBtn.click({ force: true }).catch(() => {})
   await sleep(5000)
 
@@ -107,4 +109,6 @@ console.log()
 console.log(`/v1/swap calls observed: ${swapRequests.calls.length}`)
 swapRequests.dispose()
 
+// At end-of-script the CDP transport sometimes tears down before close()
+// resolves; we already have the data we wanted so swallowing the error is fine.
 await browser.close().catch(() => {})

--- a/apps/web/e2e/watch-only/examples/swap-flow.mjs
+++ b/apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -88,7 +88,6 @@ for (const amount of AMOUNTS) {
     return {
       loadingQuote: t.includes('Loading quote'),
       approveAndSwap: /Approve and [sS]wap/.test(t),
-      youreSwapping: t.includes("You're swapping"),
       submit: Array.from(document.querySelectorAll('button'))
         .map((b) => (b.innerText || '').replace(/\s+/g, ' ').trim())
         .find((s) => /Approve|Loading|Acknowledge|Swap|quote|Insufficient/.test(s)),

--- a/apps/web/e2e/watch-only/examples/swap-flow.mjs
+++ b/apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -1,0 +1,107 @@
+// Reproduces the "Loading quote… sticks forever" investigation we used to
+// pin down the Satsuma routing bug fixed in PR #752.
+//
+// Behaviour: connects Rabby, switches to Citrea Mainnet, drives the swap form
+// at a list of input amounts, opens Review, and dumps the submit-button text
+// plus a count of `/v1/swap` calls.
+//
+// Usage:
+//   yarn web dev                                                # in a separate terminal
+//   apps/web/e2e/watch-only/scripts/launch-chrome.sh            # one-shot
+//   node apps/web/e2e/watch-only/examples/swap-flow.mjs
+
+import {
+  attach,
+  autoApproveRabbyPopups,
+  connectRabby,
+  recordRequests,
+  switchChain,
+  walletState,
+} from '../helpers/rabby.mjs'
+
+const APP_PREFIX = process.env.APP_PREFIX ?? 'http://localhost:3001'
+const CITREA_MAINNET_HEX = '0x1012' // 4114
+
+// USDC.e/ctUSD on Citrea Mainnet — the pair where the original bug was reported.
+const CTUSD = '0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D'
+const USDC_E = '0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839'
+
+const AMOUNTS = process.env.AMOUNTS?.split(',') ?? ['100', '1000', '10000', '50000']
+
+const swapUrl = (inputCurrency, outputCurrency) =>
+  `${APP_PREFIX}/swap?chain=citrea_mainnet&inputCurrency=${inputCurrency}&outputCurrency=${outputCurrency}`
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const { browser, ctx, app: existingApp } = await attach({ appUrlPrefix: APP_PREFIX })
+const app = existingApp ?? (await ctx.newPage())
+await app.bringToFront()
+
+autoApproveRabbyPopups(ctx)
+
+// First-time landing
+await app.goto(swapUrl(CTUSD, USDC_E), { waitUntil: 'domcontentloaded' })
+await sleep(3000)
+
+const accountState = await walletState(app)
+if (!accountState.accounts?.length) {
+  console.log('Wallet not connected yet, attempting connect…')
+  if (!(await connectRabby(app))) {
+    console.error('ERROR: Rabby not found in the wallet modal — did you onboard Rabby?')
+    process.exit(1)
+  }
+  await sleep(4000)
+}
+
+if ((await walletState(app)).chainId !== CITREA_MAINNET_HEX) {
+  console.log('Switching to Citrea Mainnet…')
+  await switchChain(app, CITREA_MAINNET_HEX)
+}
+
+const final = await walletState(app)
+console.log(`Connected: ${final.accounts?.[0]}  chainId=${final.chainId}`)
+console.log()
+
+// Sweep amounts
+const swapRequests = recordRequests(app, '/v1/swap')
+
+for (const amount of AMOUNTS) {
+  await app.goto(swapUrl(CTUSD, USDC_E), { waitUntil: 'domcontentloaded' })
+  await sleep(3000)
+
+  const inputs = await app.$$('input')
+  if (inputs.length === 0) {
+    console.log(`[${amount}]  no inputs on the page — skipping`)
+    continue
+  }
+  await inputs[0].fill(amount)
+  await sleep(4000)
+
+  const reviewBtn = app.locator('button[data-testid="review-swap"]').first()
+  const reviewText = (await reviewBtn.innerText().catch(() => '?')).replace(/\s+/g, ' ').trim()
+
+  await reviewBtn.click({ force: true }).catch(() => {})
+  await sleep(5000)
+
+  const result = await app.evaluate(() => {
+    const t = document.body.innerText
+    return {
+      loadingQuote: t.includes('Loading quote'),
+      approveAndSwap: /Approve and [sS]wap/.test(t),
+      youreSwapping: t.includes("You're swapping"),
+      submit: Array.from(document.querySelectorAll('button'))
+        .map((b) => (b.innerText || '').replace(/\s+/g, ' ').trim())
+        .find((s) => /Approve|Loading|Acknowledge|Swap|quote|Insufficient/.test(s)),
+    }
+  })
+  const stuck = result.loadingQuote && !result.approveAndSwap
+  console.log(
+    `[${amount.padStart(8)}]  review="${reviewText.slice(0, 18)}"  submit="${(result.submit || '?').slice(0, 40)}"  ${stuck ? '❌ STUCK' : '✓'}`,
+  )
+}
+
+console.log()
+console.log(`/v1/swap calls observed: ${swapRequests.calls.length}`)
+swapRequests.dispose()
+
+await browser.close().catch(() => {})

--- a/apps/web/e2e/watch-only/examples/swap-flow.mjs
+++ b/apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -101,13 +101,14 @@ for (const amount of AMOUNTS) {
       loadingQuote: t.includes('Loading quote'),
       approveAndSwap: /Approve and [sS]wap/.test(t),
       submit: Array.from(document.querySelectorAll('button'))
-        .map((b) => (b.innerText || '').replace(/\s+/g, ' ').trim())
+        .map((b) => b.innerText.replace(/\s+/g, ' ').trim())
         .find((s) => /Approve|Loading|Acknowledge|Swap|quote|Insufficient/.test(s)),
     }
   })
   const stuck = result.loadingQuote && !result.approveAndSwap
+  const submitLabel = result.submit?.slice(0, 40) ?? '?'
   console.log(
-    `[${amount.padStart(8)}]  review="${reviewText.slice(0, 18)}"  submit="${(result.submit || '?').slice(0, 40)}"  ${stuck ? '❌ STUCK' : '✓'}`,
+    `[${amount.padStart(8)}]  review="${reviewText.slice(0, 18)}"  submit="${submitLabel}"  ${stuck ? '❌ STUCK' : '✓'}`,
   )
 }
 

--- a/apps/web/e2e/watch-only/examples/swap-flow.mjs
+++ b/apps/web/e2e/watch-only/examples/swap-flow.mjs
@@ -55,7 +55,11 @@ if (!accountState.accounts?.length) {
 
 if ((await walletState(app)).chainId !== CITREA_MAINNET_HEX) {
   console.log('Switching to Citrea Mainnet…')
-  await switchChain(app, CITREA_MAINNET_HEX)
+  const switchResult = await switchChain(app, CITREA_MAINNET_HEX)
+  if (!switchResult.ok) {
+    console.error(`ERROR: chain switch rejected (${switchResult.error}); on ${switchResult.chainId}`)
+    process.exit(1)
+  }
 }
 
 const final = await walletState(app)

--- a/apps/web/e2e/watch-only/helpers/onboard.mjs
+++ b/apps/web/e2e/watch-only/helpers/onboard.mjs
@@ -13,9 +13,12 @@
 
 import { createRequire } from 'node:module'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
+// Resolve playwright-core relative to this file, not the caller's CWD.
 const require = createRequire(import.meta.url)
-const playwrightCore = require(path.resolve(process.cwd(), 'node_modules/playwright-core'))
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const playwrightCore = require(path.resolve(__dirname, '../../../../../node_modules/playwright-core'))
 const { chromium } = playwrightCore
 
 const WATCH_ADDR = process.env.WATCH_ADDR

--- a/apps/web/e2e/watch-only/helpers/onboard.mjs
+++ b/apps/web/e2e/watch-only/helpers/onboard.mjs
@@ -1,0 +1,120 @@
+// Walk a fresh Rabby installation through its first-run flow and register the
+// caller-provided watch-only address.
+//
+// Reads:
+//   WATCH_ADDR   required, the address to add (0x…)
+//   PASSWORD     optional, defaults to TestPass123!
+//   DEBUG_PORT   optional, defaults to 9223
+//
+// Idempotency: if Rabby is already past the welcome screens (e.g. you ran this
+// before), the script jumps straight to #/import/watch-address and just adds
+// the address. Re-running with the same address is a no-op (Rabby refuses
+// duplicates but the navigation still succeeds).
+
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+const playwrightCore = require(path.resolve(process.cwd(), 'node_modules/playwright-core'))
+const { chromium } = playwrightCore
+
+const WATCH_ADDR = process.env.WATCH_ADDR
+const PASSWORD = process.env.PASSWORD ?? 'TestPass123!'
+const DEBUG_PORT = process.env.DEBUG_PORT ?? '9223'
+const RABBY_ID = 'acmacodkjbdgmoleebolmdjonilkdbch'
+
+if (!WATCH_ADDR || !/^0x[a-fA-F0-9]{40}$/.test(WATCH_ADDR)) {
+  console.error('ERROR: WATCH_ADDR env must be a 0x-prefixed 40-hex address')
+  process.exit(1)
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const browser = await chromium.connectOverCDP(`http://localhost:${DEBUG_PORT}`)
+const ctx = browser.contexts()[0]
+
+let page = ctx.pages().find((p) => p.url().includes(RABBY_ID) && !p.url().includes('offscreen'))
+if (!page) {
+  page = await ctx.newPage()
+  await page.goto(`chrome-extension://${RABBY_ID}/index.html#/welcome`, { waitUntil: 'domcontentloaded' })
+}
+await page.bringToFront()
+
+const clickByText = async (label) => {
+  const loc = page.locator(`text="${label}"`).first()
+  if ((await loc.count()) === 0) return false
+  try {
+    await loc.click({ force: true, timeout: 3000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Detect whether Rabby is already past initial setup
+const isSetUp = async () => {
+  const result = await page.evaluate(
+    () => new Promise((res) => chrome.storage.local.get(['keyringState'], (r) => res(!!r.keyringState))),
+  )
+  return result
+}
+
+if (!(await isSetUp())) {
+  console.log('Rabby is fresh — running first-time setup')
+
+  // Reset to a known starting point
+  await page.evaluate(
+    async () => await new Promise((r) => chrome.storage.local.clear(() => chrome.storage.session.clear(() => r()))),
+  )
+  await page.goto(`chrome-extension://${RABBY_ID}/index.html#/new-user/guide`, { waitUntil: 'domcontentloaded' })
+  await sleep(2000)
+
+  // The first-time guide insists on a seed-bearing first wallet; create a throwaway HD wallet.
+  // It only exists in this disposable profile and never sees real value.
+  if (!(await clickByText('Erstellen Sie eine neue Adresse'))) {
+    if (!(await clickByText('Create a new address'))) {
+      throw new Error('could not find "Create new address" button — wrong locale?')
+    }
+  }
+  await sleep(2000)
+
+  // Set the password (used to unlock the keystore on each session; we keep it predictable)
+  const pwInputs = await page.$$('input[type=password]')
+  for (const inp of pwInputs) {
+    await inp.fill(PASSWORD)
+  }
+  await sleep(500)
+  if (!(await clickByText('Bestätigen')) && !(await clickByText('Confirm'))) {
+    throw new Error('could not find password Confirm button')
+  }
+  await sleep(2500)
+
+  console.log('✓ throwaway HD wallet created')
+}
+
+// Add the watch-only address
+console.log(`Adding watch-only address ${WATCH_ADDR}`)
+await page.goto(`chrome-extension://${RABBY_ID}/index.html#/import/watch-address`, { waitUntil: 'domcontentloaded' })
+await sleep(2000)
+
+const addrInputs = await page.$$('input[type=text], textarea')
+if (addrInputs.length === 0) {
+  throw new Error('watch-address page has no text input — Rabby UI changed?')
+}
+await addrInputs[0].fill(WATCH_ADDR)
+await sleep(800)
+
+if (!(await clickByText('Bestätigen')) && !(await clickByText('Confirm'))) {
+  throw new Error('could not find Confirm button on watch-address page')
+}
+await sleep(2500)
+
+const finalText = await page.evaluate(() => document.body.innerText)
+if (/erfolgreich|added|hinzugefügt|success/i.test(finalText)) {
+  console.log('✓ watch-only address added')
+} else {
+  console.warn('⚠ Rabby did not confirm success. Last page text:')
+  console.warn(finalText.replace(/\s+/g, ' ').slice(0, 400))
+}
+
+await browser.close().catch(() => {})

--- a/apps/web/e2e/watch-only/helpers/onboard.mjs
+++ b/apps/web/e2e/watch-only/helpers/onboard.mjs
@@ -33,6 +33,16 @@ if (!WATCH_ADDR || !/^0x[a-fA-F0-9]{40}$/.test(WATCH_ADDR)) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
+// Timings tuned on a 2024 M-series Mac; the Rabby UI is React + animated and
+// occasionally needs a full second to settle between route transitions. Each
+// constant names the transition it waits on.
+const TIMINGS = {
+  ROUTE_TRANSITION_MS: 2000, // welcome → no-address, no-address → import flow
+  WALLET_CREATE_MS: 2500, // password submit → success screen render
+  FIELD_SETTLE_MS: 500, // input fill → submit-enabled validation
+  ADDRESS_FILL_MS: 800, // address fill → "Confirm" enable
+}
+
 const browser = await chromium.connectOverCDP(`http://localhost:${DEBUG_PORT}`)
 const ctx = browser.contexts()[0]
 
@@ -70,7 +80,7 @@ if (!(await isSetUp())) {
     async () => await new Promise((r) => chrome.storage.local.clear(() => chrome.storage.session.clear(() => r()))),
   )
   await page.goto(`chrome-extension://${RABBY_ID}/index.html#/new-user/guide`, { waitUntil: 'domcontentloaded' })
-  await sleep(2000)
+  await sleep(TIMINGS.ROUTE_TRANSITION_MS)
 
   // The first-time guide insists on a seed-bearing first wallet; create a throwaway HD wallet.
   // It only exists in this disposable profile and never sees real value.
@@ -79,18 +89,18 @@ if (!(await isSetUp())) {
       throw new Error('could not find "Create new address" button — wrong locale?')
     }
   }
-  await sleep(2000)
+  await sleep(TIMINGS.ROUTE_TRANSITION_MS)
 
   // Set the password (used to unlock the keystore on each session; we keep it predictable)
   const pwInputs = await page.$$('input[type=password]')
   for (const inp of pwInputs) {
     await inp.fill(PASSWORD)
   }
-  await sleep(500)
+  await sleep(TIMINGS.FIELD_SETTLE_MS)
   if (!(await clickByText('Bestätigen')) && !(await clickByText('Confirm'))) {
     throw new Error('could not find password Confirm button')
   }
-  await sleep(2500)
+  await sleep(TIMINGS.WALLET_CREATE_MS)
 
   console.log('✓ throwaway HD wallet created')
 }
@@ -105,7 +115,7 @@ if (addrInputs.length === 0) {
   throw new Error('watch-address page has no text input — Rabby UI changed?')
 }
 await addrInputs[0].fill(WATCH_ADDR)
-await sleep(800)
+await sleep(TIMINGS.ADDRESS_FILL_MS)
 
 if (!(await clickByText('Bestätigen')) && !(await clickByText('Confirm'))) {
   throw new Error('could not find Confirm button on watch-address page')

--- a/apps/web/e2e/watch-only/helpers/onboard.mjs
+++ b/apps/web/e2e/watch-only/helpers/onboard.mjs
@@ -130,4 +130,5 @@ if (/erfolgreich|added|hinzugefügt|success/i.test(finalText)) {
   console.warn(finalText.replace(/\s+/g, ' ').slice(0, 400))
 }
 
+// CDP transport sometimes closes before close() resolves; we're already done.
 await browser.close().catch(() => {})

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -29,6 +29,27 @@ export const LABELS = {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
+// Timings tuned against Citrea Mainnet on a 2024 M-series Mac.
+// All numbers are wall-clock milliseconds; increase if your network/machine is
+// slower. Values are paired with what they wait on:
+//   POPUP_SETTLE_MS   — Rabby renders the notification popup HTML before its
+//                       React tree is interactive. The locator-click below
+//                       fails on the initial paint without this grace period.
+//   POPUP_RISK_GAP_MS — the risk-warning row is fully dismissed before we
+//                       click the primary confirm button, so the confirm is
+//                       not gated.
+//   MODAL_OPEN_MS     — the dApp's wallet-modal slides in via Tamagui
+//                       animation; clicking too early misses the option grid.
+//   CHAIN_SWITCH_MS   — wallet_switchEthereumChain returns immediately, but
+//                       window.ethereum.chainId only updates after Rabby
+//                       broadcasts the chainChanged event back to the page.
+const TIMINGS = {
+  POPUP_SETTLE_MS: 1200,
+  POPUP_RISK_GAP_MS: 500,
+  MODAL_OPEN_MS: 1500,
+  CHAIN_SWITCH_MS: 3000,
+}
+
 /**
  * Connect to a running Chrome for Testing instance on the given CDP port.
  * Returns { browser, ctx, app } where `app` is the first localhost page.
@@ -56,7 +77,7 @@ export function autoApproveRabbyPopups(ctx, { labels = LABELS, log = console.log
     try {
       await popup.waitForLoadState('domcontentloaded')
     } catch {}
-    await sleep(1200)
+    await sleep(TIMINGS.POPUP_SETTLE_MS)
 
     const tryClick = async (text) => {
       const loc = popup.locator(`text="${text}"`).first()
@@ -72,7 +93,7 @@ export function autoApproveRabbyPopups(ctx, { labels = LABELS, log = console.log
 
     // Dismiss any risk warnings first; some popups gate the primary action on this.
     await tryClick(labels.ignoreRiskWarning)
-    await sleep(500)
+    await sleep(TIMINGS.POPUP_RISK_GAP_MS)
 
     // Click the first matching primary action.
     for (const candidate of [labels.connect, labels.switchChain, labels.confirm, labels.allow]) {
@@ -89,7 +110,7 @@ export function autoApproveRabbyPopups(ctx, { labels = LABELS, log = console.log
  */
 export async function connectRabby(app) {
   await app.locator('button[data-testid="navbar-connect-wallet"]').first().click({ force: true })
-  await sleep(1500)
+  await sleep(TIMINGS.MODAL_OPEN_MS)
   const rabbyOption = app.locator('text=/Rabby/').first()
   if ((await rabbyOption.count()) === 0) return false
   await rabbyOption.click({ force: true })
@@ -100,19 +121,23 @@ export async function connectRabby(app) {
  * Ask the connected wallet to switch chains. Pair with `autoApproveRabbyPopups`
  * to dismiss the chain-switch popup automatically.
  *
- * Returns the resulting chainId hex.
+ * Returns `{ ok, error?, chainId }`. `ok` reflects whether the request resolved
+ * cleanly inside the page; `chainId` is the eventual `window.ethereum.chainId`
+ * (which the page reads from the `chainChanged` event, so it may still be the
+ * old chain if the popup was rejected — check `ok`).
  */
 export async function switchChain(app, chainIdHex) {
-  await app.evaluate(async (hex) => {
+  const requestResult = await app.evaluate(async (hex) => {
     try {
       await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: hex }] })
+      return { ok: true }
     } catch (e) {
-      return 'err: ' + e.message
+      return { ok: false, error: e.message ?? String(e) }
     }
-    return 'ok'
   }, chainIdHex)
-  await sleep(3000)
-  return app.evaluate(() => window.ethereum?.chainId)
+  await sleep(TIMINGS.CHAIN_SWITCH_MS)
+  const chainId = await app.evaluate(() => window.ethereum?.chainId)
+  return { ...requestResult, chainId }
 }
 
 /**

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -17,14 +17,14 @@ export const RABBY_ID = 'acmacodkjbdgmoleebolmdjonilkdbch'
 
 // German UI labels — Chrome for Testing inherits the system locale and the
 // onboarding scripts ran in DE. If you're on a different locale, swap these.
+// Only the labels actually clicked by helpers below are listed; if you need
+// more (e.g. to detect a "Cancel" path), add them here.
 export const LABELS = {
   connect: 'Verbinden',
-  cancel: 'Abbrechen',
   confirm: 'Bestätigen',
   ignoreRiskWarning: 'Alle ignorieren',
   switchChain: 'Wechseln',
   allow: 'Erlauben',
-  done: 'Erledigt',
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
@@ -68,6 +68,12 @@ export async function attach({ port = '9223', appUrlPrefix = 'http://localhost:3
  * The handler:
  *   1. dismisses the risk-warning row ("Alle ignorieren") if present
  *   2. clicks the primary confirm button ("Verbinden", "Wechseln", "Bestätigen", …)
+ *
+ * Options:
+ *   labels — label strings to click; defaults to LABELS (German).
+ *   log    — logger called once per successful popup click. Defaults to
+ *            console.log; pass () => {} to silence, or a custom sink to route
+ *            into the example script's own log stream.
  *
  * Returns a disposer; call it to remove the listener.
  */

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -4,9 +4,13 @@
 
 import { createRequire } from 'node:module'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
+// Resolve playwright-core relative to this file, not the caller's CWD —
+// scripts that source these helpers can run from any directory.
 const require = createRequire(import.meta.url)
-const playwrightCore = require(path.resolve(process.cwd(), 'node_modules/playwright-core'))
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const playwrightCore = require(path.resolve(__dirname, '../../../../../node_modules/playwright-core'))
 const { chromium } = playwrightCore
 
 export const RABBY_ID = 'acmacodkjbdgmoleebolmdjonilkdbch'

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -148,6 +148,11 @@ export async function switchChain(app, chainIdHex) {
 
 /**
  * Convenience: return the connected accounts and chainId.
+ *
+ * Note: the `.catch(() => [])` on `eth_accounts` is intentional — `walletState`
+ * is used as a probe (e.g. "are we connected yet?"), so callers expect a shape,
+ * not an exception, even before the wallet has been authorised. Errors only
+ * arise when the page has no `window.ethereum` yet, which is itself an answer.
  */
 export async function walletState(app) {
   return await app.evaluate(async () => ({
@@ -171,6 +176,8 @@ export function recordRequests(app, urlSubstring) {
     if (!resp.url().includes(urlSubstring)) return
     const entry = calls.find((c) => c.req === resp.request() && !c.response)
     if (entry) {
+      // body=null when text() fails (binary response, transport teardown, …);
+      // the status code on its own is still useful for "did this fire?" probes.
       entry.response = { status: resp.status(), body: await resp.text().catch(() => null) }
     }
   }

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -1,0 +1,151 @@
+// Helpers for driving Rabby + the JuiceSwap dApp via playwright-core over CDP.
+//
+// Imported by the example scripts under apps/web/e2e/watch-only/examples/.
+
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+const require = createRequire(import.meta.url)
+const playwrightCore = require(path.resolve(process.cwd(), 'node_modules/playwright-core'))
+const { chromium } = playwrightCore
+
+export const RABBY_ID = 'acmacodkjbdgmoleebolmdjonilkdbch'
+
+// German UI labels — Chrome for Testing inherits the system locale and the
+// onboarding scripts ran in DE. If you're on a different locale, swap these.
+export const LABELS = {
+  connect: 'Verbinden',
+  cancel: 'Abbrechen',
+  confirm: 'Bestätigen',
+  ignoreRiskWarning: 'Alle ignorieren',
+  switchChain: 'Wechseln',
+  allow: 'Erlauben',
+  done: 'Erledigt',
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * Connect to a running Chrome for Testing instance on the given CDP port.
+ * Returns { browser, ctx, app } where `app` is the first localhost page.
+ */
+export async function attach({ port = '9223', appUrlPrefix = 'http://localhost:3001' } = {}) {
+  const browser = await chromium.connectOverCDP(`http://localhost:${port}`)
+  const ctx = browser.contexts()[0]
+  const app = ctx.pages().find((p) => p.url().startsWith(appUrlPrefix))
+  return { browser, ctx, app: app ?? null }
+}
+
+/**
+ * Install a context-level page listener that auto-handles Rabby notification
+ * popups (the small popups Rabby spawns for connect / chain-switch / sign).
+ *
+ * The handler:
+ *   1. dismisses the risk-warning row ("Alle ignorieren") if present
+ *   2. clicks the primary confirm button ("Verbinden", "Wechseln", "Bestätigen", …)
+ *
+ * Returns a disposer; call it to remove the listener.
+ */
+export function autoApproveRabbyPopups(ctx, { labels = LABELS, log = console.log } = {}) {
+  const handler = async (popup) => {
+    if (!popup.url().includes(RABBY_ID) || !popup.url().includes('notification')) return
+    try {
+      await popup.waitForLoadState('domcontentloaded')
+    } catch {}
+    await sleep(1200)
+
+    const tryClick = async (text) => {
+      const loc = popup.locator(`text="${text}"`).first()
+      if ((await loc.count()) === 0) return false
+      try {
+        await loc.click({ force: true, timeout: 2000 })
+        log(`  ✓ popup: ${text}`)
+        return true
+      } catch {
+        return false
+      }
+    }
+
+    // Dismiss any risk warnings first; some popups gate the primary action on this.
+    await tryClick(labels.ignoreRiskWarning)
+    await sleep(500)
+
+    // Click the first matching primary action.
+    for (const candidate of [labels.connect, labels.switchChain, labels.confirm, labels.allow]) {
+      if (await tryClick(candidate)) break
+    }
+  }
+  ctx.on('page', handler)
+  return () => ctx.off('page', handler)
+}
+
+/**
+ * Click the dApp's "Connect wallet" button and pick Rabby from the wallet modal.
+ * Returns true when Rabby is in the modal and was clicked.
+ */
+export async function connectRabby(app) {
+  await app.locator('button[data-testid="navbar-connect-wallet"]').first().click({ force: true })
+  await sleep(1500)
+  const rabbyOption = app.locator('text=/Rabby/').first()
+  if ((await rabbyOption.count()) === 0) return false
+  await rabbyOption.click({ force: true })
+  return true
+}
+
+/**
+ * Ask the connected wallet to switch chains. Pair with `autoApproveRabbyPopups`
+ * to dismiss the chain-switch popup automatically.
+ *
+ * Returns the resulting chainId hex.
+ */
+export async function switchChain(app, chainIdHex) {
+  await app.evaluate(async (hex) => {
+    try {
+      await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: hex }] })
+    } catch (e) {
+      return 'err: ' + e.message
+    }
+    return 'ok'
+  }, chainIdHex)
+  await sleep(3000)
+  return app.evaluate(() => window.ethereum?.chainId)
+}
+
+/**
+ * Convenience: return the connected accounts and chainId.
+ */
+export async function walletState(app) {
+  return await app.evaluate(async () => ({
+    accounts: await window.ethereum?.request?.({ method: 'eth_accounts' }).catch(() => []),
+    chainId: window.ethereum?.chainId,
+  }))
+}
+
+/**
+ * Record every request and matching response to a URL substring. Returns a
+ * { calls, dispose } pair. Useful for asserting "did /v1/swap fire?".
+ */
+export function recordRequests(app, urlSubstring) {
+  const calls = []
+  const onReq = (req) => {
+    if (req.url().includes(urlSubstring)) {
+      calls.push({ req, response: null, at: Date.now() })
+    }
+  }
+  const onResp = async (resp) => {
+    if (!resp.url().includes(urlSubstring)) return
+    const entry = calls.find((c) => c.req === resp.request() && !c.response)
+    if (entry) {
+      entry.response = { status: resp.status(), body: await resp.text().catch(() => null) }
+    }
+  }
+  app.on('request', onReq)
+  app.on('response', onResp)
+  return {
+    calls,
+    dispose: () => {
+      app.off('request', onReq)
+      app.off('response', onResp)
+    },
+  }
+}

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -52,13 +52,14 @@ const TIMINGS = {
 
 /**
  * Connect to a running Chrome for Testing instance on the given CDP port.
- * Returns { browser, ctx, app } where `app` is the first localhost page.
+ * Returns `{ browser, ctx, app }` where `app` is the first page whose URL
+ * starts with `appUrlPrefix`, or `undefined` when no such page is open yet.
  */
 export async function attach({ port = '9223', appUrlPrefix = 'http://localhost:3001' } = {}) {
   const browser = await chromium.connectOverCDP(`http://localhost:${port}`)
   const ctx = browser.contexts()[0]
   const app = ctx.pages().find((p) => p.url().startsWith(appUrlPrefix))
-  return { browser, ctx, app: app ?? null }
+  return { browser, ctx, app }
 }
 
 /**
@@ -138,7 +139,9 @@ export async function switchChain(app, chainIdHex) {
       await window.ethereum.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: hex }] })
       return { ok: true }
     } catch (e) {
-      return { ok: false, error: e.message ?? String(e) }
+      // String(e) handles both real Errors ("Error: message") and weird
+      // non-Error throws (ProviderRpcError, plain strings, …) without a default.
+      return { ok: false, error: String(e) }
     }
   }, chainIdHex)
   await sleep(TIMINGS.CHAIN_SWITCH_MS)
@@ -149,14 +152,17 @@ export async function switchChain(app, chainIdHex) {
 /**
  * Convenience: return the connected accounts and chainId.
  *
- * Note: the `.catch(() => [])` on `eth_accounts` is intentional — `walletState`
- * is used as a probe (e.g. "are we connected yet?"), so callers expect a shape,
- * not an exception, even before the wallet has been authorised. Errors only
- * arise when the page has no `window.ethereum` yet, which is itself an answer.
+ * Shape over exception: this is a probe, so it never rejects. When
+ * `window.ethereum` is not injected, both fields are `undefined`. When
+ * `eth_accounts` itself throws (rare — e.g. the user is locked), `accounts`
+ * is `[]`. Distinguish "not connected" (`accounts === undefined`) from
+ * "ethereum present but no authorised accounts" (`accounts === []`).
  */
 export async function walletState(app) {
   return await app.evaluate(async () => ({
-    accounts: await window.ethereum?.request?.({ method: 'eth_accounts' }).catch(() => []),
+    // `?.catch` (not `.catch`) so the chain short-circuits to undefined when
+    // request() isn't callable, instead of trying to call .catch on undefined.
+    accounts: await window.ethereum?.request?.({ method: 'eth_accounts' })?.catch(() => []),
     chainId: window.ethereum?.chainId,
   }))
 }

--- a/apps/web/e2e/watch-only/helpers/rabby.mjs
+++ b/apps/web/e2e/watch-only/helpers/rabby.mjs
@@ -154,9 +154,11 @@ export async function switchChain(app, chainIdHex) {
  *
  * Shape over exception: this is a probe, so it never rejects. When
  * `window.ethereum` is not injected, both fields are `undefined`. When
- * `eth_accounts` itself throws (rare — e.g. the user is locked), `accounts`
- * is `[]`. Distinguish "not connected" (`accounts === undefined`) from
- * "ethereum present but no authorised accounts" (`accounts === []`).
+ * `eth_accounts` rejects (a rare RPC-level error, not the locked-wallet
+ * case — EIP-1193 specifies the locked state returns `[]` instead of
+ * throwing), `accounts` is `[]`. Distinguish "not connected"
+ * (`accounts === undefined`) from "ethereum present but no authorised
+ * accounts" (`accounts === []`).
  */
 export async function walletState(app) {
   return await app.evaluate(async () => ({

--- a/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+++ b/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
@@ -11,7 +11,16 @@ mkdir -p "${CACHE_DIR}"
 
 echo "Fetching latest Rabby release URL…"
 if ! command -v gh >/dev/null 2>&1; then
-  echo "ERROR: gh CLI is required (brew install gh)" >&2
+  echo "ERROR: gh CLI is required" >&2
+  echo "       brew install gh && gh auth login" >&2
+  exit 1
+fi
+if ! command -v unzip >/dev/null 2>&1; then
+  echo "ERROR: unzip is required (macOS ships it; install Xcode CLT if missing)" >&2
+  exit 1
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated — run \`gh auth login\` first" >&2
   exit 1
 fi
 

--- a/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+++ b/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
@@ -20,11 +20,20 @@ done
 # RabbyHub/Rabby is a public repo, so the unauthenticated GitHub REST API works
 # (rate-limited but fine for one-shot use). gh CLI is optional; we use it when
 # available to get a higher rate limit.
+extract_zip_url_from_stdin() {
+  node --input-type=module -e "
+    const chunks = []
+    for await (const c of process.stdin) chunks.push(c)
+    const release = JSON.parse(Buffer.concat(chunks).toString())
+    const zip = release.assets?.find((a) => a.name.endsWith('.zip'))
+    process.stdout.write(zip ? zip.browser_download_url : '')
+  "
+}
+
 if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
   ZIP_URL="$(gh api repos/RabbyHub/Rabby/releases/latest --jq '.assets[] | select(.name | endswith(".zip")) | .browser_download_url' | head -1)"
 else
-  ZIP_URL="$(curl -fsSL https://api.github.com/repos/RabbyHub/Rabby/releases/latest \
-    | node -e "let d=''; process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d); const a=j.assets.find(a=>a.name.endsWith('.zip')); process.stdout.write(a?a.browser_download_url:'')})")"
+  ZIP_URL="$(curl -fsSL https://api.github.com/repos/RabbyHub/Rabby/releases/latest | extract_zip_url_from_stdin)"
 fi
 
 if [[ -z "${ZIP_URL}" ]]; then

--- a/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+++ b/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
@@ -10,21 +10,22 @@ TARGET="${CACHE_DIR}/rabby"
 mkdir -p "${CACHE_DIR}"
 
 echo "Fetching latest Rabby release URL…"
-if ! command -v gh >/dev/null 2>&1; then
-  echo "ERROR: gh CLI is required" >&2
-  echo "       brew install gh && gh auth login" >&2
-  exit 1
-fi
-if ! command -v unzip >/dev/null 2>&1; then
-  echo "ERROR: unzip is required (macOS ships it; install Xcode CLT if missing)" >&2
-  exit 1
-fi
-if ! gh auth status >/dev/null 2>&1; then
-  echo "ERROR: gh is not authenticated — run \`gh auth login\` first" >&2
-  exit 1
-fi
+for tool in curl unzip node; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "ERROR: \`${tool}\` is required but not found in PATH" >&2
+    exit 1
+  fi
+done
 
-ZIP_URL="$(gh api repos/RabbyHub/Rabby/releases/latest --jq '.assets[] | select(.name | endswith(".zip")) | .browser_download_url' | head -1)"
+# RabbyHub/Rabby is a public repo, so the unauthenticated GitHub REST API works
+# (rate-limited but fine for one-shot use). gh CLI is optional; we use it when
+# available to get a higher rate limit.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  ZIP_URL="$(gh api repos/RabbyHub/Rabby/releases/latest --jq '.assets[] | select(.name | endswith(".zip")) | .browser_download_url' | head -1)"
+else
+  ZIP_URL="$(curl -fsSL https://api.github.com/repos/RabbyHub/Rabby/releases/latest \
+    | node -e "let d=''; process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d); const a=j.assets.find(a=>a.name.endsWith('.zip')); process.stdout.write(a?a.browser_download_url:'')})")"
+fi
 
 if [[ -z "${ZIP_URL}" ]]; then
   echo "ERROR: could not resolve a .zip asset on the latest Rabby release" >&2
@@ -48,4 +49,4 @@ if [[ ! -f "${TARGET}/manifest.json" ]]; then
 fi
 
 echo "✓ Rabby unpacked at ${TARGET}"
-echo "  Version: $(python3 -c "import json; print(json.load(open('${TARGET}/manifest.json'))['version'])")"
+echo "  Version: $(node -p "require('${TARGET}/manifest.json').version")"

--- a/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+++ b/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Download and extract the latest Rabby release to ~/.cache/chrome-extensions/rabby/
+# This is the directory `launch-chrome.sh` passes to `--load-extension`.
+
+set -euo pipefail
+
+CACHE_DIR="${HOME}/.cache/chrome-extensions"
+TARGET="${CACHE_DIR}/rabby"
+
+mkdir -p "${CACHE_DIR}"
+
+echo "Fetching latest Rabby release URL…"
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is required (brew install gh)" >&2
+  exit 1
+fi
+
+ZIP_URL="$(gh api repos/RabbyHub/Rabby/releases/latest --jq '.assets[] | select(.name | endswith(".zip")) | .browser_download_url' | head -1)"
+
+if [[ -z "${ZIP_URL}" ]]; then
+  echo "ERROR: could not resolve a .zip asset on the latest Rabby release" >&2
+  exit 1
+fi
+
+echo "Downloading ${ZIP_URL}…"
+TMP_ZIP="${CACHE_DIR}/rabby.zip"
+curl -sSL -o "${TMP_ZIP}" "${ZIP_URL}"
+
+echo "Extracting to ${TARGET}…"
+rm -rf "${TARGET}"
+mkdir -p "${TARGET}"
+unzip -q "${TMP_ZIP}" -d "${TARGET}"
+rm "${TMP_ZIP}"
+
+# Sanity check
+if [[ ! -f "${TARGET}/manifest.json" ]]; then
+  echo "ERROR: manifest.json missing — the zip layout changed?" >&2
+  exit 1
+fi
+
+echo "✓ Rabby unpacked at ${TARGET}"
+echo "  Version: $(python3 -c "import json; print(json.load(open('${TARGET}/manifest.json'))['version'])")"

--- a/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
+++ b/apps/web/e2e/watch-only/scripts/fetch-rabby.sh
@@ -43,7 +43,9 @@ fi
 
 echo "Downloading ${ZIP_URL}…"
 TMP_ZIP="${CACHE_DIR}/rabby.zip"
-curl -sSL -o "${TMP_ZIP}" "${ZIP_URL}"
+# -f makes curl fail loudly on HTTP errors instead of saving an HTML error page
+# (which would then break unzip with a confusing "End-of-central-directory" error).
+curl -fsSL -o "${TMP_ZIP}" "${ZIP_URL}"
 
 echo "Extracting to ${TARGET}…"
 rm -rf "${TARGET}"

--- a/apps/web/e2e/watch-only/scripts/launch-chrome.sh
+++ b/apps/web/e2e/watch-only/scripts/launch-chrome.sh
@@ -7,6 +7,18 @@
 
 set -euo pipefail
 
+# Platform guard — see README "Platform support" for porting notes
+case "$(uname -s)/$(uname -m)" in
+  Darwin/arm64) ;;
+  *)
+    echo "ERROR: this harness is only tested on macOS arm64." >&2
+    echo "       Current platform: $(uname -s) $(uname -m)" >&2
+    echo "       To port: change the mac_arm-* glob and chrome-mac-arm64" >&2
+    echo "       subpath below to your puppeteer Chrome variant." >&2
+    exit 1
+    ;;
+esac
+
 PROFILE_DIR="${HOME}/.cache/chrome-rabby-profile"
 EXT_DIR="${HOME}/.cache/chrome-extensions/rabby"
 DEBUG_PORT="${DEBUG_PORT:-9223}"
@@ -28,6 +40,9 @@ fi
 CFT_DIR="$(ls -1d "${PUPPETEER_CACHE}"/mac_arm-* 2>/dev/null | sort -V | tail -1)"
 if [[ -z "${CFT_DIR}" ]]; then
   echo "ERROR: no Chrome for Testing variant in ${PUPPETEER_CACHE}" >&2
+  echo "       \`yarn install\` may have skipped puppeteer's postinstall." >&2
+  echo "       Trigger the download manually with:" >&2
+  echo "       node -e \"require('puppeteer-core/internal/node/Browser').install({ browser: 'chrome' })\"" >&2
   exit 1
 fi
 

--- a/apps/web/e2e/watch-only/scripts/launch-chrome.sh
+++ b/apps/web/e2e/watch-only/scripts/launch-chrome.sh
@@ -52,11 +52,23 @@ if [[ ! -x "${CFT_BIN}" ]]; then
   exit 1
 fi
 
-# Nothing running on the debug port?
+# If something is already on the debug port, only reap it when it's *our* Chrome
+# (matched via the unique --user-data-dir). Foreign port-holders are left alone
+# and the user is told to free the port themselves — silently killing whatever
+# is on port 9223 would be a footgun.
 if lsof -ti ":${DEBUG_PORT}" >/dev/null 2>&1; then
-  echo "Port ${DEBUG_PORT} is busy. Killing existing Chrome for Testing…"
-  pkill -f "chrome-rabby-profile" 2>/dev/null || true
-  sleep 2
+  if pgrep -f "chrome-rabby-profile" >/dev/null 2>&1; then
+    echo "Reusing port ${DEBUG_PORT}: stopping the previous Chrome for Testing…"
+    pkill -f "chrome-rabby-profile" 2>/dev/null || true
+    sleep 2
+    # Chrome leaves a SingletonLock that prevents the next launch from reusing
+    # the profile. Remove it so the new instance starts cleanly.
+    rm -f "${PROFILE_DIR}/SingletonLock"
+  else
+    echo "ERROR: port ${DEBUG_PORT} is busy and not held by this harness." >&2
+    echo "  Free it (or set DEBUG_PORT=<other port>) and retry." >&2
+    exit 1
+  fi
 fi
 
 # Ensure profile dir exists (Rabby state lives here after onboarding)
@@ -87,6 +99,9 @@ for _ in $(seq 1 20); do
   sleep 0.5
 done
 
+# Don't leave an orphaned Chrome behind if CDP never came up — it would
+# otherwise hold the profile lock and confuse the next launch.
 echo "ERROR: Chrome for Testing did not expose CDP on port ${DEBUG_PORT}" >&2
 echo "  tail /tmp/chrome-rabby.log for details" >&2
+pkill -f "chrome-rabby-profile" 2>/dev/null || true
 exit 1

--- a/apps/web/e2e/watch-only/scripts/launch-chrome.sh
+++ b/apps/web/e2e/watch-only/scripts/launch-chrome.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Launch Chrome for Testing with Rabby loaded and remote debugging on port 9223.
+#
+# Stable Google Chrome 130+ silently rejects --load-extension, so we use the
+# puppeteer-shipped variant. The binary lives in the puppeteer cache after a
+# successful `yarn install`.
+
+set -euo pipefail
+
+PROFILE_DIR="${HOME}/.cache/chrome-rabby-profile"
+EXT_DIR="${HOME}/.cache/chrome-extensions/rabby"
+DEBUG_PORT="${DEBUG_PORT:-9223}"
+
+if [[ ! -d "${EXT_DIR}" ]]; then
+  echo "ERROR: Rabby is not installed at ${EXT_DIR}" >&2
+  echo "  Run apps/web/e2e/watch-only/scripts/fetch-rabby.sh first." >&2
+  exit 1
+fi
+
+# Pick the most recent Chrome for Testing in puppeteer's cache
+PUPPETEER_CACHE="${HOME}/.cache/puppeteer/chrome"
+if [[ ! -d "${PUPPETEER_CACHE}" ]]; then
+  echo "ERROR: puppeteer cache not found at ${PUPPETEER_CACHE}" >&2
+  echo "  Run \`yarn install\` from the repo root to populate it." >&2
+  exit 1
+fi
+
+CFT_DIR="$(ls -1d "${PUPPETEER_CACHE}"/mac_arm-* 2>/dev/null | sort -V | tail -1)"
+if [[ -z "${CFT_DIR}" ]]; then
+  echo "ERROR: no Chrome for Testing variant in ${PUPPETEER_CACHE}" >&2
+  exit 1
+fi
+
+CFT_BIN="${CFT_DIR}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+if [[ ! -x "${CFT_BIN}" ]]; then
+  echo "ERROR: ${CFT_BIN} not found or not executable" >&2
+  exit 1
+fi
+
+# Nothing running on the debug port?
+if lsof -ti ":${DEBUG_PORT}" >/dev/null 2>&1; then
+  echo "Port ${DEBUG_PORT} is busy. Killing existing Chrome for Testing…"
+  pkill -f "chrome-rabby-profile" 2>/dev/null || true
+  sleep 2
+fi
+
+# Ensure profile dir exists (Rabby state lives here after onboarding)
+mkdir -p "${PROFILE_DIR}"
+
+echo "Launching Chrome for Testing…"
+echo "  binary:  ${CFT_BIN}"
+echo "  profile: ${PROFILE_DIR}"
+echo "  rabby:   ${EXT_DIR}"
+echo "  CDP:     http://localhost:${DEBUG_PORT}"
+
+# nohup so this survives the parent shell exiting
+nohup "${CFT_BIN}" \
+  --user-data-dir="${PROFILE_DIR}" \
+  --load-extension="${EXT_DIR}" \
+  --remote-debugging-port="${DEBUG_PORT}" \
+  --no-first-run \
+  --no-default-browser-check \
+  >/tmp/chrome-rabby.log 2>&1 &
+disown
+
+# Wait for CDP to come up
+for i in $(seq 1 20); do
+  if curl -sf "http://localhost:${DEBUG_PORT}/json/version" >/dev/null; then
+    echo "✓ CDP up at http://localhost:${DEBUG_PORT}"
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "ERROR: Chrome for Testing did not expose CDP on port ${DEBUG_PORT}" >&2
+echo "  tail /tmp/chrome-rabby.log for details" >&2
+exit 1

--- a/apps/web/e2e/watch-only/scripts/launch-chrome.sh
+++ b/apps/web/e2e/watch-only/scripts/launch-chrome.sh
@@ -78,8 +78,8 @@ nohup "${CFT_BIN}" \
   >/tmp/chrome-rabby.log 2>&1 &
 disown
 
-# Wait for CDP to come up
-for i in $(seq 1 20); do
+# Wait for CDP to come up (10s budget)
+for _ in $(seq 1 20); do
   if curl -sf "http://localhost:${DEBUG_PORT}/json/version" >/dev/null; then
     echo "✓ CDP up at http://localhost:${DEBUG_PORT}"
     exit 0

--- a/apps/web/e2e/watch-only/scripts/onboard.sh
+++ b/apps/web/e2e/watch-only/scripts/onboard.sh
@@ -17,7 +17,9 @@ if [[ -z "${WATCH_ADDR:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DEBUG_PORT="${DEBUG_PORT:-9223}"
+# Export so child processes (curl invocations below + the node helper) see the
+# same effective value regardless of whether the caller set it.
+export DEBUG_PORT="${DEBUG_PORT:-9223}"
 RABBY_ID="acmacodkjbdgmoleebolmdjonilkdbch"
 
 # Ensure Chrome is running
@@ -33,6 +35,7 @@ if ! curl -s "http://localhost:${DEBUG_PORT}/json/list" | grep -q "${RABBY_ID}/i
   sleep 2
 fi
 
-# Drive the onboarding via the node helper. WATCH_ADDR, PASSWORD, DEBUG_PORT
-# are inherited from this script's environment via execve(2).
+# Drive the onboarding via the node helper. WATCH_ADDR + PASSWORD are inherited
+# from the calling shell (bash auto-exports `VAR=val cmd` assignments for cmd's
+# lifetime); DEBUG_PORT is exported explicitly above.
 exec node "${SCRIPT_DIR}/../helpers/onboard.mjs"

--- a/apps/web/e2e/watch-only/scripts/onboard.sh
+++ b/apps/web/e2e/watch-only/scripts/onboard.sh
@@ -17,21 +17,22 @@ if [[ -z "${WATCH_ADDR:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEBUG_PORT="${DEBUG_PORT:-9223}"
+RABBY_ID="acmacodkjbdgmoleebolmdjonilkdbch"
 
 # Ensure Chrome is running
-if ! curl -sf "http://localhost:${DEBUG_PORT:-9223}/json/version" >/dev/null; then
+if ! curl -sf "http://localhost:${DEBUG_PORT}/json/version" >/dev/null; then
   echo "Chrome is not up — launching it first."
   "${SCRIPT_DIR}/launch-chrome.sh"
 fi
 
 # Open the Rabby UI tab if not present
-RABBY_ID="acmacodkjbdgmoleebolmdjonilkdbch"
-PORT="${DEBUG_PORT:-9223}"
-if ! curl -s "http://localhost:${PORT}/json/list" | grep -q "${RABBY_ID}/index.html"; then
+if ! curl -s "http://localhost:${DEBUG_PORT}/json/list" | grep -q "${RABBY_ID}/index.html"; then
   echo "Opening Rabby UI tab…"
-  curl -s -X PUT "http://localhost:${PORT}/json/new?chrome-extension://${RABBY_ID}/index.html#/welcome" >/dev/null
+  curl -s -X PUT "http://localhost:${DEBUG_PORT}/json/new?chrome-extension://${RABBY_ID}/index.html#/welcome" >/dev/null
   sleep 2
 fi
 
-# Drive the onboarding via the node helper
+# Drive the onboarding via the node helper. WATCH_ADDR, PASSWORD, DEBUG_PORT
+# are inherited from this script's environment via execve(2).
 exec node "${SCRIPT_DIR}/../helpers/onboard.mjs"

--- a/apps/web/e2e/watch-only/scripts/onboard.sh
+++ b/apps/web/e2e/watch-only/scripts/onboard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Run Rabby through first-time setup and add a watch-only address.
+#
+# Required env:
+#   WATCH_ADDR   the address to track (0x-prefixed checksummed)
+#
+# Optional env:
+#   PASSWORD     Rabby unlock password (default: TestPass123!)
+#   DEBUG_PORT   CDP port (default: 9223)
+
+set -euo pipefail
+
+if [[ -z "${WATCH_ADDR:-}" ]]; then
+  echo "ERROR: WATCH_ADDR is required" >&2
+  echo "  WATCH_ADDR=0x… $0" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure Chrome is running
+if ! curl -sf "http://localhost:${DEBUG_PORT:-9223}/json/version" >/dev/null; then
+  echo "Chrome is not up — launching it first."
+  "${SCRIPT_DIR}/launch-chrome.sh"
+fi
+
+# Open the Rabby UI tab if not present
+RABBY_ID="acmacodkjbdgmoleebolmdjonilkdbch"
+PORT="${DEBUG_PORT:-9223}"
+if ! curl -s "http://localhost:${PORT}/json/list" | grep -q "${RABBY_ID}/index.html"; then
+  echo "Opening Rabby UI tab…"
+  curl -s -X PUT "http://localhost:${PORT}/json/new?chrome-extension://${RABBY_ID}/index.html#/welcome" >/dev/null
+  sleep 2
+fi
+
+# Drive the onboarding via the node helper
+exec node "${SCRIPT_DIR}/../helpers/onboard.mjs"


### PR DESCRIPTION
## Why

The existing `apps/web/e2e/metamask/` suite is built around a seeded test wallet hitting Anvil + mocked endpoints. It cannot reach the class of bug that only shows up with a **real connected wallet against the live Trading API** — see PR #752 (the Satsuma routing bug) which only manifested with a real wallet on Citrea Mainnet making real `/v1/quote` + `/v1/swap` calls.

This PR adds a self-contained debugging harness for exactly that surface, *without* requiring a private key.

## What's included

`apps/web/e2e/watch-only/`

| File | Purpose |
|---|---|
| `README.md` | When/when-not to use this, the Chrome-for-Testing rationale, EIP-6963 / main-vs-isolated world caveats, troubleshooting matrix |
| `scripts/fetch-rabby.sh` | Pulls the latest Rabby release zip from GitHub into `~/.cache/chrome-extensions/rabby/` |
| `scripts/launch-chrome.sh` | Boots Chrome for Testing with the prepared profile + Rabby + CDP on `:9223` |
| `scripts/onboard.sh` + `helpers/onboard.mjs` | Automates Rabby's first-run flow (throwaway HD wallet, password) and adds a caller-provided watch-only address; idempotent on re-runs |
| `helpers/rabby.mjs` | Reusable `connectOverCDP` attach, popup auto-handler, wallet-state + request-recording utilities; locale labels are centralised at the top of the file |
| `examples/swap-flow.mjs` | The exact pattern used to investigate the bug PR #752 fixes — reproducible smoke for any similar swap-review investigation |

## Why Chrome for Testing, not stable Chrome

Stable Google Chrome 130+ silently rejects `--load-extension`:

```
WARNING:chrome/browser/extensions/extension_service.cc] --load-extension is not allowed in Google Chrome, ignoring.
```

Chrome for Testing (the variant `puppeteer-core` ships) still honours it. After a successful `yarn install` the binary lives at `~/.cache/puppeteer/chrome/mac_arm-<version>/…`.

`chrome-devtools-mcp` is intentionally not in the path: it launches Chrome with `--disable-extensions` by default *and* filters `chrome-extension://` pages out of `list_pages`, so it cannot drive Rabby's UI. We attach `playwright-core` over CDP directly.

## Test plan

- [x] All shell scripts pass `bash -n`
- [x] All `.mjs` files pass `node --check`
- [x] `helpers/rabby.mjs` smoke-tested end-to-end against a running Rabby + dev server: `attach`, `walletState`, `recordRequests` all return the expected shapes
- [x] Prettier passes on the whole tree

## Out of scope

- This is **not a CI test**. The harness depends on the live backend; failures are not always reproducible. Use it for debugging, not assertions.
- Watch-only addresses cannot sign — any test that needs `eth_sendTransaction` belongs in the existing MetaMask suite, not here.