### PR TITLE
Add launchpad token charts

### DIFF
--- a/apps/web/src/components/AccountDrawer/Points/styles.tsx
+++ b/apps/web/src/components/AccountDrawer/Points/styles.tsx
@@ -45,8 +45,7 @@ export function bubbleTextStyle(fontSize: number): CSSProperties {
     fontWeight: 900,
     letterSpacing: -fontSize * 0.03,
     lineHeight: 1,
-    backgroundImage:
-      'linear-gradient(135deg, #FFE9C4 0%, #FFB35C 25%, #F7911A 50%, #C46800 75%, #FFB35C 100%)',
+    backgroundImage: 'linear-gradient(135deg, #FFE9C4 0%, #FFB35C 25%, #F7911A 50%, #C46800 75%, #FFB35C 100%)',
     backgroundSize: '220% 220%',
     WebkitBackgroundClip: 'text',
     backgroundClip: 'text',
@@ -59,7 +58,7 @@ export function bubbleTextStyle(fontSize: number): CSSProperties {
 }
 
 export function LiquidBubbleStyleTag() {
-  return <style dangerouslySetInnerHTML={{ __html: LIQUID_BUBBLE_KEYFRAMES }} />
+  return <style>{LIQUID_BUBBLE_KEYFRAMES}</style>
 }
 
 const FILTER_ID_HERO = 'juice-goo-hero'
@@ -102,12 +101,7 @@ export function LiquidBg({ variant = 'hero' }: LiquidBgProps) {
       <defs>
         <filter id={filterId} x="-30%" y="-30%" width="160%" height="160%">
           <feGaussianBlur in="SourceGraphic" stdDeviation={stdDev} result="blur" />
-          <feColorMatrix
-            in="blur"
-            mode="matrix"
-            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -8"
-            result="goo"
-          />
+          <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -8" result="goo" />
           <feBlend in="SourceGraphic" in2="goo" />
         </filter>
         <radialGradient id={orbId} cx="50%" cy="40%">

--- a/apps/web/src/components/Charts/PriceChart/index.tsx
+++ b/apps/web/src/components/Charts/PriceChart/index.tsx
@@ -19,7 +19,7 @@ import {
   PriceLineOptions,
   UTCTimestamp,
 } from 'lightweight-charts'
-import { useMemo } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import { Trans } from 'react-i18next'
 import { Flex, Text, styled } from 'ui/src'
 import { opacify } from 'ui/src/theme'
@@ -30,6 +30,7 @@ export type PriceChartData = CandlestickData<UTCTimestamp> & AreaData<UTCTimesta
 
 interface PriceChartModelParams extends ChartModelParams<PriceChartData> {
   type: PriceChartType
+  variant?: 'default' | 'launchpad'
 }
 
 const LOW_PRICE_RANGE_THRESHOLD = 0.2
@@ -93,7 +94,8 @@ export class PriceChartModel extends ChartModel<PriceChartData> {
   }
 
   updateOptions(params: PriceChartModelParams) {
-    const { data, theme, type, locale, format, tokenFormatType } = params
+    const { data, theme, type, locale, format, tokenFormatType, variant } = params
+    const isLaunchpad = variant === 'launchpad'
     super.updateOptions(params, {
       localization: {
         locale,
@@ -112,9 +114,53 @@ export class PriceChartModel extends ChartModel<PriceChartData> {
         },
       },
       grid: {
-        vertLines: { style: LineStyle.CustomDotGrid, color: theme.neutral3 },
-        horzLines: { style: LineStyle.CustomDotGrid, color: theme.neutral3 },
+        vertLines: {
+          visible: true,
+          style: isLaunchpad ? LineStyle.Solid : LineStyle.CustomDotGrid,
+          color: isLaunchpad ? opacify(10, theme.accent1) : theme.neutral3,
+        },
+        horzLines: {
+          visible: true,
+          style: isLaunchpad ? LineStyle.Solid : LineStyle.CustomDotGrid,
+          color: isLaunchpad ? theme.surface3 : theme.neutral3,
+        },
       },
+      ...(isLaunchpad
+        ? {
+            crosshair: {
+              horzLine: {
+                visible: true,
+                style: LineStyle.Solid,
+                width: 1,
+                color: opacify(55, theme.accent1),
+                labelVisible: false,
+              },
+              vertLine: {
+                visible: true,
+                style: LineStyle.Solid,
+                width: 1,
+                color: opacify(55, theme.accent1),
+                labelVisible: false,
+              },
+            },
+            rightPriceScale: {
+              visible: false,
+              borderVisible: false,
+              scaleMargins: {
+                top: 0.24,
+                bottom: 0.18,
+              },
+              autoScale: true,
+            },
+            timeScale: {
+              borderVisible: false,
+              ticksVisible: false,
+              timeVisible: true,
+              fixLeftEdge: true,
+              fixRightEdge: true,
+            },
+          }
+        : {}),
     })
 
     // Handles changing between line/candlestick view
@@ -150,17 +196,17 @@ export class PriceChartModel extends ChartModel<PriceChartData> {
 
       // Line-specific options:
       lineType: data.length < 20 ? LineType.WithSteps : LineType.Curved, // Stepped line is visually preferred for smaller datasets
-      lineWidth: 2,
+      lineWidth: isLaunchpad ? 3 : 2,
       lineColor,
-      topColor: opacify(12, lineColor),
-      bottomColor: opacify(12, lineColor),
+      topColor: opacify(isLaunchpad ? 22 : 12, lineColor),
+      bottomColor: opacify(isLaunchpad ? 4 : 12, lineColor),
       crosshairMarkerRadius: 5,
-      crosshairMarkerBorderColor: opacify(30, lineColor),
+      crosshairMarkerBorderColor: opacify(isLaunchpad ? 55 : 30, lineColor),
       crosshairMarkerBorderWidth: 3,
 
       // Candlestick-specific options:
-      upColor: theme.success,
-      wickUpColor: theme.success,
+      upColor: isLaunchpad ? theme.accent1 : theme.success,
+      wickUpColor: isLaunchpad ? theme.accent1 : theme.success,
       downColor: theme.critical,
       wickDownColor: theme.critical,
       borderVisible: false,
@@ -225,6 +271,8 @@ interface PriceChartProps {
   height: number
   data: PriceChartData[]
   stale: boolean
+  variant?: 'default' | 'launchpad'
+  valueFormatter?: (value: number | undefined) => ReactElement
 }
 
 const CandlestickTooltipRow = styled(Flex, {
@@ -259,20 +307,26 @@ function CandlestickTooltip({ data }: { data: PriceChartData }) {
   )
 }
 
-export function PriceChart({ data, height, type, stale }: PriceChartProps) {
+export function PriceChart({ data, height, type, stale, variant = 'default', valueFormatter }: PriceChartProps) {
   const lastPrice = data[data.length - 1]
 
   return (
     <Chart
       Model={PriceChartModel}
-      params={useMemo(() => ({ data, type, stale }), [data, stale, type])}
+      params={useMemo(() => ({ data, type, stale, variant }), [data, stale, type, variant])}
       height={height}
       TooltipBody={type === PriceChartType.CANDLESTICK ? CandlestickTooltip : undefined}
     >
       {(crosshairData) => (
         <ChartHeader
-          value={(crosshairData ?? lastPrice).value}
-          additionalFields={<PriceChartDelta startingPrice={data[0]} endingPrice={crosshairData ?? lastPrice} />}
+          value={
+            valueFormatter ? valueFormatter((crosshairData ?? lastPrice).value) : (crosshairData ?? lastPrice).value
+          }
+          additionalFields={
+            variant === 'launchpad' ? undefined : (
+              <PriceChartDelta startingPrice={data[0]} endingPrice={crosshairData ?? lastPrice} />
+            )
+          }
           valueFormatterType={NumberType.FiatTokenPrice}
           time={crosshairData?.time}
         />

--- a/apps/web/src/components/Logo/QueryTokenLogo.tsx
+++ b/apps/web/src/components/Logo/QueryTokenLogo.tsx
@@ -15,8 +15,9 @@ export default function QueryTokenLogo(
     token?: TokenStat
   },
 ) {
-  const chainId = getChainIdFromChainUrlParam(props.token?.chain.toLowerCase()) ?? UniverseChainId.Mainnet
-  const isNative = props.token?.address === NATIVE_CHAIN_ID
+  const { token } = props
+  const chainId = getChainIdFromChainUrlParam(token?.chain.toLowerCase()) ?? UniverseChainId.Mainnet
+  const isNative = token?.address === NATIVE_CHAIN_ID
 
   const nativeCurrency = useNativeCurrency(chainId)
   const currency = isNative ? nativeCurrency : undefined
@@ -24,10 +25,9 @@ export default function QueryTokenLogo(
   const currencies = useMemo(() => (!isNative ? undefined : [currency]), [currency, isNative])
 
   // Launchpad token logo - resolved from metadata when token is from launchpad
-  const launchpadLogoUrl = useLaunchpadTokenLogoUrl(props.token?.address, chainId)
+  const launchpadLogoUrl = useLaunchpadTokenLogoUrl(token?.address, chainId)
 
   const logoUrl = useMemo(() => {
-    const { token } = props
     const candidates = [
       token?.logo,
       token?.project?.logo?.url,
@@ -37,15 +37,7 @@ export default function QueryTokenLogo(
       launchpadLogoUrl,
     ]
     return candidates.find(Boolean) ?? undefined
-  }, [
-    props.token,
-    props.token?.logo,
-    props.token?.project?.logo?.url,
-    props.token?.address,
-    props.token?.symbol,
-    chainId,
-    launchpadLogoUrl,
-  ])
+  }, [token, chainId, launchpadLogoUrl])
 
   return <PortfolioLogo currencies={currencies} chainId={chainId} images={[logoUrl]} {...props} />
 }

--- a/apps/web/src/components/Popups/PopupContent.tsx
+++ b/apps/web/src/components/Popups/PopupContent.tsx
@@ -240,7 +240,6 @@ export function BridgingPopupContent({ hash, onClose }: { hash: string; onClose:
 export function LightningBridgePopupContent({
   direction,
   status,
-  url,
   onClose,
 }: {
   direction: LightningBridgeDirection
@@ -288,11 +287,6 @@ export function LightningBridgePopupContent({
   }, [direction])
 
   const isPending = status === LdsBridgeStatus.Pending
-
-  const onClick = () => {
-    window.open(url, '_blank', 'noopener,noreferrer')
-    onClose()
-  }
 
   return (
     <Flex

--- a/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
+++ b/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
@@ -81,7 +81,7 @@ function WebUniswapProviderInner({ children }: PropsWithChildren) {
 
   const navigateToBridgesSwaps = useCallback(() => {
     navigate('/bridge-swaps')
-  }, [])
+  }, [navigate])
 
   const navigateToUrl = useCallback(
     (url: string) => {

--- a/apps/web/src/hooks/useLaunchpadTokens.ts
+++ b/apps/web/src/hooks/useLaunchpadTokens.ts
@@ -78,6 +78,45 @@ export interface LaunchpadTradesResponse {
   }
 }
 
+export type LaunchpadCandleInterval = '1m' | '5m' | '15m' | '1h' | '4h' | '1d'
+
+export interface LaunchpadCandle {
+  time: number
+  open: number
+  high: number
+  low: number
+  close: number
+  volumeBase: number
+  volumeToken: number
+  tradeCount: number
+}
+
+export interface LaunchpadUserTradeMarker {
+  time: number
+  side: 'buy' | 'sell'
+  price: number
+  baseAmount: number
+  tokenAmount: number
+  txHash: `0x${string}`
+  blockNumber: number
+}
+
+export interface LaunchpadCandlesResponse {
+  range: {
+    from: number
+    to: number
+    interval: LaunchpadCandleInterval
+    intervalSeconds: number
+    limit: number
+  }
+  source: 'bonding_curve' | 'bonding_curve_pre_graduation'
+  priceBasis: 'execution_price'
+  currency: 'base'
+  candles: LaunchpadCandle[]
+  latest: { price: number; timestamp: number } | null
+  userTrades?: LaunchpadUserTradeMarker[]
+}
+
 export interface UseLaunchpadTokensOptions {
   filter?: LaunchpadFilterType
   page?: number
@@ -213,6 +252,45 @@ export function useLaunchpadTrades(options: UseLaunchpadTradesOptions) {
     enabled: !!address,
     staleTime: 10_000,
     refetchInterval: 15_000, // 15 seconds
+  })
+}
+
+export function useLaunchpadCandles({
+  address,
+  chainId,
+  interval = '5m',
+  trader,
+}: {
+  address: string | undefined
+  chainId?: number
+  interval?: LaunchpadCandleInterval
+  trader?: string
+}) {
+  return useQuery({
+    queryKey: ['launchpad-candles', address, chainId, interval, trader],
+    queryFn: async (): Promise<LaunchpadCandlesResponse> => {
+      const params = new URLSearchParams({
+        interval,
+        limit: '240',
+        fill: 'last',
+        currency: 'base',
+      })
+      if (chainId) {
+        params.set('chainId', chainId.toString())
+      }
+      if (trader) {
+        params.set('trader', trader)
+      }
+
+      const response = await fetch(`${API_URL}/v1/launchpad/token/${address}/candles?${params}`)
+      if (!response.ok) {
+        throw new Error('Failed to fetch launchpad candles')
+      }
+      return response.json()
+    },
+    enabled: !!address,
+    staleTime: 10_000,
+    refetchInterval: 10_000,
   })
 }
 

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -1,8 +1,12 @@
+import { PriceChart, type PriceChartData } from 'components/Charts/PriceChart'
+import { PriceChartType } from 'components/Charts/utils'
+import { useAccount } from 'hooks/useAccount'
 import { useBondingCurveToken } from 'hooks/useBondingCurveToken'
 import { useLaunchpadTokenPrice } from 'hooks/useLaunchpadTokenPrice'
-import { useLaunchpadToken } from 'hooks/useLaunchpadTokens'
+import { useLaunchpadCandles, useLaunchpadToken, type LaunchpadCandleInterval } from 'hooks/useLaunchpadTokens'
 import { useTokenInfo } from 'hooks/useTokenFactory'
 import { getSocialLink, useTokenMetadata } from 'hooks/useTokenMetadata'
+import type { UTCTimestamp } from 'lightweight-charts'
 import { BuySellPanel } from 'pages/Launchpad/components/BuySellPanel'
 import { TokenLogo } from 'pages/Launchpad/components/TokenLogo'
 import {
@@ -16,6 +20,7 @@ import {
   StatValue,
   getProgressGradient,
 } from 'pages/Launchpad/components/shared'
+import { LAUNCHPAD_TOKEN_TOTAL_SUPPLY } from 'pages/Launchpad/constants'
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Flex, ModalCloseIcon, Text, styled } from 'ui/src'
@@ -31,6 +36,7 @@ import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
 import { formatUnits } from 'viem'
 
 type SocialPlatform = 'Twitter' | 'Telegram'
+type ChartPriceUnit = 'usd' | 'jusd'
 
 const SOCIAL_URL_PATTERNS: Record<SocialPlatform, { check: (s: string) => boolean; regex: RegExp }> = {
   Twitter: {
@@ -57,6 +63,26 @@ function extractSocialHandle(value: string | null | undefined, platform: SocialP
   }
 
   return trimmed.replace('@', '')
+}
+
+const USD_AMOUNT_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2,
+})
+
+const USD_PRICE_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumSignificantDigits: 6,
+})
+
+function formatUsdAmount(value: number | null): string {
+  return typeof value === 'number' && Number.isFinite(value) ? USD_AMOUNT_FORMATTER.format(value) : '-'
+}
+
+function formatUsdPrice(value: number | undefined): string {
+  return typeof value === 'number' && Number.isFinite(value) ? USD_PRICE_FORMATTER.format(value) : '-'
 }
 
 const PageContainer = styled(Flex, {
@@ -101,6 +127,7 @@ const TokenSymbol = styled(Text, {
 
 const MainContent = styled(Flex, {
   flexDirection: 'row',
+  alignItems: 'stretch',
   gap: '$spacing24',
   $md: {
     flexDirection: 'column',
@@ -119,6 +146,7 @@ const RightColumn = styled(Flex, {
   flexShrink: 0,
   width: 360,
   maxWidth: '100%',
+  alignSelf: 'stretch',
   gap: '$spacing24',
   overflow: 'hidden',
   $md: {
@@ -127,10 +155,102 @@ const RightColumn = styled(Flex, {
   },
 })
 
+const FullWidthStack = styled(Flex, {
+  gap: '$spacing24',
+})
+
+const ChartCard = styled(Card, {
+  borderTopWidth: 2,
+  borderTopColor: '$accent1',
+})
+
 const CardTitle = styled(Text, {
   variant: 'body1',
   color: '$neutral1',
   fontWeight: '600',
+})
+
+const ChartStatsGrid = styled(Flex, {
+  flexDirection: 'row',
+  gap: '$spacing12',
+  flexWrap: 'wrap',
+})
+
+const ChartStat = styled(Flex, {
+  flex: 1,
+  minWidth: 150,
+  minHeight: 76,
+  justifyContent: 'center',
+  gap: '$spacing6',
+  backgroundColor: '$surface1',
+  borderRadius: '$rounded16',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  padding: '$spacing16',
+})
+
+const ChartStatValue = styled(StatValue, {
+  variant: 'subheading2',
+  fontWeight: '700',
+})
+
+const ChartHeaderRow = styled(Flex, {
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: '$spacing12',
+  flexWrap: 'wrap',
+})
+
+const ChartControls = styled(Flex, {
+  flexDirection: 'row',
+  gap: '$spacing8',
+  flexWrap: 'wrap',
+  maxWidth: '100%',
+  $md: {
+    width: '100%',
+    flexDirection: 'column',
+  },
+})
+
+const SegmentedControl = styled(Flex, {
+  flexDirection: 'row',
+  gap: '$spacing4',
+  padding: '$spacing4',
+  borderRadius: '$rounded16',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  backgroundColor: '$surface1',
+  maxWidth: '100%',
+  $md: {
+    width: '100%',
+    justifyContent: 'space-between',
+  },
+})
+
+const SegmentButton = styled(Flex, {
+  minWidth: 40,
+  minHeight: 34,
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingHorizontal: '$spacing10',
+  borderRadius: '$rounded12',
+  cursor: 'pointer',
+  $md: {
+    flex: 1,
+    minWidth: 0,
+    paddingHorizontal: '$spacing6',
+  },
+  hoverStyle: {
+    backgroundColor: '$surface2',
+  },
+  variants: {
+    active: {
+      true: {
+        backgroundColor: '$accent1',
+      },
+    },
+  } as const,
 })
 
 const AddressRow = styled(Flex, {
@@ -152,6 +272,9 @@ const AddressLink = styled(Flex, {
 export default function TokenDetail() {
   const { tokenAddress } = useParams<{ tokenAddress: string }>()
   const navigate = useNavigate()
+  const account = useAccount()
+  const [chartInterval, setChartInterval] = useState<LaunchpadCandleInterval>('5m')
+  const [chartPriceUnit, setChartPriceUnit] = useState<ChartPriceUnit>('usd')
 
   // First, fetch the token data from API to get the correct chainId
   const { data: launchpadData } = useLaunchpadToken(tokenAddress)
@@ -175,6 +298,12 @@ export default function TokenDetail() {
 
   const { tokenInfo } = useTokenInfo(tokenAddress, chainId)
   const { data: metadata } = useTokenMetadata(launchpadData?.token.metadataURI)
+  const { data: candlesData, isLoading: candlesLoading } = useLaunchpadCandles({
+    address: tokenAddress,
+    chainId: launchpadData?.token.chainId,
+    interval: chartInterval,
+    trader: account.address,
+  })
   const [showBondingModal, setShowBondingModal] = useState(false)
 
   // Use unified price hook for graduated/non-graduated tokens
@@ -190,6 +319,19 @@ export default function TokenDetail() {
     bondingCurveReserves: reserves,
     chainId,
   })
+
+  const displayName = name || launchpadData?.token.name || 'Unknown Token'
+  const displaySymbol = symbol || launchpadData?.token.symbol || '???'
+  const displayGraduated = graduated || launchpadData?.token.graduated || false
+  const displayCanGraduate = canGraduate || launchpadData?.token.canGraduate || false
+  const displayBaseAsset = baseAsset || launchpadData?.token.baseAsset
+  const displayV2Pair = v2Pair || launchpadData?.token.v2Pair || undefined
+  const indexedProgress = launchpadData?.token.progress
+    ? launchpadData.token.progress > 100
+      ? launchpadData.token.progress / 100
+      : launchpadData.token.progress
+    : 0
+  const displayProgress = displayGraduated ? 100 : progress || indexedProgress
 
   const handleBack = useCallback(() => {
     navigate('/launchpad')
@@ -213,16 +355,62 @@ export default function TokenDetail() {
   }, [tokenAddress, chainId])
 
   // Format volume from indexed data
-  const volume = useMemo(() => {
+  const volumeValue = useMemo(() => {
     if (!launchpadData?.token.totalVolumeBase) {
-      return '0'
+      return null
     }
-    const value = Number(formatUnits(BigInt(launchpadData.token.totalVolumeBase), 18))
-    return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    return Number(formatUnits(BigInt(launchpadData.token.totalVolumeBase), 18))
   }, [launchpadData?.token.totalVolumeBase])
+
+  const volume = volumeValue?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? '0'
+  const volumeUsd = formatUsdAmount(volumeValue)
 
   // Total trades from indexed data
   const totalTrades = (launchpadData?.token.totalBuys ?? 0) + (launchpadData?.token.totalSells ?? 0)
+
+  const latestCandle = candlesData?.candles[candlesData.candles.length - 1]
+  const latestChartPriceValue = candlesData?.latest?.price ?? latestCandle?.close ?? null
+
+  const chartData = useMemo<PriceChartData[]>(() => {
+    return (
+      candlesData?.candles.map((candle) => ({
+        time: candle.time as UTCTimestamp,
+        open: candle.open,
+        high: candle.high,
+        low: candle.low,
+        close: candle.close,
+        value: candle.close,
+      })) ?? []
+    )
+  }, [candlesData?.candles])
+
+  const latestChartPrice = latestChartPriceValue
+    ? latestChartPriceValue.toLocaleString(undefined, { maximumSignificantDigits: 6 })
+    : null
+  const fallbackMarketCap = latestChartPriceValue ? latestChartPriceValue * LAUNCHPAD_TOKEN_TOTAL_SUPPLY : null
+  const displayMarketCap =
+    marketCap && !['0', 'N/A', '...'].includes(marketCap)
+      ? marketCap
+      : fallbackMarketCap?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? marketCap
+  const displayMarketCapUsd = formatUsdAmount(fallbackMarketCap)
+
+  const chartValueFormatter = useCallback(
+    (value: number | undefined) => {
+      const formatted =
+        chartPriceUnit === 'usd'
+          ? formatUsdPrice(value)
+          : typeof value === 'number' && Number.isFinite(value)
+            ? `${value.toLocaleString(undefined, { maximumSignificantDigits: 8 })} JUSD`
+            : '-'
+
+      return (
+        <Text variant="heading2" color="$neutral1">
+          {formatted}
+        </Text>
+      )
+    },
+    [chartPriceUnit],
+  )
 
   const tokensRemaining = useMemo(() => {
     if (!reserves) {
@@ -231,19 +419,22 @@ export default function TokenDetail() {
     return Number(formatUnits(reserves.realToken, 18)).toLocaleString(undefined, { maximumFractionDigits: 0 })
   }, [reserves])
 
+  const creatorAddress = tokenInfo?.creator ?? launchpadData?.token.creator
   const creatorShort = useMemo(() => {
-    if (!tokenInfo?.creator) {
+    if (!creatorAddress) {
       return '...'
     }
-    return `${tokenInfo.creator.slice(0, 6)}...${tokenInfo.creator.slice(-4)}`
-  }, [tokenInfo])
+    return `${creatorAddress.slice(0, 6)}...${creatorAddress.slice(-4)}`
+  }, [creatorAddress])
 
   const createdDate = useMemo(() => {
-    if (!tokenInfo?.timestamp) {
+    const timestamp =
+      tokenInfo?.timestamp ?? (launchpadData?.token.createdAt ? Number(launchpadData.token.createdAt) : null)
+    if (!timestamp) {
       return ''
     }
-    return new Date(tokenInfo.timestamp * 1000).toLocaleDateString()
-  }, [tokenInfo])
+    return new Date(timestamp * 1000).toLocaleDateString()
+  }, [launchpadData?.token.createdAt, tokenInfo?.timestamp])
 
   if (isLoading) {
     return (
@@ -281,11 +472,11 @@ export default function TokenDetail() {
           </BackButton>
 
           <HeaderSection>
-            <TokenLogo metadataURI={launchpadData?.token.metadataURI} symbol={symbol || '?'} size={80} />
+            <TokenLogo metadataURI={launchpadData?.token.metadataURI} symbol={displaySymbol || '?'} size={80} />
             <TokenInfo>
               <Flex flexDirection="row" alignItems="center" gap="$spacing12">
-                <TokenName>{name || 'Unknown Token'}</TokenName>
-                {graduated && (
+                <TokenName>{displayName}</TokenName>
+                {displayGraduated && (
                   <GraduatedBadge size="md">
                     <Text variant="body3" color="$statusSuccess" fontWeight="600">
                       Graduated
@@ -293,7 +484,7 @@ export default function TokenDetail() {
                   </GraduatedBadge>
                 )}
               </Flex>
-              <TokenSymbol>${symbol || '???'}</TokenSymbol>
+              <TokenSymbol>${displaySymbol}</TokenSymbol>
               <AddressRow>
                 <Text variant="body3" color="$neutral3">
                   {tokenAddress.slice(0, 10)}...{tokenAddress.slice(-8)}
@@ -352,143 +543,239 @@ export default function TokenDetail() {
             </TokenInfo>
           </HeaderSection>
 
-          {metadata?.description && (
-            <Card>
-              <CardTitle>About</CardTitle>
+          <Card>
+            <CardTitle>Bonding Curve Progress</CardTitle>
+            <ProgressBar>
+              <ProgressFill
+                style={{
+                  width: `${Math.min(displayProgress, 100)}%`,
+                  background: getProgressGradient(displayProgress),
+                }}
+              />
+            </ProgressBar>
+            <Flex flexDirection="row" justifyContent="space-between">
               <Text variant="body2" color="$neutral2">
-                {metadata.description}
+                {displayGraduated ? '100%' : `${displayProgress.toFixed(2)}%`} complete
               </Text>
-            </Card>
-          )}
+              <Text variant="body2" color={displayGraduated ? '$statusSuccess' : '$neutral1'}>
+                {displayGraduated ? 'Graduated to V2' : `${tokensRemaining} tokens remaining`}
+              </Text>
+            </Flex>
+
+            {!displayGraduated && (
+              <Flex
+                flexDirection="row"
+                alignItems="center"
+                gap="$spacing6"
+                marginTop="$spacing4"
+                cursor="pointer"
+                onPress={() => setShowBondingModal(true)}
+                hoverStyle={{ opacity: 0.7 }}
+              >
+                <Text variant="body3" color="$neutral3">
+                  Graduates to V2 at 100% · 1% fee
+                </Text>
+                <InfoCircle size={14} color="$neutral3" />
+              </Flex>
+            )}
+          </Card>
 
           <MainContent>
             <LeftColumn>
-              <Card>
-                <CardTitle>Bonding Curve Progress</CardTitle>
-                <ProgressBar>
-                  <ProgressFill
-                    style={{
-                      width: `${graduated ? 100 : Math.min(progress, 100)}%`,
-                      background: getProgressGradient(graduated ? 100 : progress),
-                    }}
-                  />
-                </ProgressBar>
-                <Flex flexDirection="row" justifyContent="space-between">
-                  <Text variant="body2" color="$neutral2">
-                    {graduated ? '100%' : `${progress.toFixed(2)}%`} complete
-                  </Text>
-                  <Text variant="body2" color={graduated ? '$statusSuccess' : '$neutral1'}>
-                    {graduated ? 'Graduated to V2' : `${tokensRemaining} tokens remaining`}
-                  </Text>
-                </Flex>
+              <ChartCard>
+                <ChartStatsGrid>
+                  <ChartStat>
+                    <StatLabel variant="body3">Market Cap</StatLabel>
+                    <ChartStatValue>{displayMarketCapUsd}</ChartStatValue>
+                  </ChartStat>
+                  <ChartStat>
+                    <StatLabel variant="body3">Volume</StatLabel>
+                    <ChartStatValue>{volumeUsd}</ChartStatValue>
+                  </ChartStat>
+                  <ChartStat>
+                    <StatLabel variant="body3">Trades</StatLabel>
+                    <ChartStatValue>{totalTrades}</ChartStatValue>
+                  </ChartStat>
+                </ChartStatsGrid>
 
-                {!graduated && (
-                  <Flex
-                    flexDirection="row"
-                    alignItems="center"
-                    gap="$spacing6"
-                    marginTop="$spacing4"
-                    cursor="pointer"
-                    onPress={() => setShowBondingModal(true)}
-                    hoverStyle={{ opacity: 0.7 }}
-                  >
-                    <Text variant="body3" color="$neutral3">
-                      Graduates to V2 at 100% · 1% fee
+                <ChartHeaderRow>
+                  <Flex gap="$spacing4">
+                    <CardTitle>Price Chart</CardTitle>
+                    <Text variant="body3" color="$neutral2">
+                      {candlesData?.source === 'bonding_curve_pre_graduation'
+                        ? 'Bonding curve history before graduation'
+                        : 'Bonding curve execution price'}
                     </Text>
-                    <InfoCircle size={14} color="$neutral3" />
+                  </Flex>
+                  <ChartControls>
+                    <SegmentedControl aria-label="Chart price unit" role="tablist">
+                      {(['usd', 'jusd'] as const).map((unit) => (
+                        <SegmentButton
+                          key={unit}
+                          aria-selected={chartPriceUnit === unit}
+                          active={chartPriceUnit === unit}
+                          onPress={() => setChartPriceUnit(unit)}
+                          role="tab"
+                        >
+                          <Text variant="buttonLabel4" color={chartPriceUnit === unit ? '$white' : '$neutral2'}>
+                            {unit === 'usd' ? 'USD' : 'JUSD'}
+                          </Text>
+                        </SegmentButton>
+                      ))}
+                    </SegmentedControl>
+                    <SegmentedControl aria-label="Chart interval" role="tablist">
+                      {(['1m', '5m', '15m', '1h', '4h', '1d'] as const).map((interval) => (
+                        <SegmentButton
+                          key={interval}
+                          aria-selected={chartInterval === interval}
+                          active={chartInterval === interval}
+                          onPress={() => setChartInterval(interval)}
+                          role="tab"
+                        >
+                          <Text variant="buttonLabel4" color={chartInterval === interval ? '$white' : '$neutral2'}>
+                            {interval}
+                          </Text>
+                        </SegmentButton>
+                      ))}
+                    </SegmentedControl>
+                  </ChartControls>
+                </ChartHeaderRow>
+
+                {chartData.length > 0 ? (
+                  <PriceChart
+                    data={chartData}
+                    height={360}
+                    type={PriceChartType.LINE}
+                    stale={false}
+                    variant="launchpad"
+                    valueFormatter={chartValueFormatter}
+                  />
+                ) : (
+                  <Flex height={360} alignItems="center" justifyContent="center">
+                    <Text variant="body2" color="$neutral2">
+                      {candlesLoading ? 'Loading chart...' : 'No chart data yet'}
+                    </Text>
                   </Flex>
                 )}
-              </Card>
 
-              <Card>
-                <CardTitle>Token Info</CardTitle>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Current Price</StatLabel>
-                  <StatValue variant="body2">{currentPrice} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Market Cap</StatLabel>
-                  <StatValue variant="body2">{marketCap} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Liquidity</StatLabel>
-                  <StatValue variant="body2">{liquidity} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Volume</StatLabel>
-                  <StatValue variant="body2">{volume} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Trades</StatLabel>
-                  <StatValue variant="body2">{totalTrades}</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Total Supply</StatLabel>
-                  <StatValue variant="body2">1,000,000,000</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Creator</StatLabel>
-                  <AddressLink
-                    onPress={() => {
-                      if (tokenInfo?.creator) {
-                        const url = getExplorerLink({
-                          chainId,
-                          data: tokenInfo.creator,
-                          type: ExplorerDataType.ADDRESS,
-                        })
-                        window.open(url, '_blank')
-                      }
-                    }}
-                  >
-                    <StatValue variant="body2">{creatorShort}</StatValue>
-                    <ExternalLink size="$icon.16" color="$neutral2" />
-                  </AddressLink>
-                </StatRow>
-                {createdDate && (
-                  <StatRow paddingVertical="$spacing4">
-                    <StatLabel variant="body2">Created</StatLabel>
-                    <StatValue variant="body2">{createdDate}</StatValue>
-                  </StatRow>
-                )}
-                {graduated && v2Pair && (
-                  <StatRow paddingVertical="$spacing4">
-                    <StatLabel variant="body2">V2 Pair</StatLabel>
-                    <AddressLink
-                      onPress={() => {
-                        const url = getExplorerLink({
-                          chainId,
-                          data: v2Pair,
-                          type: ExplorerDataType.ADDRESS,
-                        })
-                        window.open(url, '_blank')
-                      }}
-                    >
-                      <StatValue variant="body2">
-                        {v2Pair.slice(0, 6)}...{v2Pair.slice(-4)}
-                      </StatValue>
-                      <ExternalLink size="$icon.16" color="$neutral2" />
-                    </AddressLink>
-                  </StatRow>
-                )}
-              </Card>
+                {candlesData?.userTrades?.length ? (
+                  <Flex gap="$spacing8">
+                    <Text variant="body3" color="$neutral2">
+                      Your trades in this range
+                    </Text>
+                    {candlesData.userTrades.slice(-5).map((trade) => (
+                      <StatRow key={`${trade.txHash}-${trade.time}`} paddingVertical="$spacing2">
+                        <StatLabel variant="body3">{trade.side === 'buy' ? 'Buy' : 'Sell'}</StatLabel>
+                        <StatValue variant="body3">
+                          {trade.price.toLocaleString(undefined, { maximumSignificantDigits: 6 })} JUSD
+                        </StatValue>
+                      </StatRow>
+                    ))}
+                  </Flex>
+                ) : null}
+              </ChartCard>
             </LeftColumn>
 
             <RightColumn>
-              {baseAsset && (
+              {displayBaseAsset && (
                 <BuySellPanel
                   tokenAddress={tokenAddress}
-                  tokenSymbol={symbol || '???'}
-                  baseAsset={baseAsset}
-                  graduated={graduated}
-                  canGraduate={canGraduate}
+                  tokenSymbol={displaySymbol}
+                  baseAsset={displayBaseAsset}
+                  graduated={displayGraduated}
+                  canGraduate={displayCanGraduate}
                   chainId={chainId}
                   reserves={reserves}
+                  matchChartHeight
                   onTransactionComplete={refetchBondingCurve}
                   onGraduateComplete={refetchBondingCurve}
                 />
               )}
             </RightColumn>
           </MainContent>
+
+          <FullWidthStack>
+            {metadata?.description && (
+              <Card>
+                <CardTitle>About</CardTitle>
+                <Text variant="body2" color="$neutral2">
+                  {metadata.description}
+                </Text>
+              </Card>
+            )}
+
+            <Card>
+              <CardTitle>Token Info</CardTitle>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Current Price</StatLabel>
+                <StatValue variant="body2">{latestChartPrice || currentPrice} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Market Cap</StatLabel>
+                <StatValue variant="body2">{displayMarketCap} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Liquidity</StatLabel>
+                <StatValue variant="body2">{liquidity} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Volume</StatLabel>
+                <StatValue variant="body2">{volume} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Trades</StatLabel>
+                <StatValue variant="body2">{totalTrades}</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Total Supply</StatLabel>
+                <StatValue variant="body2">1,000,000,000</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Creator</StatLabel>
+                <AddressLink
+                  onPress={() => {
+                    if (creatorAddress) {
+                      const url = getExplorerLink({
+                        chainId,
+                        data: creatorAddress,
+                        type: ExplorerDataType.ADDRESS,
+                      })
+                      window.open(url, '_blank')
+                    }
+                  }}
+                >
+                  <StatValue variant="body2">{creatorShort}</StatValue>
+                  <ExternalLink size="$icon.16" color="$neutral2" />
+                </AddressLink>
+              </StatRow>
+              {createdDate && (
+                <StatRow paddingVertical="$spacing4">
+                  <StatLabel variant="body2">Created</StatLabel>
+                  <StatValue variant="body2">{createdDate}</StatValue>
+                </StatRow>
+              )}
+              {displayGraduated && displayV2Pair && (
+                <StatRow paddingVertical="$spacing4">
+                  <StatLabel variant="body2">V2 Pair</StatLabel>
+                  <AddressLink
+                    onPress={() => {
+                      const url = getExplorerLink({
+                        chainId,
+                        data: displayV2Pair,
+                        type: ExplorerDataType.ADDRESS,
+                      })
+                      window.open(url, '_blank')
+                    }}
+                  >
+                    <StatValue variant="body2">
+                      {displayV2Pair.slice(0, 6)}...{displayV2Pair.slice(-4)}
+                    </StatValue>
+                    <ExternalLink size="$icon.16" color="$neutral2" />
+                  </AddressLink>
+                </StatRow>
+              )}
+            </Card>
+          </FullWidthStack>
         </ContentWrapper>
       </PageContainer>
 

--- a/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
+++ b/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
@@ -36,6 +36,16 @@ const PanelContainer = styled(Flex, {
   gap: '$spacing16',
   overflow: 'hidden',
   minWidth: 0,
+  variants: {
+    matchChartHeight: {
+      true: {
+        minHeight: 524,
+        height: '100%',
+        padding: '$spacing24',
+        gap: '$spacing20',
+      },
+    },
+  } as const,
 })
 
 const TabContainer = styled(Flex, {
@@ -44,6 +54,14 @@ const TabContainer = styled(Flex, {
   padding: '$spacing4',
   backgroundColor: '$surface3',
   borderRadius: '$rounded12',
+  variants: {
+    large: {
+      true: {
+        padding: '$spacing6',
+        borderRadius: '$rounded16',
+      },
+    },
+  } as const,
 })
 
 const Tab = styled(Flex, {
@@ -57,6 +75,12 @@ const Tab = styled(Flex, {
     active: {
       true: {
         backgroundColor: '$accent1',
+      },
+    },
+    large: {
+      true: {
+        paddingVertical: '$spacing16',
+        borderRadius: '$rounded12',
       },
     },
   } as const,
@@ -208,6 +232,8 @@ interface BuySellPanelProps {
   chainId: number | undefined
   /** Bonding curve reserves - used for excess JUSD warning */
   reserves: BondingCurveReserves | undefined
+  /** Enlarges the panel for token detail layouts where it sits beside a chart. */
+  matchChartHeight?: boolean
   onTransactionComplete?: () => void
   onGraduateComplete?: () => void
 }
@@ -220,6 +246,7 @@ export function BuySellPanel({
   canGraduate,
   chainId,
   reserves,
+  matchChartHeight = false,
   onTransactionComplete,
   onGraduateComplete,
 }: BuySellPanelProps) {
@@ -694,7 +721,7 @@ export function BuySellPanel({
 
   if (graduated) {
     return (
-      <PanelContainer>
+      <PanelContainer matchChartHeight={matchChartHeight}>
         <Text variant="body1" color="$neutral1" textAlign="center">
           This token has graduated to JuiceSwap V2
         </Text>
@@ -711,14 +738,14 @@ export function BuySellPanel({
   }
 
   return (
-    <PanelContainer>
-      <TabContainer>
-        <Tab active={isBuy} onPress={() => setIsBuy(true)}>
+    <PanelContainer matchChartHeight={matchChartHeight}>
+      <TabContainer large={matchChartHeight}>
+        <Tab active={isBuy} large={matchChartHeight} onPress={() => setIsBuy(true)}>
           <Text variant="buttonLabel3" color={isBuy ? '$white' : '$neutral2'}>
             Buy
           </Text>
         </Tab>
-        <Tab active={!isBuy} onPress={() => setIsBuy(false)}>
+        <Tab active={!isBuy} large={matchChartHeight} onPress={() => setIsBuy(false)}>
           <Text variant="buttonLabel3" color={!isBuy ? '$white' : '$neutral2'}>
             Sell
           </Text>


### PR DESCRIPTION
## Summary
- add launchpad candle fetching for per-token price charts, including interval and USD/JUSD display switching
- rebuild the token detail top layout so identity stays first, bonding progress follows, then chart plus buy/sell panel
- simplify the launchpad chart UI with Juice-styled line/grid, hidden right price scale, and a single visible price
- enlarge the buy/sell panel pill to match the chart zone
- fix a few existing web lint blockers so `@uniswap/interface` lint is green

## Validation
- `yarn workspace @uniswap/interface lint`
- `yarn workspace @uniswap/interface build:production`
- `git diff --check HEAD~1 HEAD`
- Playwright visual QA: dark/light desktop and mobile token detail screenshots
- Playwright interaction QA: USD/JUSD chart toggle and accessible chart tabs
- Local API checks: `/healthz` and launchpad candles endpoint for the Noracoin test token

## Notes
- `yarn workspace @uniswap/interface typecheck` still fails locally on the existing repo typecheck baseline (`TS6305` generated declaration state plus unrelated appGraphql/BridgeSwaps errors). I also ran `yarn g:prepare` and checked Turbo typecheck behavior; the remaining failures are outside the launchpad chart change.