### PR TITLE
feat(launchpad): token charts + brand revamp

### DIFF
--- a/apps/web/src/components/AccountDrawer/Points/styles.tsx
+++ b/apps/web/src/components/AccountDrawer/Points/styles.tsx
@@ -45,8 +45,7 @@ export function bubbleTextStyle(fontSize: number): CSSProperties {
     fontWeight: 900,
     letterSpacing: -fontSize * 0.03,
     lineHeight: 1,
-    backgroundImage:
-      'linear-gradient(135deg, #FFE9C4 0%, #FFB35C 25%, #F7911A 50%, #C46800 75%, #FFB35C 100%)',
+    backgroundImage: 'linear-gradient(135deg, #FFE9C4 0%, #FFB35C 25%, #F7911A 50%, #C46800 75%, #FFB35C 100%)',
     backgroundSize: '220% 220%',
     WebkitBackgroundClip: 'text',
     backgroundClip: 'text',
@@ -59,7 +58,7 @@ export function bubbleTextStyle(fontSize: number): CSSProperties {
 }
 
 export function LiquidBubbleStyleTag() {
-  return <style dangerouslySetInnerHTML={{ __html: LIQUID_BUBBLE_KEYFRAMES }} />
+  return <style>{LIQUID_BUBBLE_KEYFRAMES}</style>
 }
 
 const FILTER_ID_HERO = 'juice-goo-hero'
@@ -102,12 +101,7 @@ export function LiquidBg({ variant = 'hero' }: LiquidBgProps) {
       <defs>
         <filter id={filterId} x="-30%" y="-30%" width="160%" height="160%">
           <feGaussianBlur in="SourceGraphic" stdDeviation={stdDev} result="blur" />
-          <feColorMatrix
-            in="blur"
-            mode="matrix"
-            values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -8"
-            result="goo"
-          />
+          <feColorMatrix in="blur" mode="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -8" result="goo" />
           <feBlend in="SourceGraphic" in2="goo" />
         </filter>
         <radialGradient id={orbId} cx="50%" cy="40%">

--- a/apps/web/src/components/Charts/PriceChart/index.tsx
+++ b/apps/web/src/components/Charts/PriceChart/index.tsx
@@ -19,7 +19,7 @@ import {
   PriceLineOptions,
   UTCTimestamp,
 } from 'lightweight-charts'
-import { useMemo } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import { Trans } from 'react-i18next'
 import { Flex, Text, styled } from 'ui/src'
 import { opacify } from 'ui/src/theme'
@@ -30,6 +30,7 @@ export type PriceChartData = CandlestickData<UTCTimestamp> & AreaData<UTCTimesta
 
 interface PriceChartModelParams extends ChartModelParams<PriceChartData> {
   type: PriceChartType
+  variant?: 'default' | 'launchpad'
 }
 
 const LOW_PRICE_RANGE_THRESHOLD = 0.2
@@ -93,7 +94,8 @@ export class PriceChartModel extends ChartModel<PriceChartData> {
   }
 
   updateOptions(params: PriceChartModelParams) {
-    const { data, theme, type, locale, format, tokenFormatType } = params
+    const { data, theme, type, locale, format, tokenFormatType, variant } = params
+    const isLaunchpad = variant === 'launchpad'
     super.updateOptions(params, {
       localization: {
         locale,
@@ -112,9 +114,53 @@ export class PriceChartModel extends ChartModel<PriceChartData> {
         },
       },
       grid: {
-        vertLines: { style: LineStyle.CustomDotGrid, color: theme.neutral3 },
-        horzLines: { style: LineStyle.CustomDotGrid, color: theme.neutral3 },
+        vertLines: {
+          visible: true,
+          style: isLaunchpad ? LineStyle.Solid : LineStyle.CustomDotGrid,
+          color: isLaunchpad ? opacify(10, theme.accent1) : theme.neutral3,
+        },
+        horzLines: {
+          visible: true,
+          style: isLaunchpad ? LineStyle.Solid : LineStyle.CustomDotGrid,
+          color: isLaunchpad ? theme.surface3 : theme.neutral3,
+        },
       },
+      ...(isLaunchpad
+        ? {
+            crosshair: {
+              horzLine: {
+                visible: true,
+                style: LineStyle.Solid,
+                width: 1,
+                color: opacify(55, theme.accent1),
+                labelVisible: false,
+              },
+              vertLine: {
+                visible: true,
+                style: LineStyle.Solid,
+                width: 1,
+                color: opacify(55, theme.accent1),
+                labelVisible: false,
+              },
+            },
+            rightPriceScale: {
+              visible: false,
+              borderVisible: false,
+              scaleMargins: {
+                top: 0.24,
+                bottom: 0.18,
+              },
+              autoScale: true,
+            },
+            timeScale: {
+              borderVisible: false,
+              ticksVisible: false,
+              timeVisible: true,
+              fixLeftEdge: true,
+              fixRightEdge: true,
+            },
+          }
+        : {}),
     })
 
     // Handles changing between line/candlestick view
@@ -150,17 +196,17 @@ export class PriceChartModel extends ChartModel<PriceChartData> {
 
       // Line-specific options:
       lineType: data.length < 20 ? LineType.WithSteps : LineType.Curved, // Stepped line is visually preferred for smaller datasets
-      lineWidth: 2,
+      lineWidth: isLaunchpad ? 3 : 2,
       lineColor,
-      topColor: opacify(12, lineColor),
-      bottomColor: opacify(12, lineColor),
+      topColor: opacify(isLaunchpad ? 22 : 12, lineColor),
+      bottomColor: opacify(isLaunchpad ? 4 : 12, lineColor),
       crosshairMarkerRadius: 5,
-      crosshairMarkerBorderColor: opacify(30, lineColor),
+      crosshairMarkerBorderColor: opacify(isLaunchpad ? 55 : 30, lineColor),
       crosshairMarkerBorderWidth: 3,
 
       // Candlestick-specific options:
-      upColor: theme.success,
-      wickUpColor: theme.success,
+      upColor: isLaunchpad ? theme.accent1 : theme.success,
+      wickUpColor: isLaunchpad ? theme.accent1 : theme.success,
       downColor: theme.critical,
       wickDownColor: theme.critical,
       borderVisible: false,
@@ -225,6 +271,8 @@ interface PriceChartProps {
   height: number
   data: PriceChartData[]
   stale: boolean
+  variant?: 'default' | 'launchpad'
+  valueFormatter?: (value: number | undefined) => ReactElement
 }
 
 const CandlestickTooltipRow = styled(Flex, {
@@ -259,20 +307,26 @@ function CandlestickTooltip({ data }: { data: PriceChartData }) {
   )
 }
 
-export function PriceChart({ data, height, type, stale }: PriceChartProps) {
+export function PriceChart({ data, height, type, stale, variant = 'default', valueFormatter }: PriceChartProps) {
   const lastPrice = data[data.length - 1]
 
   return (
     <Chart
       Model={PriceChartModel}
-      params={useMemo(() => ({ data, type, stale }), [data, stale, type])}
+      params={useMemo(() => ({ data, type, stale, variant }), [data, stale, type, variant])}
       height={height}
       TooltipBody={type === PriceChartType.CANDLESTICK ? CandlestickTooltip : undefined}
     >
       {(crosshairData) => (
         <ChartHeader
-          value={(crosshairData ?? lastPrice).value}
-          additionalFields={<PriceChartDelta startingPrice={data[0]} endingPrice={crosshairData ?? lastPrice} />}
+          value={
+            valueFormatter ? valueFormatter((crosshairData ?? lastPrice).value) : (crosshairData ?? lastPrice).value
+          }
+          additionalFields={
+            variant === 'launchpad' ? undefined : (
+              <PriceChartDelta startingPrice={data[0]} endingPrice={crosshairData ?? lastPrice} />
+            )
+          }
           valueFormatterType={NumberType.FiatTokenPrice}
           time={crosshairData?.time}
         />

--- a/apps/web/src/components/Logo/QueryTokenLogo.tsx
+++ b/apps/web/src/components/Logo/QueryTokenLogo.tsx
@@ -15,8 +15,9 @@ export default function QueryTokenLogo(
     token?: TokenStat
   },
 ) {
-  const chainId = getChainIdFromChainUrlParam(props.token?.chain.toLowerCase()) ?? UniverseChainId.Mainnet
-  const isNative = props.token?.address === NATIVE_CHAIN_ID
+  const { token } = props
+  const chainId = getChainIdFromChainUrlParam(token?.chain.toLowerCase()) ?? UniverseChainId.Mainnet
+  const isNative = token?.address === NATIVE_CHAIN_ID
 
   const nativeCurrency = useNativeCurrency(chainId)
   const currency = isNative ? nativeCurrency : undefined
@@ -24,10 +25,9 @@ export default function QueryTokenLogo(
   const currencies = useMemo(() => (!isNative ? undefined : [currency]), [currency, isNative])
 
   // Launchpad token logo - resolved from metadata when token is from launchpad
-  const launchpadLogoUrl = useLaunchpadTokenLogoUrl(props.token?.address, chainId)
+  const launchpadLogoUrl = useLaunchpadTokenLogoUrl(token?.address, chainId)
 
   const logoUrl = useMemo(() => {
-    const { token } = props
     const candidates = [
       token?.logo,
       token?.project?.logo?.url,
@@ -37,15 +37,7 @@ export default function QueryTokenLogo(
       launchpadLogoUrl,
     ]
     return candidates.find(Boolean) ?? undefined
-  }, [
-    props.token,
-    props.token?.logo,
-    props.token?.project?.logo?.url,
-    props.token?.address,
-    props.token?.symbol,
-    chainId,
-    launchpadLogoUrl,
-  ])
+  }, [token, chainId, launchpadLogoUrl])
 
   return <PortfolioLogo currencies={currencies} chainId={chainId} images={[logoUrl]} {...props} />
 }

--- a/apps/web/src/components/Popups/PopupContent.tsx
+++ b/apps/web/src/components/Popups/PopupContent.tsx
@@ -240,7 +240,6 @@ export function BridgingPopupContent({ hash, onClose }: { hash: string; onClose:
 export function LightningBridgePopupContent({
   direction,
   status,
-  url,
   onClose,
 }: {
   direction: LightningBridgeDirection
@@ -288,11 +287,6 @@ export function LightningBridgePopupContent({
   }, [direction])
 
   const isPending = status === LdsBridgeStatus.Pending
-
-  const onClick = () => {
-    window.open(url, '_blank', 'noopener,noreferrer')
-    onClose()
-  }
 
   return (
     <Flex

--- a/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
+++ b/apps/web/src/components/Web3Provider/WebUniswapContext.tsx
@@ -81,7 +81,7 @@ function WebUniswapProviderInner({ children }: PropsWithChildren) {
 
   const navigateToBridgesSwaps = useCallback(() => {
     navigate('/bridge-swaps')
-  }, [])
+  }, [navigate])
 
   const navigateToUrl = useCallback(
     (url: string) => {

--- a/apps/web/src/global.css
+++ b/apps/web/src/global.css
@@ -59,6 +59,37 @@ html {
   }
 }
 
+/* Launchpad live trade ticker — seamless horizontal scroll (content duplicated 2x) */
+@keyframes launchpad-ticker {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* Launchpad progress-bar sheen — a highlight sweeps across the filled portion */
+@keyframes lp-sheen {
+  0% {
+    transform: translateX(-150%) skewX(-20deg);
+  }
+  55%,
+  100% {
+    transform: translateX(420%) skewX(-20deg);
+  }
+}
+
+/* Launchpad shimmer — animated gradient sweep for empty/loading surfaces */
+@keyframes lp-shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
 @keyframes token-rotate-animation {
   0% {
     transform: rotate(-22deg);

--- a/apps/web/src/global.css
+++ b/apps/web/src/global.css
@@ -80,13 +80,15 @@ html {
   }
 }
 
-/* Launchpad shimmer — animated gradient sweep for empty/loading surfaces */
-@keyframes lp-shimmer {
+/* Launchpad shimmer — a citrus highlight bar sweeps across empty surfaces.
+   `transform`-driven (compositor-only) instead of animating background-position,
+   which would repaint the whole surface every frame on low-end GPUs. */
+@keyframes lp-shimmer-x {
   0% {
-    background-position: -200% 0;
+    transform: translateX(-120%);
   }
   100% {
-    background-position: 200% 0;
+    transform: translateX(260%);
   }
 }
 
@@ -96,6 +98,28 @@ html {
   }
   100% {
     transform: rotate(22deg);
+  }
+}
+
+/* Launchpad performance for low-end / battery-saver phones ------------------ */
+
+/* Lighter elevation on phones: drop the soft 24px depth-shadow layer (a paint
+   cost while scrolling on old GPUs), keep a hairline. Desktop keeps the full
+   two-layer shadow. Applied to launchpad panels/cards tagged `lp-elev`. */
+@media (max-width: 640px) {
+  .lp-elev {
+    box-shadow: 0 1px 2px rgba(16, 16, 16, 0.05) !important;
+  }
+}
+
+/* Belt-and-suspenders for reduced-motion: the launchpad's continuous
+   animations are already gated in JS (useLaunchpadMotion), but never let the
+   marquee / sheen / shimmer run for users who explicitly opt out of motion. */
+@media (prefers-reduced-motion: reduce) {
+  [style*='launchpad-ticker'],
+  [style*='lp-sheen'],
+  [style*='lp-shimmer-x'] {
+    animation: none !important;
   }
 }
 

--- a/apps/web/src/hooks/useLaunchpadTokens.ts
+++ b/apps/web/src/hooks/useLaunchpadTokens.ts
@@ -78,6 +78,45 @@ export interface LaunchpadTradesResponse {
   }
 }
 
+export type LaunchpadCandleInterval = '1m' | '5m' | '15m' | '1h' | '4h' | '1d'
+
+export interface LaunchpadCandle {
+  time: number
+  open: number
+  high: number
+  low: number
+  close: number
+  volumeBase: number
+  volumeToken: number
+  tradeCount: number
+}
+
+export interface LaunchpadUserTradeMarker {
+  time: number
+  side: 'buy' | 'sell'
+  price: number
+  baseAmount: number
+  tokenAmount: number
+  txHash: `0x${string}`
+  blockNumber: number
+}
+
+export interface LaunchpadCandlesResponse {
+  range: {
+    from: number
+    to: number
+    interval: LaunchpadCandleInterval
+    intervalSeconds: number
+    limit: number
+  }
+  source: 'bonding_curve' | 'bonding_curve_pre_graduation'
+  priceBasis: 'execution_price'
+  currency: 'base'
+  candles: LaunchpadCandle[]
+  latest: { price: number; timestamp: number } | null
+  userTrades?: LaunchpadUserTradeMarker[]
+}
+
 export interface UseLaunchpadTokensOptions {
   filter?: LaunchpadFilterType
   page?: number
@@ -213,6 +252,45 @@ export function useLaunchpadTrades(options: UseLaunchpadTradesOptions) {
     enabled: !!address,
     staleTime: 10_000,
     refetchInterval: 15_000, // 15 seconds
+  })
+}
+
+export function useLaunchpadCandles({
+  address,
+  chainId,
+  interval = '5m',
+  trader,
+}: {
+  address: string | undefined
+  chainId?: number
+  interval?: LaunchpadCandleInterval
+  trader?: string
+}) {
+  return useQuery({
+    queryKey: ['launchpad-candles', address, chainId, interval, trader],
+    queryFn: async (): Promise<LaunchpadCandlesResponse> => {
+      const params = new URLSearchParams({
+        interval,
+        limit: '240',
+        fill: 'last',
+        currency: 'base',
+      })
+      if (chainId) {
+        params.set('chainId', chainId.toString())
+      }
+      if (trader) {
+        params.set('trader', trader)
+      }
+
+      const response = await fetch(`${API_URL}/v1/launchpad/token/${address}/candles?${params}`)
+      if (!response.ok) {
+        throw new Error('Failed to fetch launchpad candles')
+      }
+      return response.json()
+    },
+    enabled: !!address,
+    staleTime: 10_000,
+    refetchInterval: 10_000,
   })
 }
 

--- a/apps/web/src/pages/Launchpad/Create.tsx
+++ b/apps/web/src/pages/Launchpad/Create.tsx
@@ -42,6 +42,7 @@ const PageContainer = styled(Flex, {
   paddingTop: '$spacing24',
   paddingBottom: '$spacing60',
   paddingHorizontal: '$spacing20',
+  $sm: { paddingHorizontal: '$spacing12' },
 })
 
 const ContentWrapper = styled(Flex, {

--- a/apps/web/src/pages/Launchpad/Create.tsx
+++ b/apps/web/src/pages/Launchpad/Create.tsx
@@ -5,13 +5,27 @@ import { useCreateToken, useUploadTokenMetadata } from 'hooks/useLaunchpadAction
 import useSelectChain from 'hooks/useSelectChain'
 import { useTokenFactory } from 'hooks/useTokenFactory'
 import styledComponents from 'lib/styled-components'
-import { BackButton, StatLabel, StatRow, StatValue } from 'pages/Launchpad/components/shared'
+import {
+  BackButton,
+  Card,
+  JuiceScriptText,
+  LaunchpadBackdrop,
+  PrimaryButton,
+  StatLabel,
+  StatRow,
+  StatValue,
+  TrustBadge,
+} from 'pages/Launchpad/components/shared'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { waitForNetwork } from 'state/sagas/transactions/chainSwitchUtils'
 import { useTransactionAdder } from 'state/transactions/hooks'
 import { Flex, Text, styled } from 'ui/src'
 import { BackArrow } from 'ui/src/components/icons/BackArrow'
+import { CheckCircleFilled } from 'ui/src/components/icons/CheckCircleFilled'
+import { Lock } from 'ui/src/components/icons/Lock'
+import { ShieldCheck } from 'ui/src/components/icons/ShieldCheck'
+import { Verified } from 'ui/src/components/icons/Verified'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import { InterfacePageName } from 'uniswap/src/features/telemetry/constants'
@@ -20,32 +34,34 @@ import { formatUnits, parseEther } from 'viem'
 import { useBalance } from 'wagmi'
 
 const PageContainer = styled(Flex, {
+  position: 'relative',
+  overflow: 'hidden',
   width: '100%',
   minHeight: '100vh',
   backgroundColor: '$surface1',
-  paddingTop: '$spacing20',
+  paddingTop: '$spacing24',
   paddingBottom: '$spacing60',
   paddingHorizontal: '$spacing20',
 })
 
 const ContentWrapper = styled(Flex, {
+  position: 'relative',
+  zIndex: 1,
   maxWidth: 600,
   width: '100%',
   alignSelf: 'center',
-  gap: '$spacing24',
+  gap: '$spacing20',
 })
 
 const HeaderSection = styled(Flex, {
-  gap: '$spacing8',
-  paddingBottom: '$spacing24',
-  borderBottomWidth: 1,
-  borderBottomColor: '$surface3',
+  gap: '$spacing4',
 })
 
-const MainTitle = styled(Text, {
-  variant: 'heading2',
-  color: '$neutral1',
-  fontWeight: 'bold',
+const Eyebrow = styled(Text, {
+  variant: 'body3',
+  color: '$accent1',
+  fontWeight: '700',
+  letterSpacing: 1.4,
 })
 
 const Subtitle = styled(Text, {
@@ -53,13 +69,10 @@ const Subtitle = styled(Text, {
   color: '$neutral2',
 })
 
-const FormCard = styled(Flex, {
-  backgroundColor: '$surface2',
-  borderRadius: '$rounded16',
-  borderWidth: 1,
-  borderColor: '$surface3',
-  padding: '$spacing24',
-  gap: '$spacing20',
+const TrustRow = styled(Flex, {
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  gap: '$spacing8',
 })
 
 const InputGroup = styled(Flex, {
@@ -149,33 +162,6 @@ const ImagePreview = styledComponents.img`
   border-radius: 8px;
   object-fit: cover;
 `
-
-const CreateButton = styled(Flex, {
-  alignItems: 'center',
-  justifyContent: 'center',
-  paddingVertical: '$spacing16',
-  backgroundColor: '$accent1',
-  borderRadius: '$rounded12',
-  cursor: 'pointer',
-  hoverStyle: {
-    backgroundColor: '$accent2',
-  },
-  variants: {
-    disabled: {
-      true: {
-        backgroundColor: '$surface3',
-        cursor: 'not-allowed',
-      },
-    },
-  } as const,
-})
-
-const InfoCard = styled(Flex, {
-  backgroundColor: '$accent2',
-  borderRadius: '$rounded12',
-  padding: '$spacing16',
-  gap: '$spacing12',
-})
 
 const ErrorText = styled(Text, {
   variant: 'body3',
@@ -449,6 +435,7 @@ export default function CreateToken() {
   return (
     <Trace logImpression page={InterfacePageName.LaunchpadCreatePage}>
       <PageContainer>
+        <LaunchpadBackdrop />
         <ContentWrapper>
           <BackButton onPress={handleBack}>
             <BackArrow size="$icon.20" color="$neutral2" />
@@ -458,11 +445,44 @@ export default function CreateToken() {
           </BackButton>
 
           <HeaderSection>
-            <MainTitle>Create Token</MainTitle>
-            <Subtitle>Launch your token on the bonding curve. No upfront liquidity required.</Subtitle>
+            <Eyebrow>JUICESWAP LAUNCHPAD</Eyebrow>
+            <JuiceScriptText fontSize={40} lineHeight={60} $sm={{ fontSize: 32, lineHeight: 48 }}>
+              fresh squeeze
+            </JuiceScriptText>
+            <Subtitle>
+              Fair-launch a token on a bonding curve — no upfront liquidity. It graduates to JuiceSwap V2 with
+              liquidity locked forever.
+            </Subtitle>
           </HeaderSection>
 
-          <FormCard>
+          <TrustRow>
+            <TrustBadge>
+              <Lock size="$icon.16" color="$statusSuccess" />
+              <Text variant="body4" color="$statusSuccess" fontWeight="600">
+                Locked liquidity
+              </Text>
+            </TrustBadge>
+            <TrustBadge>
+              <ShieldCheck size="$icon.16" color="$statusSuccess" />
+              <Text variant="body4" color="$statusSuccess" fontWeight="600">
+                Immutable metadata
+              </Text>
+            </TrustBadge>
+            <TrustBadge>
+              <Verified size="$icon.16" color="$statusSuccess" />
+              <Text variant="body4" color="$statusSuccess" fontWeight="600">
+                JUSD-backed
+              </Text>
+            </TrustBadge>
+            <TrustBadge>
+              <CheckCircleFilled size="$icon.16" color="$statusSuccess" />
+              <Text variant="body4" color="$statusSuccess" fontWeight="600">
+                1% flat fee
+              </Text>
+            </TrustBadge>
+          </TrustRow>
+
+          <Card emphasis padding="$spacing24" gap="$spacing20">
             <InputGroup>
               <InputLabel>Token Name</InputLabel>
               <StyledInput
@@ -585,23 +605,28 @@ export default function CreateToken() {
 
             {error && <ErrorText>{error}</ErrorText>}
 
-            <CreateButton disabled={isButtonDisabled} onPress={isButtonDisabled ? undefined : handleButtonPress}>
+            <PrimaryButton
+              fill
+              size="lg"
+              disabled={isButtonDisabled}
+              onPress={isButtonDisabled ? undefined : handleButtonPress}
+            >
               <Text variant="buttonLabel2" color="$white">
                 {buttonText}
               </Text>
-            </CreateButton>
-          </FormCard>
+            </PrimaryButton>
+          </Card>
 
-          <InfoCard>
+          <Card gap="$spacing12">
             <Text variant="body2" color="$neutral1" fontWeight="600">
-              Token Economics
+              Token economics
             </Text>
             <StatRow>
-              <StatLabel variant="body3">Total Supply</StatLabel>
+              <StatLabel variant="body3">Total supply</StatLabel>
               <StatValue variant="body3">1,000,000,000</StatValue>
             </StatRow>
             <StatRow>
-              <StatLabel variant="body3">Available on Curve</StatLabel>
+              <StatLabel variant="body3">Available on curve</StatLabel>
               <StatValue variant="body3">793,100,000 (79.31%)</StatValue>
             </StatRow>
             <StatRow>
@@ -609,32 +634,60 @@ export default function CreateToken() {
               <StatValue variant="body3">206,900,000 (20.69%)</StatValue>
             </StatRow>
             <StatRow>
-              <StatLabel variant="body3">Initial Virtual Liquidity</StatLabel>
+              <StatLabel variant="body3">Initial virtual liquidity</StatLabel>
               <StatValue variant="body3">{initialLiquidity} JUSD</StatValue>
             </StatRow>
             <StatRow>
-              <StatLabel variant="body3">Trading Fee</StatLabel>
+              <StatLabel variant="body3">Trading fee</StatLabel>
               <StatValue variant="body3">1%</StatValue>
             </StatRow>
-          </InfoCard>
+          </Card>
 
-          <Flex gap="$spacing8" backgroundColor="$surface2" padding="$spacing16" borderRadius="$rounded12">
+          <Card gap="$spacing12">
             <Text variant="body2" color="$neutral1" fontWeight="600">
               How it works
             </Text>
-            <Text variant="body3" color="$neutral2">
-              1. Your token launches on a bonding curve with virtual liquidity
-            </Text>
-            <Text variant="body3" color="$neutral2">
-              2. Anyone can buy tokens - price increases with each purchase
-            </Text>
-            <Text variant="body3" color="$neutral2">
-              3. When all tokens are sold, the token graduates to JuiceSwap V2
-            </Text>
-            <Text variant="body3" color="$neutral2">
-              4. LP tokens are burned forever - liquidity is permanently locked
-            </Text>
-          </Flex>
+            {[
+              'Your token launches on a bonding curve with virtual liquidity — no upfront capital needed.',
+              'Anyone can buy from the curve; the price rises with every purchase.',
+              'Once the curve fills, the token graduates to JuiceSwap V2.',
+            ].map((step, i) => (
+              <Flex key={i} flexDirection="row" gap="$spacing12" alignItems="flex-start">
+                <Flex
+                  width={22}
+                  height={22}
+                  borderRadius="$roundedFull"
+                  backgroundColor="$accent2"
+                  alignItems="center"
+                  justifyContent="center"
+                  flexShrink={0}
+                >
+                  <Text variant="body4" color="$accent1" fontWeight="700">
+                    {i + 1}
+                  </Text>
+                </Flex>
+                <Text variant="body3" color="$neutral2" flex={1}>
+                  {step}
+                </Text>
+              </Flex>
+            ))}
+            <Flex flexDirection="row" gap="$spacing12" alignItems="flex-start">
+              <Flex
+                width={22}
+                height={22}
+                borderRadius="$roundedFull"
+                backgroundColor="$statusSuccess2"
+                alignItems="center"
+                justifyContent="center"
+                flexShrink={0}
+              >
+                <Lock size={12} color="$statusSuccess" />
+              </Flex>
+              <Text variant="body3" color="$neutral1" flex={1} fontWeight="600">
+                LP tokens are burned forever — liquidity is permanently locked. No rug.
+              </Text>
+            </Flex>
+          </Card>
         </ContentWrapper>
       </PageContainer>
     </Trace>

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -1,8 +1,12 @@
+import { PriceChart, type PriceChartData } from 'components/Charts/PriceChart'
+import { PriceChartType } from 'components/Charts/utils'
+import { useAccount } from 'hooks/useAccount'
 import { useBondingCurveToken } from 'hooks/useBondingCurveToken'
 import { useLaunchpadTokenPrice } from 'hooks/useLaunchpadTokenPrice'
-import { useLaunchpadToken } from 'hooks/useLaunchpadTokens'
+import { useLaunchpadCandles, useLaunchpadToken, type LaunchpadCandleInterval } from 'hooks/useLaunchpadTokens'
 import { useTokenInfo } from 'hooks/useTokenFactory'
 import { getSocialLink, useTokenMetadata } from 'hooks/useTokenMetadata'
+import type { UTCTimestamp } from 'lightweight-charts'
 import { BuySellPanel } from 'pages/Launchpad/components/BuySellPanel'
 import { TokenLogo } from 'pages/Launchpad/components/TokenLogo'
 import {
@@ -16,6 +20,7 @@ import {
   StatValue,
   getProgressGradient,
 } from 'pages/Launchpad/components/shared'
+import { LAUNCHPAD_TOKEN_TOTAL_SUPPLY } from 'pages/Launchpad/constants'
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Flex, ModalCloseIcon, Text, styled } from 'ui/src'
@@ -31,6 +36,7 @@ import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
 import { formatUnits } from 'viem'
 
 type SocialPlatform = 'Twitter' | 'Telegram'
+type ChartPriceUnit = 'usd' | 'jusd'
 
 const SOCIAL_URL_PATTERNS: Record<SocialPlatform, { check: (s: string) => boolean; regex: RegExp }> = {
   Twitter: {
@@ -57,6 +63,26 @@ function extractSocialHandle(value: string | null | undefined, platform: SocialP
   }
 
   return trimmed.replace('@', '')
+}
+
+const USD_AMOUNT_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 2,
+})
+
+const USD_PRICE_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumSignificantDigits: 6,
+})
+
+function formatUsdAmount(value: number | null): string {
+  return typeof value === 'number' && Number.isFinite(value) ? USD_AMOUNT_FORMATTER.format(value) : '-'
+}
+
+function formatUsdPrice(value: number | undefined): string {
+  return typeof value === 'number' && Number.isFinite(value) ? USD_PRICE_FORMATTER.format(value) : '-'
 }
 
 const PageContainer = styled(Flex, {
@@ -101,6 +127,7 @@ const TokenSymbol = styled(Text, {
 
 const MainContent = styled(Flex, {
   flexDirection: 'row',
+  alignItems: 'stretch',
   gap: '$spacing24',
   $md: {
     flexDirection: 'column',
@@ -119,6 +146,7 @@ const RightColumn = styled(Flex, {
   flexShrink: 0,
   width: 360,
   maxWidth: '100%',
+  alignSelf: 'stretch',
   gap: '$spacing24',
   overflow: 'hidden',
   $md: {
@@ -127,10 +155,102 @@ const RightColumn = styled(Flex, {
   },
 })
 
+const FullWidthStack = styled(Flex, {
+  gap: '$spacing24',
+})
+
+const ChartCard = styled(Card, {
+  borderTopWidth: 2,
+  borderTopColor: '$accent1',
+})
+
 const CardTitle = styled(Text, {
   variant: 'body1',
   color: '$neutral1',
   fontWeight: '600',
+})
+
+const ChartStatsGrid = styled(Flex, {
+  flexDirection: 'row',
+  gap: '$spacing12',
+  flexWrap: 'wrap',
+})
+
+const ChartStat = styled(Flex, {
+  flex: 1,
+  minWidth: 150,
+  minHeight: 76,
+  justifyContent: 'center',
+  gap: '$spacing6',
+  backgroundColor: '$surface1',
+  borderRadius: '$rounded16',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  padding: '$spacing16',
+})
+
+const ChartStatValue = styled(StatValue, {
+  variant: 'subheading2',
+  fontWeight: '700',
+})
+
+const ChartHeaderRow = styled(Flex, {
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: '$spacing12',
+  flexWrap: 'wrap',
+})
+
+const ChartControls = styled(Flex, {
+  flexDirection: 'row',
+  gap: '$spacing8',
+  flexWrap: 'wrap',
+  maxWidth: '100%',
+  $md: {
+    width: '100%',
+    flexDirection: 'column',
+  },
+})
+
+const SegmentedControl = styled(Flex, {
+  flexDirection: 'row',
+  gap: '$spacing4',
+  padding: '$spacing4',
+  borderRadius: '$rounded16',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  backgroundColor: '$surface1',
+  maxWidth: '100%',
+  $md: {
+    width: '100%',
+    justifyContent: 'space-between',
+  },
+})
+
+const SegmentButton = styled(Flex, {
+  minWidth: 40,
+  minHeight: 34,
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingHorizontal: '$spacing10',
+  borderRadius: '$rounded12',
+  cursor: 'pointer',
+  $md: {
+    flex: 1,
+    minWidth: 0,
+    paddingHorizontal: '$spacing6',
+  },
+  hoverStyle: {
+    backgroundColor: '$surface2',
+  },
+  variants: {
+    active: {
+      true: {
+        backgroundColor: '$accent1',
+      },
+    },
+  } as const,
 })
 
 const AddressRow = styled(Flex, {
@@ -152,6 +272,9 @@ const AddressLink = styled(Flex, {
 export default function TokenDetail() {
   const { tokenAddress } = useParams<{ tokenAddress: string }>()
   const navigate = useNavigate()
+  const account = useAccount()
+  const [chartInterval, setChartInterval] = useState<LaunchpadCandleInterval>('5m')
+  const [chartPriceUnit, setChartPriceUnit] = useState<ChartPriceUnit>('usd')
 
   // First, fetch the token data from API to get the correct chainId
   const { data: launchpadData } = useLaunchpadToken(tokenAddress)
@@ -175,6 +298,12 @@ export default function TokenDetail() {
 
   const { tokenInfo } = useTokenInfo(tokenAddress, chainId)
   const { data: metadata } = useTokenMetadata(launchpadData?.token.metadataURI)
+  const { data: candlesData, isLoading: candlesLoading } = useLaunchpadCandles({
+    address: tokenAddress,
+    chainId: launchpadData?.token.chainId,
+    interval: chartInterval,
+    trader: account.address,
+  })
   const [showBondingModal, setShowBondingModal] = useState(false)
 
   // Use unified price hook for graduated/non-graduated tokens
@@ -190,6 +319,19 @@ export default function TokenDetail() {
     bondingCurveReserves: reserves,
     chainId,
   })
+
+  const displayName = name || launchpadData?.token.name || 'Unknown Token'
+  const displaySymbol = symbol || launchpadData?.token.symbol || '???'
+  const displayGraduated = graduated || launchpadData?.token.graduated || false
+  const displayCanGraduate = canGraduate || launchpadData?.token.canGraduate || false
+  const displayBaseAsset = baseAsset || launchpadData?.token.baseAsset
+  const displayV2Pair = v2Pair || launchpadData?.token.v2Pair || undefined
+  const indexedProgress = launchpadData?.token.progress
+    ? launchpadData.token.progress > 100
+      ? launchpadData.token.progress / 100
+      : launchpadData.token.progress
+    : 0
+  const displayProgress = displayGraduated ? 100 : progress || indexedProgress
 
   const handleBack = useCallback(() => {
     navigate('/launchpad')
@@ -213,16 +355,62 @@ export default function TokenDetail() {
   }, [tokenAddress, chainId])
 
   // Format volume from indexed data
-  const volume = useMemo(() => {
+  const volumeValue = useMemo(() => {
     if (!launchpadData?.token.totalVolumeBase) {
-      return '0'
+      return null
     }
-    const value = Number(formatUnits(BigInt(launchpadData.token.totalVolumeBase), 18))
-    return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+    return Number(formatUnits(BigInt(launchpadData.token.totalVolumeBase), 18))
   }, [launchpadData?.token.totalVolumeBase])
+
+  const volume = volumeValue?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? '0'
+  const volumeUsd = formatUsdAmount(volumeValue)
 
   // Total trades from indexed data
   const totalTrades = (launchpadData?.token.totalBuys ?? 0) + (launchpadData?.token.totalSells ?? 0)
+
+  const latestCandle = candlesData?.candles[candlesData.candles.length - 1]
+  const latestChartPriceValue = candlesData?.latest?.price ?? latestCandle?.close ?? null
+
+  const chartData = useMemo<PriceChartData[]>(() => {
+    return (
+      candlesData?.candles.map((candle) => ({
+        time: candle.time as UTCTimestamp,
+        open: candle.open,
+        high: candle.high,
+        low: candle.low,
+        close: candle.close,
+        value: candle.close,
+      })) ?? []
+    )
+  }, [candlesData?.candles])
+
+  const latestChartPrice = latestChartPriceValue
+    ? latestChartPriceValue.toLocaleString(undefined, { maximumSignificantDigits: 6 })
+    : null
+  const fallbackMarketCap = latestChartPriceValue ? latestChartPriceValue * LAUNCHPAD_TOKEN_TOTAL_SUPPLY : null
+  const displayMarketCap =
+    marketCap && !['0', 'N/A', '...'].includes(marketCap)
+      ? marketCap
+      : fallbackMarketCap?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? marketCap
+  const displayMarketCapUsd = formatUsdAmount(fallbackMarketCap)
+
+  const chartValueFormatter = useCallback(
+    (value: number | undefined) => {
+      const formatted =
+        chartPriceUnit === 'usd'
+          ? formatUsdPrice(value)
+          : typeof value === 'number' && Number.isFinite(value)
+            ? `${value.toLocaleString(undefined, { maximumSignificantDigits: 8 })} JUSD`
+            : '-'
+
+      return (
+        <Text variant="heading2" color="$neutral1">
+          {formatted}
+        </Text>
+      )
+    },
+    [chartPriceUnit],
+  )
 
   const tokensRemaining = useMemo(() => {
     if (!reserves) {
@@ -231,19 +419,22 @@ export default function TokenDetail() {
     return Number(formatUnits(reserves.realToken, 18)).toLocaleString(undefined, { maximumFractionDigits: 0 })
   }, [reserves])
 
+  const creatorAddress = tokenInfo?.creator ?? launchpadData?.token.creator
   const creatorShort = useMemo(() => {
-    if (!tokenInfo?.creator) {
+    if (!creatorAddress) {
       return '...'
     }
-    return `${tokenInfo.creator.slice(0, 6)}...${tokenInfo.creator.slice(-4)}`
-  }, [tokenInfo])
+    return `${creatorAddress.slice(0, 6)}...${creatorAddress.slice(-4)}`
+  }, [creatorAddress])
 
   const createdDate = useMemo(() => {
-    if (!tokenInfo?.timestamp) {
+    const timestamp =
+      tokenInfo?.timestamp ?? (launchpadData?.token.createdAt ? Number(launchpadData.token.createdAt) : null)
+    if (!timestamp) {
       return ''
     }
-    return new Date(tokenInfo.timestamp * 1000).toLocaleDateString()
-  }, [tokenInfo])
+    return new Date(timestamp * 1000).toLocaleDateString()
+  }, [launchpadData?.token.createdAt, tokenInfo?.timestamp])
 
   if (isLoading) {
     return (
@@ -281,11 +472,11 @@ export default function TokenDetail() {
           </BackButton>
 
           <HeaderSection>
-            <TokenLogo metadataURI={launchpadData?.token.metadataURI} symbol={symbol || '?'} size={80} />
+            <TokenLogo metadataURI={launchpadData?.token.metadataURI} symbol={displaySymbol || '?'} size={80} />
             <TokenInfo>
               <Flex flexDirection="row" alignItems="center" gap="$spacing12">
-                <TokenName>{name || 'Unknown Token'}</TokenName>
-                {graduated && (
+                <TokenName>{displayName}</TokenName>
+                {displayGraduated && (
                   <GraduatedBadge size="md">
                     <Text variant="body3" color="$statusSuccess" fontWeight="600">
                       Graduated
@@ -293,7 +484,7 @@ export default function TokenDetail() {
                   </GraduatedBadge>
                 )}
               </Flex>
-              <TokenSymbol>${symbol || '???'}</TokenSymbol>
+              <TokenSymbol>${displaySymbol}</TokenSymbol>
               <AddressRow>
                 <Text variant="body3" color="$neutral3">
                   {tokenAddress.slice(0, 10)}...{tokenAddress.slice(-8)}
@@ -352,143 +543,239 @@ export default function TokenDetail() {
             </TokenInfo>
           </HeaderSection>
 
-          {metadata?.description && (
-            <Card>
-              <CardTitle>About</CardTitle>
+          <Card>
+            <CardTitle>Bonding Curve Progress</CardTitle>
+            <ProgressBar>
+              <ProgressFill
+                style={{
+                  width: `${Math.min(displayProgress, 100)}%`,
+                  background: getProgressGradient(displayProgress),
+                }}
+              />
+            </ProgressBar>
+            <Flex flexDirection="row" justifyContent="space-between">
               <Text variant="body2" color="$neutral2">
-                {metadata.description}
+                {displayGraduated ? '100%' : `${displayProgress.toFixed(2)}%`} complete
               </Text>
-            </Card>
-          )}
+              <Text variant="body2" color={displayGraduated ? '$statusSuccess' : '$neutral1'}>
+                {displayGraduated ? 'Graduated to V2' : `${tokensRemaining} tokens remaining`}
+              </Text>
+            </Flex>
+
+            {!displayGraduated && (
+              <Flex
+                flexDirection="row"
+                alignItems="center"
+                gap="$spacing6"
+                marginTop="$spacing4"
+                cursor="pointer"
+                onPress={() => setShowBondingModal(true)}
+                hoverStyle={{ opacity: 0.7 }}
+              >
+                <Text variant="body3" color="$neutral3">
+                  Graduates to V2 at 100% · 1% fee
+                </Text>
+                <InfoCircle size={14} color="$neutral3" />
+              </Flex>
+            )}
+          </Card>
 
           <MainContent>
             <LeftColumn>
-              <Card>
-                <CardTitle>Bonding Curve Progress</CardTitle>
-                <ProgressBar>
-                  <ProgressFill
-                    style={{
-                      width: `${graduated ? 100 : Math.min(progress, 100)}%`,
-                      background: getProgressGradient(graduated ? 100 : progress),
-                    }}
-                  />
-                </ProgressBar>
-                <Flex flexDirection="row" justifyContent="space-between">
-                  <Text variant="body2" color="$neutral2">
-                    {graduated ? '100%' : `${progress.toFixed(2)}%`} complete
-                  </Text>
-                  <Text variant="body2" color={graduated ? '$statusSuccess' : '$neutral1'}>
-                    {graduated ? 'Graduated to V2' : `${tokensRemaining} tokens remaining`}
-                  </Text>
-                </Flex>
+              <ChartCard>
+                <ChartStatsGrid>
+                  <ChartStat>
+                    <StatLabel variant="body3">Market Cap</StatLabel>
+                    <ChartStatValue>{displayMarketCapUsd}</ChartStatValue>
+                  </ChartStat>
+                  <ChartStat>
+                    <StatLabel variant="body3">Volume</StatLabel>
+                    <ChartStatValue>{volumeUsd}</ChartStatValue>
+                  </ChartStat>
+                  <ChartStat>
+                    <StatLabel variant="body3">Trades</StatLabel>
+                    <ChartStatValue>{totalTrades}</ChartStatValue>
+                  </ChartStat>
+                </ChartStatsGrid>
 
-                {!graduated && (
-                  <Flex
-                    flexDirection="row"
-                    alignItems="center"
-                    gap="$spacing6"
-                    marginTop="$spacing4"
-                    cursor="pointer"
-                    onPress={() => setShowBondingModal(true)}
-                    hoverStyle={{ opacity: 0.7 }}
-                  >
-                    <Text variant="body3" color="$neutral3">
-                      Graduates to V2 at 100% · 1% fee
+                <ChartHeaderRow>
+                  <Flex gap="$spacing4">
+                    <CardTitle>Price Chart</CardTitle>
+                    <Text variant="body3" color="$neutral2">
+                      {candlesData?.source === 'bonding_curve_pre_graduation'
+                        ? 'Bonding curve history before graduation'
+                        : 'Bonding curve execution price'}
                     </Text>
-                    <InfoCircle size={14} color="$neutral3" />
+                  </Flex>
+                  <ChartControls>
+                    <SegmentedControl aria-label="Chart price unit" role="tablist">
+                      {(['usd', 'jusd'] as const).map((unit) => (
+                        <SegmentButton
+                          key={unit}
+                          aria-selected={chartPriceUnit === unit}
+                          active={chartPriceUnit === unit}
+                          onPress={() => setChartPriceUnit(unit)}
+                          role="tab"
+                        >
+                          <Text variant="buttonLabel4" color={chartPriceUnit === unit ? '$white' : '$neutral2'}>
+                            {unit === 'usd' ? 'USD' : 'JUSD'}
+                          </Text>
+                        </SegmentButton>
+                      ))}
+                    </SegmentedControl>
+                    <SegmentedControl aria-label="Chart interval" role="tablist">
+                      {(['1m', '5m', '15m', '1h', '4h', '1d'] as const).map((interval) => (
+                        <SegmentButton
+                          key={interval}
+                          aria-selected={chartInterval === interval}
+                          active={chartInterval === interval}
+                          onPress={() => setChartInterval(interval)}
+                          role="tab"
+                        >
+                          <Text variant="buttonLabel4" color={chartInterval === interval ? '$white' : '$neutral2'}>
+                            {interval}
+                          </Text>
+                        </SegmentButton>
+                      ))}
+                    </SegmentedControl>
+                  </ChartControls>
+                </ChartHeaderRow>
+
+                {chartData.length > 0 ? (
+                  <PriceChart
+                    data={chartData}
+                    height={360}
+                    type={PriceChartType.LINE}
+                    stale={false}
+                    variant="launchpad"
+                    valueFormatter={chartValueFormatter}
+                  />
+                ) : (
+                  <Flex height={360} alignItems="center" justifyContent="center">
+                    <Text variant="body2" color="$neutral2">
+                      {candlesLoading ? 'Loading chart...' : 'No chart data yet'}
+                    </Text>
                   </Flex>
                 )}
-              </Card>
 
-              <Card>
-                <CardTitle>Token Info</CardTitle>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Current Price</StatLabel>
-                  <StatValue variant="body2">{currentPrice} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Market Cap</StatLabel>
-                  <StatValue variant="body2">{marketCap} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Liquidity</StatLabel>
-                  <StatValue variant="body2">{liquidity} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Volume</StatLabel>
-                  <StatValue variant="body2">{volume} JUSD</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Trades</StatLabel>
-                  <StatValue variant="body2">{totalTrades}</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Total Supply</StatLabel>
-                  <StatValue variant="body2">1,000,000,000</StatValue>
-                </StatRow>
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Creator</StatLabel>
-                  <AddressLink
-                    onPress={() => {
-                      if (tokenInfo?.creator) {
-                        const url = getExplorerLink({
-                          chainId,
-                          data: tokenInfo.creator,
-                          type: ExplorerDataType.ADDRESS,
-                        })
-                        window.open(url, '_blank')
-                      }
-                    }}
-                  >
-                    <StatValue variant="body2">{creatorShort}</StatValue>
-                    <ExternalLink size="$icon.16" color="$neutral2" />
-                  </AddressLink>
-                </StatRow>
-                {createdDate && (
-                  <StatRow paddingVertical="$spacing4">
-                    <StatLabel variant="body2">Created</StatLabel>
-                    <StatValue variant="body2">{createdDate}</StatValue>
-                  </StatRow>
-                )}
-                {graduated && v2Pair && (
-                  <StatRow paddingVertical="$spacing4">
-                    <StatLabel variant="body2">V2 Pair</StatLabel>
-                    <AddressLink
-                      onPress={() => {
-                        const url = getExplorerLink({
-                          chainId,
-                          data: v2Pair,
-                          type: ExplorerDataType.ADDRESS,
-                        })
-                        window.open(url, '_blank')
-                      }}
-                    >
-                      <StatValue variant="body2">
-                        {v2Pair.slice(0, 6)}...{v2Pair.slice(-4)}
-                      </StatValue>
-                      <ExternalLink size="$icon.16" color="$neutral2" />
-                    </AddressLink>
-                  </StatRow>
-                )}
-              </Card>
+                {candlesData?.userTrades?.length ? (
+                  <Flex gap="$spacing8">
+                    <Text variant="body3" color="$neutral2">
+                      Your trades in this range
+                    </Text>
+                    {candlesData.userTrades.slice(-5).map((trade) => (
+                      <StatRow key={`${trade.txHash}-${trade.time}`} paddingVertical="$spacing2">
+                        <StatLabel variant="body3">{trade.side === 'buy' ? 'Buy' : 'Sell'}</StatLabel>
+                        <StatValue variant="body3">
+                          {trade.price.toLocaleString(undefined, { maximumSignificantDigits: 6 })} JUSD
+                        </StatValue>
+                      </StatRow>
+                    ))}
+                  </Flex>
+                ) : null}
+              </ChartCard>
             </LeftColumn>
 
             <RightColumn>
-              {baseAsset && (
+              {displayBaseAsset && (
                 <BuySellPanel
                   tokenAddress={tokenAddress}
-                  tokenSymbol={symbol || '???'}
-                  baseAsset={baseAsset}
-                  graduated={graduated}
-                  canGraduate={canGraduate}
+                  tokenSymbol={displaySymbol}
+                  baseAsset={displayBaseAsset}
+                  graduated={displayGraduated}
+                  canGraduate={displayCanGraduate}
                   chainId={chainId}
                   reserves={reserves}
+                  matchChartHeight
                   onTransactionComplete={refetchBondingCurve}
                   onGraduateComplete={refetchBondingCurve}
                 />
               )}
             </RightColumn>
           </MainContent>
+
+          <FullWidthStack>
+            {metadata?.description && (
+              <Card>
+                <CardTitle>About</CardTitle>
+                <Text variant="body2" color="$neutral2">
+                  {metadata.description}
+                </Text>
+              </Card>
+            )}
+
+            <Card>
+              <CardTitle>Token Info</CardTitle>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Current Price</StatLabel>
+                <StatValue variant="body2">{latestChartPrice || currentPrice} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Market Cap</StatLabel>
+                <StatValue variant="body2">{displayMarketCap} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Liquidity</StatLabel>
+                <StatValue variant="body2">{liquidity} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Volume</StatLabel>
+                <StatValue variant="body2">{volume} JUSD</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Trades</StatLabel>
+                <StatValue variant="body2">{totalTrades}</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Total Supply</StatLabel>
+                <StatValue variant="body2">1,000,000,000</StatValue>
+              </StatRow>
+              <StatRow paddingVertical="$spacing4">
+                <StatLabel variant="body2">Creator</StatLabel>
+                <AddressLink
+                  onPress={() => {
+                    if (creatorAddress) {
+                      const url = getExplorerLink({
+                        chainId,
+                        data: creatorAddress,
+                        type: ExplorerDataType.ADDRESS,
+                      })
+                      window.open(url, '_blank')
+                    }
+                  }}
+                >
+                  <StatValue variant="body2">{creatorShort}</StatValue>
+                  <ExternalLink size="$icon.16" color="$neutral2" />
+                </AddressLink>
+              </StatRow>
+              {createdDate && (
+                <StatRow paddingVertical="$spacing4">
+                  <StatLabel variant="body2">Created</StatLabel>
+                  <StatValue variant="body2">{createdDate}</StatValue>
+                </StatRow>
+              )}
+              {displayGraduated && displayV2Pair && (
+                <StatRow paddingVertical="$spacing4">
+                  <StatLabel variant="body2">V2 Pair</StatLabel>
+                  <AddressLink
+                    onPress={() => {
+                      const url = getExplorerLink({
+                        chainId,
+                        data: displayV2Pair,
+                        type: ExplorerDataType.ADDRESS,
+                      })
+                      window.open(url, '_blank')
+                    }}
+                  >
+                    <StatValue variant="body2">
+                      {displayV2Pair.slice(0, 6)}...{displayV2Pair.slice(-4)}
+                    </StatValue>
+                    <ExternalLink size="$icon.16" color="$neutral2" />
+                  </AddressLink>
+                </StatRow>
+              )}
+            </Card>
+          </FullWidthStack>
         </ContentWrapper>
       </PageContainer>
 

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -20,7 +20,8 @@ import {
   StatValue,
 } from 'pages/Launchpad/components/shared'
 import { LAUNCHPAD_TOKEN_TOTAL_SUPPLY } from 'pages/Launchpad/constants'
-import { useCallback, useMemo, useState } from 'react'
+import { useLaunchpadAnimation } from 'pages/Launchpad/useLaunchpadMotion'
+import { useCallback, useMemo, useState, type ComponentProps } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { Flex, ModalCloseIcon, Text, styled } from 'ui/src'
 import { BackArrow } from 'ui/src/components/icons/BackArrow'
@@ -87,7 +88,7 @@ const ContentWrapper = styled(Flex, {
   gap: '$spacing16',
 })
 
-const Panel = styled(Flex, {
+const PanelSurface = styled(Flex, {
   backgroundColor: '$surface2',
   borderRadius: '$rounded20',
   borderWidth: 1,
@@ -105,6 +106,13 @@ const Panel = styled(Flex, {
     },
   } as const,
 })
+
+// The `lp-elev` class lets global.css drop the soft 24px depth-shadow
+// layer on phones (≤640px) — a paint win on low-end GPUs while scrolling.
+// Desktop keeps the full two-layer shadow.
+function Panel(props: ComponentProps<typeof PanelSurface>) {
+  return <PanelSurface className="lp-elev" {...props} />
+}
 
 const TokenName = styled(Text, {
   variant: 'heading2',
@@ -222,6 +230,8 @@ const SegmentButton = styled(Flex, {
 })
 
 const ChartEmpty = styled(Flex, {
+  position: 'relative',
+  overflow: 'hidden',
   height: 360,
   alignItems: 'center',
   justifyContent: 'center',
@@ -234,12 +244,37 @@ const ChartEmpty = styled(Flex, {
 })
 
 // Subtle moving citrus shimmer for the empty chart surface (high-end touch).
-const CHART_SHIMMER = {
-  backgroundImage:
-    'linear-gradient(100deg, rgba(247,145,26,0) 35%, rgba(247,145,26,0.08) 50%, rgba(247,145,26,0) 65%)',
-  backgroundSize: '220% 100%',
-  animation: 'lp-shimmer 3.6s linear infinite',
+// A `transform`-driven sweep (compositor-only, `lp-shimmer-x` in global.css)
+// instead of an animated `background-position`, which forces a full repaint
+// of the 360px surface every frame on low-end GPUs. Removed entirely under
+// prefers-reduced-motion and paused while off-screen / tab hidden.
+const ChartShimmerBar = styled(Flex, {
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  left: 0,
+  width: '45%',
+  pointerEvents: 'none',
+})
+
+const CHART_SHIMMER_STYLE = {
+  background:
+    'linear-gradient(100deg, rgba(247,145,26,0) 0%, rgba(247,145,26,0.08) 50%, rgba(247,145,26,0) 100%)',
+  animation: 'lp-shimmer-x 3.6s linear infinite',
 } as const
+
+function ChartShimmerSweep() {
+  const { ref, active, reduced } = useLaunchpadAnimation()
+  if (reduced) {
+    return null
+  }
+  return (
+    <ChartShimmerBar
+      ref={ref}
+      style={{ ...CHART_SHIMMER_STYLE, animationPlayState: active ? 'running' : 'paused' }}
+    />
+  )
+}
 
 const AddressRow = styled(Flex, {
   flexDirection: 'row',
@@ -635,7 +670,8 @@ export default function TokenDetail() {
                     valueFormatter={chartValueFormatter}
                   />
                 ) : (
-                  <ChartEmpty style={CHART_SHIMMER}>
+                  <ChartEmpty>
+                    <ChartShimmerSweep />
                     {candlesLoading ? (
                       <Text variant="body2" color="$neutral2">
                         Loading chart…

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -7,27 +7,18 @@ import { useLaunchpadCandles, useLaunchpadToken, type LaunchpadCandleInterval } 
 import { useTokenInfo } from 'hooks/useTokenFactory'
 import { getSocialLink, useTokenMetadata } from 'hooks/useTokenMetadata'
 import type { UTCTimestamp } from 'lightweight-charts'
+import { ActivityTable } from 'pages/Launchpad/components/ActivityTable'
+import { BondingCurveHero } from 'pages/Launchpad/components/BondingCurveHero'
 import { BuySellPanel } from 'pages/Launchpad/components/BuySellPanel'
 import { TokenLogo } from 'pages/Launchpad/components/TokenLogo'
-import {
-  BackButton,
-  Card,
-  GraduatedBadge,
-  ProgressBar,
-  ProgressFill,
-  StatLabel,
-  StatRow,
-  StatValue,
-  getProgressGradient,
-} from 'pages/Launchpad/components/shared'
+import { BackButton, GraduatedBadge, StatLabel, StatRow, StatValue } from 'pages/Launchpad/components/shared'
 import { LAUNCHPAD_TOKEN_TOTAL_SUPPLY } from 'pages/Launchpad/constants'
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
-import { Flex, ModalCloseIcon, Text, styled } from 'ui/src'
+import { Flex, ModalCloseIcon, Text, styled, useIsDarkMode } from 'ui/src'
 import { BackArrow } from 'ui/src/components/icons/BackArrow'
 import { CopyAlt } from 'ui/src/components/icons/CopyAlt'
 import { ExternalLink } from 'ui/src/components/icons/ExternalLink'
-import { InfoCircle } from 'ui/src/components/icons/InfoCircle'
 import { Modal } from 'uniswap/src/components/modals/Modal'
 import { UniverseChainId } from 'uniswap/src/features/chains/types'
 import Trace from 'uniswap/src/features/telemetry/Trace'
@@ -49,43 +40,64 @@ const SOCIAL_URL_PATTERNS: Record<SocialPlatform, { check: (s: string) => boolea
   },
 }
 
-// Extract social handle from various formats: @handle, handle, or full URL
 function extractSocialHandle(value: string | null | undefined, platform: SocialPlatform): string | null {
   if (!value) {
     return null
   }
   const trimmed = value.trim()
   const { check, regex } = SOCIAL_URL_PATTERNS[platform]
-
   if (check(trimmed)) {
     const match = trimmed.match(regex)
     return match ? match[1].replace('@', '') : null
   }
-
   return trimmed.replace('@', '')
 }
 
-const USD_AMOUNT_FORMATTER = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 2,
-})
-
-const USD_PRICE_FORMATTER = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumSignificantDigits: 6,
-})
-
-function formatUsdAmount(value: number | null): string {
-  return typeof value === 'number' && Number.isFinite(value) ? USD_AMOUNT_FORMATTER.format(value) : '-'
+// ⚠️ TEMP — SESSION PREVIEW ONLY. Remove before committing.
+// The backend /candles endpoint is not deployed (404), so the chart is always
+// empty. This synthesizes a plausible price series so the chart design can be
+// reviewed. Set MOCK_CHART to false (or delete) to restore the real empty state.
+const MOCK_CHART: boolean = true
+function buildMockCandles(): PriceChartData[] {
+  const now = Math.floor(Date.now() / 1000)
+  const count = 120
+  const step = 300 // 5m
+  const out: PriceChartData[] = []
+  let base = 0.0000031
+  for (let i = 0; i < count; i++) {
+    base *= 1.0042 // gentle uptrend
+    const osc = 1 + Math.sin(i / 6) * 0.06 + (Math.random() - 0.5) * 0.05
+    const close = base * osc
+    out.push({
+      time: (now - (count - i) * step) as UTCTimestamp,
+      open: close * 0.997,
+      high: close * 1.012,
+      low: close * 0.988,
+      close,
+      value: close,
+    })
+  }
+  return out
 }
 
-function formatUsdPrice(value: number | undefined): string {
-  return typeof value === 'number' && Number.isFinite(value) ? USD_PRICE_FORMATTER.format(value) : '-'
-}
+// ---------------------------------------------------------------------------
+// Layout — clean, light, JuiceSwap-branded trading terminal.
+// Citrus (#F7911A) is used only as an accent; surfaces stay clean with soft
+// shadows for depth.
+// ---------------------------------------------------------------------------
+
+// Theme-aware launchpad canvas. Each theme gets its own crafted background:
+// dark = citrus glow on near-black; light = soft warm citrus glow on off-white.
+const DARK_BASE = '#0A0A0C'
+const LIGHT_BASE = '#FAF8F4'
+const DARK_GLOW =
+  'radial-gradient(900px 520px at 8% -10%, rgba(247,145,26,0.22), transparent 60%), radial-gradient(760px 520px at 104% -4%, rgba(255,124,58,0.13), transparent 55%), radial-gradient(720px 640px at 50% 118%, rgba(99,200,122,0.07), transparent 60%)'
+const LIGHT_GLOW =
+  'radial-gradient(820px 480px at 6% -12%, rgba(247,145,26,0.16), transparent 58%), radial-gradient(700px 460px at 104% -6%, rgba(255,124,58,0.10), transparent 55%), radial-gradient(740px 560px at 50% 120%, rgba(99,200,122,0.06), transparent 60%)'
 
 const PageContainer = styled(Flex, {
+  position: 'relative',
+  overflow: 'hidden',
   width: '100%',
   minHeight: '100vh',
   backgroundColor: '$surface1',
@@ -94,30 +106,49 @@ const PageContainer = styled(Flex, {
   paddingHorizontal: '$spacing20',
 })
 
+const PageBackdrop = styled(Flex, {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 0,
+  pointerEvents: 'none',
+})
+
 const ContentWrapper = styled(Flex, {
+  position: 'relative',
+  zIndex: 1,
   maxWidth: 1200,
   width: '100%',
   alignSelf: 'center',
-  gap: '$spacing24',
+  gap: '$spacing16',
 })
 
-const HeaderSection = styled(Flex, {
-  flexDirection: 'row',
-  alignItems: 'flex-start',
-  gap: '$spacing24',
-  flexWrap: 'wrap',
-})
-
-const TokenInfo = styled(Flex, {
-  flex: 1,
-  gap: '$spacing8',
-  minWidth: 200,
+const Panel = styled(Flex, {
+  backgroundColor: '$surface2',
+  borderRadius: '$rounded20',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  padding: '$spacing20',
+  gap: '$spacing16',
+  animation: 'quick',
+  enterStyle: { opacity: 0, y: 10 },
+  '$platform-web': {
+    boxShadow: '0 1px 2px rgba(16,16,16,0.04), 0 8px 24px rgba(16,16,16,0.05)',
+  },
+  variants: {
+    accent: {
+      true: { borderTopWidth: 2, borderTopColor: '$accent1' },
+    },
+  } as const,
 })
 
 const TokenName = styled(Text, {
   variant: 'heading2',
   color: '$neutral1',
   fontWeight: 'bold',
+  numberOfLines: 1,
 })
 
 const TokenSymbol = styled(Text, {
@@ -125,73 +156,58 @@ const TokenSymbol = styled(Text, {
   color: '$neutral2',
 })
 
+const CardTitle = styled(Text, {
+  variant: 'subheading2',
+  color: '$neutral1',
+  fontWeight: '700',
+})
+
 const MainContent = styled(Flex, {
   flexDirection: 'row',
-  alignItems: 'stretch',
-  gap: '$spacing24',
-  $md: {
-    flexDirection: 'column',
-  },
+  alignItems: 'flex-start',
+  gap: '$spacing16',
+  $md: { flexDirection: 'column', alignItems: 'stretch' },
 })
 
 const LeftColumn = styled(Flex, {
   flex: 2,
   flexShrink: 1,
   minWidth: 0,
-  gap: '$spacing24',
+  gap: '$spacing16',
+  $md: { width: '100%' },
 })
 
 const RightColumn = styled(Flex, {
   flex: 1,
   flexShrink: 0,
-  width: 360,
+  width: 372,
   maxWidth: '100%',
-  alignSelf: 'stretch',
-  gap: '$spacing24',
-  overflow: 'hidden',
-  $md: {
-    width: '100%',
-    flexShrink: 1,
-  },
+  gap: '$spacing16',
+  $md: { width: '100%', flexShrink: 1 },
 })
 
-const FullWidthStack = styled(Flex, {
-  gap: '$spacing24',
-})
-
-const ChartCard = styled(Card, {
-  borderTopWidth: 2,
-  borderTopColor: '$accent1',
-})
-
-const CardTitle = styled(Text, {
-  variant: 'body1',
-  color: '$neutral1',
-  fontWeight: '600',
-})
-
-const ChartStatsGrid = styled(Flex, {
+const StatGrid = styled(Flex, {
   flexDirection: 'row',
   gap: '$spacing12',
   flexWrap: 'wrap',
 })
 
-const ChartStat = styled(Flex, {
+const StatCard = styled(Flex, {
   flex: 1,
   minWidth: 150,
-  minHeight: 76,
-  justifyContent: 'center',
-  gap: '$spacing6',
-  backgroundColor: '$surface1',
+  gap: '$spacing4',
+  padding: '$spacing16',
+  backgroundColor: '$surface2',
   borderRadius: '$rounded16',
   borderWidth: 1,
   borderColor: '$surface3',
-  padding: '$spacing16',
 })
 
-const ChartStatValue = styled(StatValue, {
-  variant: 'subheading2',
+const BigStatValue = styled(Text, {
+  variant: 'subheading1',
+  color: '$neutral1',
   fontWeight: '700',
+  numberOfLines: 1,
 })
 
 const ChartHeaderRow = styled(Flex, {
@@ -207,80 +223,83 @@ const ChartControls = styled(Flex, {
   gap: '$spacing8',
   flexWrap: 'wrap',
   maxWidth: '100%',
-  $md: {
-    width: '100%',
-    flexDirection: 'column',
-  },
+  $md: { width: '100%', flexDirection: 'column' },
 })
 
 const SegmentedControl = styled(Flex, {
   flexDirection: 'row',
   gap: '$spacing4',
   padding: '$spacing4',
-  borderRadius: '$rounded16',
+  borderRadius: '$rounded12',
+  backgroundColor: '$surface1',
   borderWidth: 1,
   borderColor: '$surface3',
-  backgroundColor: '$surface1',
   maxWidth: '100%',
-  $md: {
-    width: '100%',
-    justifyContent: 'space-between',
-  },
+  $md: { width: '100%', justifyContent: 'space-between' },
 })
 
 const SegmentButton = styled(Flex, {
   minWidth: 40,
-  minHeight: 34,
+  minHeight: 32,
   alignItems: 'center',
   justifyContent: 'center',
   paddingHorizontal: '$spacing10',
-  borderRadius: '$rounded12',
+  borderRadius: '$rounded8',
   cursor: 'pointer',
-  $md: {
-    flex: 1,
-    minWidth: 0,
-    paddingHorizontal: '$spacing6',
-  },
-  hoverStyle: {
-    backgroundColor: '$surface2',
-  },
+  animation: 'quick',
+  $md: { flex: 1, minWidth: 0, paddingHorizontal: '$spacing6' },
+  hoverStyle: { backgroundColor: '$surface3' },
   variants: {
     active: {
-      true: {
-        backgroundColor: '$accent1',
-      },
+      true: { backgroundColor: '$accent1', hoverStyle: { backgroundColor: '$accent1' } },
     },
   } as const,
 })
+
+const ChartEmpty = styled(Flex, {
+  height: 360,
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '$spacing8',
+  paddingHorizontal: '$spacing24',
+  borderRadius: '$rounded16',
+  backgroundColor: '$surface1',
+  borderWidth: 1,
+  borderColor: '$surface3',
+})
+
+// Subtle moving citrus shimmer for the empty chart surface (high-end touch).
+const CHART_SHIMMER = {
+  backgroundImage:
+    'linear-gradient(100deg, rgba(247,145,26,0) 35%, rgba(247,145,26,0.08) 50%, rgba(247,145,26,0) 65%)',
+  backgroundSize: '220% 100%',
+  animation: 'lp-shimmer 3.6s linear infinite',
+} as const
 
 const AddressRow = styled(Flex, {
   flexDirection: 'row',
   alignItems: 'center',
   gap: '$spacing8',
+  flexWrap: 'wrap',
 })
 
-const AddressLink = styled(Flex, {
+const InlineLink = styled(Flex, {
   flexDirection: 'row',
   alignItems: 'center',
   gap: '$spacing4',
   cursor: 'pointer',
-  hoverStyle: {
-    opacity: 0.7,
-  },
+  hoverStyle: { opacity: 0.7 },
 })
 
 export default function TokenDetail() {
   const { tokenAddress } = useParams<{ tokenAddress: string }>()
   const navigate = useNavigate()
   const account = useAccount()
+  const isDark = useIsDarkMode()
   const [chartInterval, setChartInterval] = useState<LaunchpadCandleInterval>('5m')
   const [chartPriceUnit, setChartPriceUnit] = useState<ChartPriceUnit>('usd')
 
-  // First, fetch the token data from API to get the correct chainId
   const { data: launchpadData } = useLaunchpadToken(tokenAddress)
-
-  // Use the token's chainId (from API) for all operations - this ensures we read from the correct chain
-  // even if the user is connected to a different network. Default to testnet while loading.
   const chainId = (launchpadData?.token.chainId as UniverseChainId | undefined) ?? UniverseChainId.CitreaTestnet
 
   const {
@@ -306,7 +325,6 @@ export default function TokenDetail() {
   })
   const [showBondingModal, setShowBondingModal] = useState(false)
 
-  // Use unified price hook for graduated/non-graduated tokens
   const {
     priceFormatted: currentPrice,
     marketCapFormatted: marketCap,
@@ -345,16 +363,10 @@ export default function TokenDetail() {
 
   const handleOpenExplorer = useCallback(() => {
     if (tokenAddress) {
-      const url = getExplorerLink({
-        chainId,
-        data: tokenAddress,
-        type: ExplorerDataType.ADDRESS,
-      })
-      window.open(url, '_blank')
+      window.open(getExplorerLink({ chainId, data: tokenAddress, type: ExplorerDataType.ADDRESS }), '_blank')
     }
   }, [tokenAddress, chainId])
 
-  // Format volume from indexed data
   const volumeValue = useMemo(() => {
     if (!launchpadData?.token.totalVolumeBase) {
       return null
@@ -363,16 +375,13 @@ export default function TokenDetail() {
   }, [launchpadData?.token.totalVolumeBase])
 
   const volume = volumeValue?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? '0'
-  const volumeUsd = formatUsdAmount(volumeValue)
-
-  // Total trades from indexed data
   const totalTrades = (launchpadData?.token.totalBuys ?? 0) + (launchpadData?.token.totalSells ?? 0)
 
   const latestCandle = candlesData?.candles[candlesData.candles.length - 1]
   const latestChartPriceValue = candlesData?.latest?.price ?? latestCandle?.close ?? null
 
   const chartData = useMemo<PriceChartData[]>(() => {
-    return (
+    const real =
       candlesData?.candles.map((candle) => ({
         time: candle.time as UTCTimestamp,
         open: candle.open,
@@ -381,7 +390,10 @@ export default function TokenDetail() {
         close: candle.close,
         value: candle.close,
       })) ?? []
-    )
+    if (real.length === 0 && MOCK_CHART) {
+      return buildMockCandles() // TEMP: session preview only
+    }
+    return real
   }, [candlesData?.candles])
 
   const latestChartPrice = latestChartPriceValue
@@ -392,17 +404,17 @@ export default function TokenDetail() {
     marketCap && !['0', 'N/A', '...'].includes(marketCap)
       ? marketCap
       : fallbackMarketCap?.toLocaleString(undefined, { maximumFractionDigits: 2 }) ?? marketCap
-  const displayMarketCapUsd = formatUsdAmount(fallbackMarketCap)
 
   const chartValueFormatter = useCallback(
     (value: number | undefined) => {
       const formatted =
         chartPriceUnit === 'usd'
-          ? formatUsdPrice(value)
+          ? typeof value === 'number' && Number.isFinite(value)
+            ? `$${value.toLocaleString(undefined, { maximumSignificantDigits: 6 })}`
+            : '-'
           : typeof value === 'number' && Number.isFinite(value)
             ? `${value.toLocaleString(undefined, { maximumSignificantDigits: 8 })} JUSD`
             : '-'
-
       return (
         <Text variant="heading2" color="$neutral1">
           {formatted}
@@ -436,6 +448,8 @@ export default function TokenDetail() {
     return new Date(timestamp * 1000).toLocaleDateString()
   }, [launchpadData?.token.createdAt, tokenInfo?.timestamp])
 
+  const displayPrice = latestChartPrice || currentPrice
+
   if (isLoading) {
     return (
       <PageContainer>
@@ -462,7 +476,8 @@ export default function TokenDetail() {
 
   return (
     <Trace logImpression page={InterfacePageName.LaunchpadTokenDetailPage}>
-      <PageContainer>
+      <PageContainer style={{ backgroundColor: isDark ? DARK_BASE : LIGHT_BASE }}>
+        <PageBackdrop style={{ background: isDark ? DARK_GLOW : LIGHT_GLOW }} />
         <ContentWrapper>
           <BackButton onPress={handleBack}>
             <BackArrow size="$icon.20" color="$neutral2" />
@@ -471,136 +486,141 @@ export default function TokenDetail() {
             </Text>
           </BackButton>
 
-          <HeaderSection>
-            <TokenLogo metadataURI={launchpadData?.token.metadataURI} symbol={displaySymbol || '?'} size={80} />
-            <TokenInfo>
-              <Flex flexDirection="row" alignItems="center" gap="$spacing12">
-                <TokenName>{displayName}</TokenName>
-                {displayGraduated && (
-                  <GraduatedBadge size="md">
-                    <Text variant="body3" color="$statusSuccess" fontWeight="600">
-                      Graduated
-                    </Text>
-                  </GraduatedBadge>
-                )}
-              </Flex>
-              <TokenSymbol>${displaySymbol}</TokenSymbol>
-              <AddressRow>
-                <Text variant="body3" color="$neutral3">
-                  {tokenAddress.slice(0, 10)}...{tokenAddress.slice(-8)}
-                </Text>
-                <AddressLink onPress={handleCopyAddress}>
-                  <CopyAlt size="$icon.16" color="$neutral3" />
-                </AddressLink>
-                <AddressLink onPress={handleOpenExplorer}>
-                  <ExternalLink size="$icon.16" color="$neutral3" />
-                </AddressLink>
-              </AddressRow>
-              {(metadata?.external_url ||
-                getSocialLink(metadata, 'Twitter') ||
-                getSocialLink(metadata, 'Telegram')) && (
-                <Flex flexDirection="row" gap="$spacing12" flexWrap="wrap" marginTop="$spacing4">
-                  {metadata?.external_url && (
-                    <AddressLink onPress={() => window.open(metadata.external_url, '_blank', 'noopener')}>
-                      <Text variant="body3" color="$accent1">
-                        Website
+          {/* Identity + headline price */}
+          <Panel>
+            <Flex flexDirection="row" justifyContent="space-between" alignItems="flex-start" gap="$spacing20" flexWrap="wrap">
+              <Flex flexDirection="row" gap="$spacing16" flex={1} minWidth={240}>
+                <TokenLogo metadataURI={launchpadData?.token.metadataURI} symbol={displaySymbol || '?'} size={64} />
+                <Flex gap="$spacing4" minWidth={0} flex={1}>
+                  <Flex flexDirection="row" alignItems="center" gap="$spacing8" flexWrap="wrap">
+                    <TokenName>{displayName}</TokenName>
+                    {displayGraduated ? (
+                      <GraduatedBadge size="md">
+                        <Text variant="body3" color="$statusSuccess" fontWeight="700">
+                          Graduated
+                        </Text>
+                      </GraduatedBadge>
+                    ) : displayCanGraduate ? (
+                      <GraduatedBadge size="md" backgroundColor="$accent2">
+                        <Text variant="body3" color="$accent1" fontWeight="700">
+                          Graduating
+                        </Text>
+                      </GraduatedBadge>
+                    ) : null}
+                  </Flex>
+                  <Flex flexDirection="row" alignItems="center" gap="$spacing12" flexWrap="wrap">
+                    <TokenSymbol>${displaySymbol}</TokenSymbol>
+                    <AddressRow>
+                      <Text variant="body3" color="$neutral3">
+                        {tokenAddress.slice(0, 8)}...{tokenAddress.slice(-6)}
                       </Text>
-                      <ExternalLink size="$icon.12" color="$accent1" />
-                    </AddressLink>
-                  )}
-                  {getSocialLink(metadata, 'Twitter') && (
-                    <AddressLink
-                      onPress={() => {
-                        const handle = extractSocialHandle(getSocialLink(metadata, 'Twitter'), 'Twitter')
-                        if (handle) {
-                          window.open(`https://x.com/${handle}`, '_blank', 'noopener')
-                        }
-                      }}
-                    >
-                      <Text variant="body3" color="$accent1">
-                        Twitter
-                      </Text>
-                      <ExternalLink size="$icon.12" color="$accent1" />
-                    </AddressLink>
-                  )}
-                  {getSocialLink(metadata, 'Telegram') && (
-                    <AddressLink
-                      onPress={() => {
-                        const handle = extractSocialHandle(getSocialLink(metadata, 'Telegram'), 'Telegram')
-                        if (handle) {
-                          window.open(`https://t.me/${handle}`, '_blank', 'noopener')
-                        }
-                      }}
-                    >
-                      <Text variant="body3" color="$accent1">
-                        Telegram
-                      </Text>
-                      <ExternalLink size="$icon.12" color="$accent1" />
-                    </AddressLink>
+                      <InlineLink onPress={handleCopyAddress}>
+                        <CopyAlt size="$icon.16" color="$neutral3" />
+                      </InlineLink>
+                      <InlineLink onPress={handleOpenExplorer}>
+                        <ExternalLink size="$icon.16" color="$neutral3" />
+                      </InlineLink>
+                    </AddressRow>
+                  </Flex>
+                  {(metadata?.external_url ||
+                    getSocialLink(metadata, 'Twitter') ||
+                    getSocialLink(metadata, 'Telegram')) && (
+                    <Flex flexDirection="row" gap="$spacing12" flexWrap="wrap" marginTop="$spacing2">
+                      {metadata?.external_url && (
+                        <InlineLink onPress={() => window.open(metadata.external_url, '_blank', 'noopener')}>
+                          <Text variant="body3" color="$accent1">
+                            Website
+                          </Text>
+                          <ExternalLink size="$icon.12" color="$accent1" />
+                        </InlineLink>
+                      )}
+                      {getSocialLink(metadata, 'Twitter') && (
+                        <InlineLink
+                          onPress={() => {
+                            const handle = extractSocialHandle(getSocialLink(metadata, 'Twitter'), 'Twitter')
+                            if (handle) {
+                              window.open(`https://x.com/${handle}`, '_blank', 'noopener')
+                            }
+                          }}
+                        >
+                          <Text variant="body3" color="$accent1">
+                            Twitter
+                          </Text>
+                          <ExternalLink size="$icon.12" color="$accent1" />
+                        </InlineLink>
+                      )}
+                      {getSocialLink(metadata, 'Telegram') && (
+                        <InlineLink
+                          onPress={() => {
+                            const handle = extractSocialHandle(getSocialLink(metadata, 'Telegram'), 'Telegram')
+                            if (handle) {
+                              window.open(`https://t.me/${handle}`, '_blank', 'noopener')
+                            }
+                          }}
+                        >
+                          <Text variant="body3" color="$accent1">
+                            Telegram
+                          </Text>
+                          <ExternalLink size="$icon.12" color="$accent1" />
+                        </InlineLink>
+                      )}
+                    </Flex>
                   )}
                 </Flex>
-              )}
-            </TokenInfo>
-          </HeaderSection>
-
-          <Card>
-            <CardTitle>Bonding Curve Progress</CardTitle>
-            <ProgressBar>
-              <ProgressFill
-                style={{
-                  width: `${Math.min(displayProgress, 100)}%`,
-                  background: getProgressGradient(displayProgress),
-                }}
-              />
-            </ProgressBar>
-            <Flex flexDirection="row" justifyContent="space-between">
-              <Text variant="body2" color="$neutral2">
-                {displayGraduated ? '100%' : `${displayProgress.toFixed(2)}%`} complete
-              </Text>
-              <Text variant="body2" color={displayGraduated ? '$statusSuccess' : '$neutral1'}>
-                {displayGraduated ? 'Graduated to V2' : `${tokensRemaining} tokens remaining`}
-              </Text>
-            </Flex>
-
-            {!displayGraduated && (
-              <Flex
-                flexDirection="row"
-                alignItems="center"
-                gap="$spacing6"
-                marginTop="$spacing4"
-                cursor="pointer"
-                onPress={() => setShowBondingModal(true)}
-                hoverStyle={{ opacity: 0.7 }}
-              >
-                <Text variant="body3" color="$neutral3">
-                  Graduates to V2 at 100% · 1% fee
-                </Text>
-                <InfoCircle size={14} color="$neutral3" />
               </Flex>
-            )}
-          </Card>
+              <Flex gap="$spacing2" alignItems="flex-end" minWidth={140}>
+                <Text variant="body3" color="$neutral2">
+                  Price
+                </Text>
+                <Text variant="heading2" color="$neutral1" fontWeight="700" numberOfLines={1}>
+                  {displayPrice} <Text variant="body2" color="$neutral2">JUSD</Text>
+                </Text>
+              </Flex>
+            </Flex>
+          </Panel>
+
+          {/* Key metrics */}
+          <StatGrid>
+            <StatCard>
+              <StatLabel variant="body4" color="$neutral3">
+                Market cap
+              </StatLabel>
+              <BigStatValue>{displayMarketCap} JUSD</BigStatValue>
+            </StatCard>
+            <StatCard>
+              <StatLabel variant="body4" color="$neutral3">
+                Liquidity
+              </StatLabel>
+              <BigStatValue>{liquidity} JUSD</BigStatValue>
+            </StatCard>
+            <StatCard>
+              <StatLabel variant="body4" color="$neutral3">
+                Volume
+              </StatLabel>
+              <BigStatValue>{volume} JUSD</BigStatValue>
+            </StatCard>
+            <StatCard>
+              <StatLabel variant="body4" color="$neutral3">
+                Trades
+              </StatLabel>
+              <BigStatValue>{totalTrades.toLocaleString()}</BigStatValue>
+            </StatCard>
+          </StatGrid>
 
           <MainContent>
             <LeftColumn>
-              <ChartCard>
-                <ChartStatsGrid>
-                  <ChartStat>
-                    <StatLabel variant="body3">Market Cap</StatLabel>
-                    <ChartStatValue>{displayMarketCapUsd}</ChartStatValue>
-                  </ChartStat>
-                  <ChartStat>
-                    <StatLabel variant="body3">Volume</StatLabel>
-                    <ChartStatValue>{volumeUsd}</ChartStatValue>
-                  </ChartStat>
-                  <ChartStat>
-                    <StatLabel variant="body3">Trades</StatLabel>
-                    <ChartStatValue>{totalTrades}</ChartStatValue>
-                  </ChartStat>
-                </ChartStatsGrid>
+              <BondingCurveHero
+                progress={displayProgress}
+                graduated={displayGraduated}
+                tokensRemaining={tokensRemaining}
+                onInfo={() => setShowBondingModal(true)}
+              />
 
+              {/* Chart */}
+              <Panel>
                 <ChartHeaderRow>
-                  <Flex gap="$spacing4">
-                    <CardTitle>Price Chart</CardTitle>
+                  <Flex gap="$spacing2">
+                    <CardTitle>Price chart</CardTitle>
                     <Text variant="body3" color="$neutral2">
                       {candlesData?.source === 'bonding_curve_pre_graduation'
                         ? 'Bonding curve history before graduation'
@@ -651,11 +671,22 @@ export default function TokenDetail() {
                     valueFormatter={chartValueFormatter}
                   />
                 ) : (
-                  <Flex height={360} alignItems="center" justifyContent="center">
-                    <Text variant="body2" color="$neutral2">
-                      {candlesLoading ? 'Loading chart...' : 'No chart data yet'}
-                    </Text>
-                  </Flex>
+                  <ChartEmpty style={CHART_SHIMMER}>
+                    {candlesLoading ? (
+                      <Text variant="body2" color="$neutral2">
+                        Loading chart…
+                      </Text>
+                    ) : (
+                      <>
+                        <Text variant="subheading2" color="$neutral1" fontWeight="600">
+                          Price history coming soon
+                        </Text>
+                        <Text variant="body3" color="$neutral3" textAlign="center">
+                          Live candles appear here once trading data is indexed. Recent trades are shown below.
+                        </Text>
+                      </>
+                    )}
+                  </ChartEmpty>
                 )}
 
                 {candlesData?.userTrades?.length ? (
@@ -673,7 +704,18 @@ export default function TokenDetail() {
                     ))}
                   </Flex>
                 ) : null}
-              </ChartCard>
+              </Panel>
+
+              {/* Live activity (real trades) */}
+              <Panel>
+                <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+                  <CardTitle>Recent activity</CardTitle>
+                  <Text variant="body4" color="$neutral3">
+                    {totalTrades.toLocaleString()} trades
+                  </Text>
+                </Flex>
+                <ActivityTable address={tokenAddress} symbol={displaySymbol} chainId={chainId} />
+              </Panel>
             </LeftColumn>
 
             <RightColumn>
@@ -686,96 +728,73 @@ export default function TokenDetail() {
                   canGraduate={displayCanGraduate}
                   chainId={chainId}
                   reserves={reserves}
-                  matchChartHeight
                   onTransactionComplete={refetchBondingCurve}
                   onGraduateComplete={refetchBondingCurve}
                 />
               )}
+
+              {/* Token info */}
+              <Panel>
+                <CardTitle>Token info</CardTitle>
+                <Flex gap="$spacing2">
+                  <StatRow paddingVertical="$spacing4">
+                    <StatLabel variant="body2">Total supply</StatLabel>
+                    <StatValue variant="body2">1,000,000,000</StatValue>
+                  </StatRow>
+                  <StatRow paddingVertical="$spacing4">
+                    <StatLabel variant="body2">Creator</StatLabel>
+                    <InlineLink
+                      onPress={() => {
+                        if (creatorAddress) {
+                          window.open(
+                            getExplorerLink({ chainId, data: creatorAddress, type: ExplorerDataType.ADDRESS }),
+                            '_blank',
+                          )
+                        }
+                      }}
+                    >
+                      <StatValue variant="body2">{creatorShort}</StatValue>
+                      <ExternalLink size="$icon.16" color="$neutral2" />
+                    </InlineLink>
+                  </StatRow>
+                  {createdDate && (
+                    <StatRow paddingVertical="$spacing4">
+                      <StatLabel variant="body2">Created</StatLabel>
+                      <StatValue variant="body2">{createdDate}</StatValue>
+                    </StatRow>
+                  )}
+                  {displayGraduated && displayV2Pair && (
+                    <StatRow paddingVertical="$spacing4">
+                      <StatLabel variant="body2">V2 pair</StatLabel>
+                      <InlineLink
+                        onPress={() => {
+                          window.open(
+                            getExplorerLink({ chainId, data: displayV2Pair, type: ExplorerDataType.ADDRESS }),
+                            '_blank',
+                          )
+                        }}
+                      >
+                        <StatValue variant="body2">
+                          {displayV2Pair.slice(0, 6)}...{displayV2Pair.slice(-4)}
+                        </StatValue>
+                        <ExternalLink size="$icon.16" color="$neutral2" />
+                      </InlineLink>
+                    </StatRow>
+                  )}
+                </Flex>
+              </Panel>
+
+              {/* About */}
+              {metadata?.description && (
+                <Panel>
+                  <CardTitle>About</CardTitle>
+                  <Text variant="body2" color="$neutral2">
+                    {metadata.description}
+                  </Text>
+                </Panel>
+              )}
             </RightColumn>
           </MainContent>
-
-          <FullWidthStack>
-            {metadata?.description && (
-              <Card>
-                <CardTitle>About</CardTitle>
-                <Text variant="body2" color="$neutral2">
-                  {metadata.description}
-                </Text>
-              </Card>
-            )}
-
-            <Card>
-              <CardTitle>Token Info</CardTitle>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Current Price</StatLabel>
-                <StatValue variant="body2">{latestChartPrice || currentPrice} JUSD</StatValue>
-              </StatRow>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Market Cap</StatLabel>
-                <StatValue variant="body2">{displayMarketCap} JUSD</StatValue>
-              </StatRow>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Liquidity</StatLabel>
-                <StatValue variant="body2">{liquidity} JUSD</StatValue>
-              </StatRow>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Volume</StatLabel>
-                <StatValue variant="body2">{volume} JUSD</StatValue>
-              </StatRow>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Trades</StatLabel>
-                <StatValue variant="body2">{totalTrades}</StatValue>
-              </StatRow>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Total Supply</StatLabel>
-                <StatValue variant="body2">1,000,000,000</StatValue>
-              </StatRow>
-              <StatRow paddingVertical="$spacing4">
-                <StatLabel variant="body2">Creator</StatLabel>
-                <AddressLink
-                  onPress={() => {
-                    if (creatorAddress) {
-                      const url = getExplorerLink({
-                        chainId,
-                        data: creatorAddress,
-                        type: ExplorerDataType.ADDRESS,
-                      })
-                      window.open(url, '_blank')
-                    }
-                  }}
-                >
-                  <StatValue variant="body2">{creatorShort}</StatValue>
-                  <ExternalLink size="$icon.16" color="$neutral2" />
-                </AddressLink>
-              </StatRow>
-              {createdDate && (
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">Created</StatLabel>
-                  <StatValue variant="body2">{createdDate}</StatValue>
-                </StatRow>
-              )}
-              {displayGraduated && displayV2Pair && (
-                <StatRow paddingVertical="$spacing4">
-                  <StatLabel variant="body2">V2 Pair</StatLabel>
-                  <AddressLink
-                    onPress={() => {
-                      const url = getExplorerLink({
-                        chainId,
-                        data: displayV2Pair,
-                        type: ExplorerDataType.ADDRESS,
-                      })
-                      window.open(url, '_blank')
-                    }}
-                  >
-                    <StatValue variant="body2">
-                      {displayV2Pair.slice(0, 6)}...{displayV2Pair.slice(-4)}
-                    </StatValue>
-                    <ExternalLink size="$icon.16" color="$neutral2" />
-                  </AddressLink>
-                </StatRow>
-              )}
-            </Card>
-          </FullWidthStack>
         </ContentWrapper>
       </PageContainer>
 
@@ -793,12 +812,10 @@ export default function TokenDetail() {
             </Text>
             <ModalCloseIcon onClose={() => setShowBondingModal(false)} />
           </Flex>
-
           <Text variant="body2" color="$neutral2">
             Tokens start on a bonding curve where price increases as more tokens are purchased. When 100% of tokens are
             sold from the curve, the token graduates to JuiceSwap V2 with permanently locked liquidity.
           </Text>
-
           <Flex gap="$spacing8">
             <Text variant="body3" color="$neutral2">
               • 1% of all trade volume flows to JUICE governance token holders

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -75,6 +75,7 @@ const PageContainer = styled(Flex, {
   paddingTop: '$spacing20',
   paddingBottom: '$spacing60',
   paddingHorizontal: '$spacing20',
+  $sm: { paddingHorizontal: '$spacing12' },
 })
 
 const ContentWrapper = styled(Flex, {
@@ -135,7 +136,10 @@ const LeftColumn = styled(Flex, {
   flexShrink: 1,
   minWidth: 0,
   gap: '$spacing16',
-  $md: { width: '100%' },
+  // On mobile the two columns collapse into MainContent's single flex column.
+  // `display: contents` promotes each panel into that column so they can be
+  // freely reordered via per-panel `$md={{ order }}` (buy/sell pulled up).
+  $md: { width: '100%', display: 'contents' },
 })
 
 const RightColumn = styled(Flex, {
@@ -144,7 +148,7 @@ const RightColumn = styled(Flex, {
   width: 372,
   maxWidth: '100%',
   gap: '$spacing16',
-  $md: { width: '100%', flexShrink: 1 },
+  $md: { width: '100%', flexShrink: 1, display: 'contents' },
 })
 
 const StatGrid = styled(Flex, {
@@ -566,15 +570,18 @@ export default function TokenDetail() {
 
           <MainContent>
             <LeftColumn>
-              <BondingCurveHero
-                progress={displayProgress}
-                graduated={displayGraduated}
-                tokensRemaining={tokensRemaining}
-                onInfo={() => setShowBondingModal(true)}
-              />
+              {/* `$md` order props arrange the flattened mobile column: curve → buy/sell → chart → activity → info → about */}
+              <Flex $md={{ order: 1 }}>
+                <BondingCurveHero
+                  progress={displayProgress}
+                  graduated={displayGraduated}
+                  tokensRemaining={tokensRemaining}
+                  onInfo={() => setShowBondingModal(true)}
+                />
+              </Flex>
 
               {/* Chart */}
-              <Panel>
+              <Panel $md={{ order: 3 }}>
                 <ChartHeaderRow>
                   <Flex gap="$spacing2">
                     <CardTitle>Price chart</CardTitle>
@@ -664,7 +671,7 @@ export default function TokenDetail() {
               </Panel>
 
               {/* Live activity (real trades) */}
-              <Panel>
+              <Panel $md={{ order: 4 }}>
                 <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
                   <CardTitle>Recent activity</CardTitle>
                   <Text variant="body4" color="$neutral3">
@@ -677,21 +684,23 @@ export default function TokenDetail() {
 
             <RightColumn>
               {displayBaseAsset && (
-                <BuySellPanel
-                  tokenAddress={tokenAddress}
-                  tokenSymbol={displaySymbol}
-                  baseAsset={displayBaseAsset}
-                  graduated={displayGraduated}
-                  canGraduate={displayCanGraduate}
-                  chainId={chainId}
-                  reserves={reserves}
-                  onTransactionComplete={refetchBondingCurve}
-                  onGraduateComplete={refetchBondingCurve}
-                />
+                <Flex $md={{ order: 2 }}>
+                  <BuySellPanel
+                    tokenAddress={tokenAddress}
+                    tokenSymbol={displaySymbol}
+                    baseAsset={displayBaseAsset}
+                    graduated={displayGraduated}
+                    canGraduate={displayCanGraduate}
+                    chainId={chainId}
+                    reserves={reserves}
+                    onTransactionComplete={refetchBondingCurve}
+                    onGraduateComplete={refetchBondingCurve}
+                  />
+                </Flex>
               )}
 
               {/* Token info */}
-              <Panel>
+              <Panel $md={{ order: 5 }}>
                 <CardTitle>Token info</CardTitle>
                 <Flex gap="$spacing2">
                   <StatRow paddingVertical="$spacing4">
@@ -743,7 +752,7 @@ export default function TokenDetail() {
 
               {/* About */}
               {metadata?.description && (
-                <Panel>
+                <Panel $md={{ order: 6 }}>
                   <CardTitle>About</CardTitle>
                   <Text variant="body2" color="$neutral2">
                     {metadata.description}

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -60,33 +60,6 @@ function extractSocialHandle(value: string | null | undefined, platform: SocialP
   return trimmed.replace('@', '')
 }
 
-// ⚠️ TEMP — SESSION PREVIEW ONLY. Remove before committing.
-// The backend /candles endpoint is not deployed (404), so the chart is always
-// empty. This synthesizes a plausible price series so the chart design can be
-// reviewed. Set MOCK_CHART to false (or delete) to restore the real empty state.
-const MOCK_CHART: boolean = true
-function buildMockCandles(): PriceChartData[] {
-  const now = Math.floor(Date.now() / 1000)
-  const count = 120
-  const step = 300 // 5m
-  const out: PriceChartData[] = []
-  let base = 0.0000031
-  for (let i = 0; i < count; i++) {
-    base *= 1.0042 // gentle uptrend
-    const osc = 1 + Math.sin(i / 6) * 0.06 + (Math.random() - 0.5) * 0.05
-    const close = base * osc
-    out.push({
-      time: (now - (count - i) * step) as UTCTimestamp,
-      open: close * 0.997,
-      high: close * 1.012,
-      low: close * 0.988,
-      close,
-      value: close,
-    })
-  }
-  return out
-}
-
 // ---------------------------------------------------------------------------
 // Layout — clean, light, JuiceSwap-branded trading terminal.
 // Citrus (#F7911A) is used only as an accent; surfaces stay clean with soft
@@ -377,9 +350,6 @@ export default function TokenDetail() {
         close: candle.close,
         value: candle.close,
       })) ?? []
-    if (real.length === 0 && MOCK_CHART) {
-      return buildMockCandles() // TEMP: session preview only
-    }
     return real
   }, [candlesData?.candles])
 

--- a/apps/web/src/pages/Launchpad/TokenDetail.tsx
+++ b/apps/web/src/pages/Launchpad/TokenDetail.tsx
@@ -11,11 +11,18 @@ import { ActivityTable } from 'pages/Launchpad/components/ActivityTable'
 import { BondingCurveHero } from 'pages/Launchpad/components/BondingCurveHero'
 import { BuySellPanel } from 'pages/Launchpad/components/BuySellPanel'
 import { TokenLogo } from 'pages/Launchpad/components/TokenLogo'
-import { BackButton, GraduatedBadge, StatLabel, StatRow, StatValue } from 'pages/Launchpad/components/shared'
+import {
+  BackButton,
+  GraduatedBadge,
+  LaunchpadBackdrop,
+  StatLabel,
+  StatRow,
+  StatValue,
+} from 'pages/Launchpad/components/shared'
 import { LAUNCHPAD_TOKEN_TOTAL_SUPPLY } from 'pages/Launchpad/constants'
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
-import { Flex, ModalCloseIcon, Text, styled, useIsDarkMode } from 'ui/src'
+import { Flex, ModalCloseIcon, Text, styled } from 'ui/src'
 import { BackArrow } from 'ui/src/components/icons/BackArrow'
 import { CopyAlt } from 'ui/src/components/icons/CopyAlt'
 import { ExternalLink } from 'ui/src/components/icons/ExternalLink'
@@ -86,15 +93,6 @@ function buildMockCandles(): PriceChartData[] {
 // shadows for depth.
 // ---------------------------------------------------------------------------
 
-// Theme-aware launchpad canvas. Each theme gets its own crafted background:
-// dark = citrus glow on near-black; light = soft warm citrus glow on off-white.
-const DARK_BASE = '#0A0A0C'
-const LIGHT_BASE = '#FAF8F4'
-const DARK_GLOW =
-  'radial-gradient(900px 520px at 8% -10%, rgba(247,145,26,0.22), transparent 60%), radial-gradient(760px 520px at 104% -4%, rgba(255,124,58,0.13), transparent 55%), radial-gradient(720px 640px at 50% 118%, rgba(99,200,122,0.07), transparent 60%)'
-const LIGHT_GLOW =
-  'radial-gradient(820px 480px at 6% -12%, rgba(247,145,26,0.16), transparent 58%), radial-gradient(700px 460px at 104% -6%, rgba(255,124,58,0.10), transparent 55%), radial-gradient(740px 560px at 50% 120%, rgba(99,200,122,0.06), transparent 60%)'
-
 const PageContainer = styled(Flex, {
   position: 'relative',
   overflow: 'hidden',
@@ -104,16 +102,6 @@ const PageContainer = styled(Flex, {
   paddingTop: '$spacing20',
   paddingBottom: '$spacing60',
   paddingHorizontal: '$spacing20',
-})
-
-const PageBackdrop = styled(Flex, {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  zIndex: 0,
-  pointerEvents: 'none',
 })
 
 const ContentWrapper = styled(Flex, {
@@ -295,7 +283,6 @@ export default function TokenDetail() {
   const { tokenAddress } = useParams<{ tokenAddress: string }>()
   const navigate = useNavigate()
   const account = useAccount()
-  const isDark = useIsDarkMode()
   const [chartInterval, setChartInterval] = useState<LaunchpadCandleInterval>('5m')
   const [chartPriceUnit, setChartPriceUnit] = useState<ChartPriceUnit>('usd')
 
@@ -476,8 +463,8 @@ export default function TokenDetail() {
 
   return (
     <Trace logImpression page={InterfacePageName.LaunchpadTokenDetailPage}>
-      <PageContainer style={{ backgroundColor: isDark ? DARK_BASE : LIGHT_BASE }}>
-        <PageBackdrop style={{ background: isDark ? DARK_GLOW : LIGHT_GLOW }} />
+      <PageContainer>
+        <LaunchpadBackdrop />
         <ContentWrapper>
           <BackButton onPress={handleBack}>
             <BackArrow size="$icon.20" color="$neutral2" />

--- a/apps/web/src/pages/Launchpad/components/ActivityTable.tsx
+++ b/apps/web/src/pages/Launchpad/components/ActivityTable.tsx
@@ -1,0 +1,177 @@
+import { useLaunchpadTrades, type LaunchpadTrade } from 'hooks/useLaunchpadTokens'
+import { useMemo } from 'react'
+import { Flex, Text, styled } from 'ui/src'
+import { ExternalLink } from 'ui/src/components/icons/ExternalLink'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { ExplorerDataType, getExplorerLink } from 'uniswap/src/utils/linking'
+import { formatUnits } from 'viem'
+
+const HeaderRow = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  paddingVertical: '$spacing8',
+  paddingHorizontal: '$spacing12',
+  borderBottomWidth: 1,
+  borderBottomColor: '$surface3',
+})
+
+const Row = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  paddingVertical: '$spacing10',
+  paddingHorizontal: '$spacing12',
+  borderRadius: '$rounded8',
+  cursor: 'pointer',
+  animation: 'quick',
+  enterStyle: { opacity: 0, x: -6 },
+  hoverStyle: { backgroundColor: '$surface1' },
+})
+
+const HeadCell = styled(Text, {
+  variant: 'body4',
+  color: '$neutral3',
+  fontWeight: '600',
+})
+
+// Column flex weights (kept in sync between header + rows)
+const COL = {
+  type: { flexBasis: 70, flexGrow: 0, flexShrink: 0 },
+  amount: { flex: 1.4, minWidth: 0 },
+  base: { flex: 1.2, minWidth: 0 },
+  trader: { flex: 1, minWidth: 0, $sm: { display: 'none' } },
+  age: { flexBasis: 64, flexGrow: 0, flexShrink: 0, alignItems: 'flex-end' },
+} as const
+
+function shortAddr(a: string): string {
+  return `${a.slice(0, 5)}…${a.slice(-4)}`
+}
+
+function compact(n: number): string {
+  return Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 2 }).format(n)
+}
+
+function ago(tsSeconds: number): string {
+  const diff = Math.floor(Date.now() / 1000) - tsSeconds
+  if (diff < 60) {
+    return `${Math.max(diff, 0)}s`
+  }
+  if (diff < 3600) {
+    return `${Math.floor(diff / 60)}m`
+  }
+  if (diff < 86400) {
+    return `${Math.floor(diff / 3600)}h`
+  }
+  return `${Math.floor(diff / 86400)}d`
+}
+
+function TradeRow({ trade, symbol, chainId }: { trade: LaunchpadTrade; symbol: string; chainId: UniverseChainId }) {
+  const tokenAmount = useMemo(() => {
+    try {
+      return compact(Number(formatUnits(BigInt(trade.tokenAmount), 18)))
+    } catch {
+      return '0'
+    }
+  }, [trade.tokenAmount])
+  const baseAmount = useMemo(() => {
+    try {
+      return compact(Number(formatUnits(BigInt(trade.baseAmount), 18)))
+    } catch {
+      return '0'
+    }
+  }, [trade.baseAmount])
+  const color = trade.isBuy ? '$statusSuccess' : '$statusCritical'
+
+  const openTx = () => {
+    window.open(getExplorerLink({ chainId, data: trade.txHash, type: ExplorerDataType.TRANSACTION }), '_blank')
+  }
+
+  return (
+    <Row onPress={openTx}>
+      <Flex {...COL.type}>
+        <Flex
+          flexDirection="row"
+          alignItems="center"
+          gap="$spacing6"
+          paddingHorizontal="$spacing8"
+          paddingVertical="$spacing2"
+          borderRadius="$roundedFull"
+          backgroundColor={trade.isBuy ? '$statusSuccess2' : '$statusCritical2'}
+          alignSelf="flex-start"
+        >
+          <Text variant="body4" color={color} fontWeight="700">
+            {trade.isBuy ? 'Buy' : 'Sell'}
+          </Text>
+        </Flex>
+      </Flex>
+      <Flex {...COL.amount}>
+        <Text variant="body3" color="$neutral1" fontWeight="600" numberOfLines={1}>
+          {tokenAmount} {symbol}
+        </Text>
+      </Flex>
+      <Flex {...COL.base}>
+        <Text variant="body3" color="$neutral2" numberOfLines={1}>
+          {baseAmount} JUSD
+        </Text>
+      </Flex>
+      <Flex {...COL.trader}>
+        <Flex flexDirection="row" alignItems="center" gap="$spacing4">
+          <Text variant="body3" color="$neutral2" numberOfLines={1}>
+            {shortAddr(trade.trader)}
+          </Text>
+          <ExternalLink size="$icon.12" color="$neutral3" />
+        </Flex>
+      </Flex>
+      <Flex {...COL.age}>
+        <Text variant="body3" color="$neutral3">
+          {ago(Number(trade.timestamp))}
+        </Text>
+      </Flex>
+    </Row>
+  )
+}
+
+export function ActivityTable({
+  address,
+  symbol,
+  chainId,
+}: {
+  address: string
+  symbol: string
+  chainId: UniverseChainId
+}) {
+  const { data, isLoading } = useLaunchpadTrades({ address, limit: 25 })
+  const trades = data?.trades ?? []
+
+  return (
+    <Flex gap="$spacing4">
+      <HeaderRow>
+        <HeadCell {...COL.type}>Type</HeadCell>
+        <HeadCell {...COL.amount}>Amount</HeadCell>
+        <HeadCell {...COL.base}>JUSD</HeadCell>
+        <HeadCell {...COL.trader}>Trader</HeadCell>
+        <HeadCell {...COL.age}>Age</HeadCell>
+      </HeaderRow>
+
+      {isLoading ? (
+        <Flex padding="$spacing24" alignItems="center">
+          <Text variant="body3" color="$neutral3">
+            Loading activity…
+          </Text>
+        </Flex>
+      ) : trades.length === 0 ? (
+        <Flex padding="$spacing24" alignItems="center" gap="$spacing4">
+          <Text variant="body2" color="$neutral1" fontWeight="600">
+            No trades yet
+          </Text>
+          <Text variant="body3" color="$neutral3">
+            Be the first to trade this token.
+          </Text>
+        </Flex>
+      ) : (
+        trades.map((trade) => (
+          <TradeRow key={`${trade.txHash}-${trade.id}`} trade={trade} symbol={symbol} chainId={chainId} />
+        ))
+      )}
+    </Flex>
+  )
+}

--- a/apps/web/src/pages/Launchpad/components/ActivityTable.tsx
+++ b/apps/web/src/pages/Launchpad/components/ActivityTable.tsx
@@ -152,26 +152,30 @@ export function ActivityTable({
         <HeadCell {...COL.age}>Age</HeadCell>
       </HeaderRow>
 
-      {isLoading ? (
-        <Flex padding="$spacing24" alignItems="center">
-          <Text variant="body3" color="$neutral3">
-            Loading activity…
-          </Text>
-        </Flex>
-      ) : trades.length === 0 ? (
-        <Flex padding="$spacing24" alignItems="center" gap="$spacing4">
-          <Text variant="body2" color="$neutral1" fontWeight="600">
-            No trades yet
-          </Text>
-          <Text variant="body3" color="$neutral3">
-            Be the first to trade this token.
-          </Text>
-        </Flex>
-      ) : (
-        trades.map((trade) => (
-          <TradeRow key={`${trade.txHash}-${trade.id}`} trade={trade} symbol={symbol} chainId={chainId} />
-        ))
-      )}
+      {/* Rows scroll within a capped height on mobile so the long trade list
+          doesn't dominate the page; desktop keeps its natural full height. */}
+      <Flex gap="$spacing4" $md={{ maxHeight: 420, overflow: 'scroll' }}>
+        {isLoading ? (
+          <Flex padding="$spacing24" alignItems="center">
+            <Text variant="body3" color="$neutral3">
+              Loading activity…
+            </Text>
+          </Flex>
+        ) : trades.length === 0 ? (
+          <Flex padding="$spacing24" alignItems="center" gap="$spacing4">
+            <Text variant="body2" color="$neutral1" fontWeight="600">
+              No trades yet
+            </Text>
+            <Text variant="body3" color="$neutral3">
+              Be the first to trade this token.
+            </Text>
+          </Flex>
+        ) : (
+          trades.map((trade) => (
+            <TradeRow key={`${trade.txHash}-${trade.id}`} trade={trade} symbol={symbol} chainId={chainId} />
+          ))
+        )}
+      </Flex>
     </Flex>
   )
 }

--- a/apps/web/src/pages/Launchpad/components/BondingCurveHero.tsx
+++ b/apps/web/src/pages/Launchpad/components/BondingCurveHero.tsx
@@ -1,4 +1,5 @@
 import { getProgressGradient } from 'pages/Launchpad/components/shared'
+import { useLaunchpadAnimation } from 'pages/Launchpad/useLaunchpadMotion'
 import { useEffect, useRef, useState } from 'react'
 import { Flex, Text, styled } from 'ui/src'
 import { InfoCircle } from 'ui/src/components/icons/InfoCircle'
@@ -42,16 +43,24 @@ const Marker = styled(Flex, {
 
 const SHEEN_STYLE = { animation: 'lp-sheen 2.8s ease-in-out infinite' } as const
 
-// requestAnimationFrame count-up to `target`, eased.
-function useCountUp(target: number, durationMs = 1100): number {
+const COUNT_UP_DURATION_MS = 1100
+
+// requestAnimationFrame count-up to `target`, eased. With `skip` (reduced
+// motion) the value snaps straight to the target — no rAF loop at all.
+function useCountUp(target: number, skip: boolean): number {
   const [val, setVal] = useState(0)
   const fromRef = useRef(0)
   useEffect(() => {
+    if (skip) {
+      fromRef.current = target
+      setVal(target)
+      return undefined
+    }
     const from = fromRef.current
     let raf = 0
     const start = performance.now()
     const tick = (now: number) => {
-      const t = Math.min((now - start) / durationMs, 1)
+      const t = Math.min((now - start) / COUNT_UP_DURATION_MS, 1)
       const eased = 1 - Math.pow(1 - t, 3)
       const next = from + (target - from) * eased
       setVal(next)
@@ -63,7 +72,7 @@ function useCountUp(target: number, durationMs = 1100): number {
     }
     raf = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(raf)
-  }, [target, durationMs])
+  }, [target, skip])
   return val
 }
 
@@ -76,19 +85,28 @@ interface BondingCurveHeroProps {
 
 export function BondingCurveHero({ progress, graduated, tokensRemaining, onInfo }: BondingCurveHeroProps) {
   const pct = graduated ? 100 : Math.min(Math.max(progress, 0), 100)
-  const animatedPct = useCountUp(pct)
+  // `ref`/`active` pause the infinite sheen sweep when off-screen; `reduced`
+  // removes the count-up, the fill transition, and the sheen entirely for
+  // users (and battery-saver phones) that prefer reduced motion.
+  const { ref, active, reduced } = useLaunchpadAnimation()
+  const animatedPct = useCountUp(pct, reduced)
 
-  // Animate the fill width from 0 -> pct on mount / change.
-  const [fillW, setFillW] = useState(0)
+  // Animate the fill width from 0 -> pct on mount / change (skipped under
+  // reduced motion, where it is rendered at its final width immediately).
+  const [fillW, setFillW] = useState(reduced ? pct : 0)
   useEffect(() => {
+    if (reduced) {
+      setFillW(pct)
+      return undefined
+    }
     const id = requestAnimationFrame(() => setFillW(pct))
     return () => cancelAnimationFrame(id)
-  }, [pct])
+  }, [pct, reduced])
 
   const accentColor = graduated ? '$statusSuccess' : '$accent1'
 
   return (
-    <Panel>
+    <Panel ref={ref} className="lp-elev">
       <Flex flexDirection="row" justifyContent="space-between" alignItems="flex-end" gap="$spacing16" flexWrap="wrap">
         <Flex gap="$spacing2">
           <Text variant="subheading2" color="$neutral1" fontWeight="700">
@@ -117,19 +135,23 @@ export function BondingCurveHero({ progress, graduated, tokensRemaining, onInfo 
           style={{
             width: `${fillW}%`,
             background: getProgressGradient(pct),
-            transition: 'width 1.4s cubic-bezier(0.22, 1, 0.36, 1)',
+            transition: reduced ? 'none' : 'width 1.4s cubic-bezier(0.22, 1, 0.36, 1)',
           }}
         >
-          <Flex
-            position="absolute"
-            top={0}
-            bottom={0}
-            width={60}
-            style={{
-              ...SHEEN_STYLE,
-              background: 'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.55) 50%, rgba(255,255,255,0) 100%)',
-            }}
-          />
+          {!reduced && (
+            <Flex
+              position="absolute"
+              top={0}
+              bottom={0}
+              width={60}
+              style={{
+                ...SHEEN_STYLE,
+                animationPlayState: active ? 'running' : 'paused',
+                background:
+                  'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.55) 50%, rgba(255,255,255,0) 100%)',
+              }}
+            />
+          )}
         </Flex>
         {!graduated && <Marker />}
       </Track>

--- a/apps/web/src/pages/Launchpad/components/BondingCurveHero.tsx
+++ b/apps/web/src/pages/Launchpad/components/BondingCurveHero.tsx
@@ -1,0 +1,167 @@
+import { getProgressGradient } from 'pages/Launchpad/components/shared'
+import { useEffect, useRef, useState } from 'react'
+import { Flex, Text, styled } from 'ui/src'
+import { InfoCircle } from 'ui/src/components/icons/InfoCircle'
+
+const Panel = styled(Flex, {
+  position: 'relative',
+  overflow: 'hidden',
+  backgroundColor: '$surface2',
+  borderRadius: '$rounded20',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  borderTopWidth: 2,
+  borderTopColor: '$accent1',
+  padding: '$spacing20',
+  gap: '$spacing12',
+  animation: 'quick',
+  enterStyle: { opacity: 0, y: 10 },
+  '$platform-web': {
+    boxShadow: '0 1px 2px rgba(16,16,16,0.04), 0 8px 24px rgba(16,16,16,0.05)',
+  },
+})
+
+// Tall, prominent track + fill.
+const Track = styled(Flex, {
+  position: 'relative',
+  height: 14,
+  borderRadius: '$rounded8',
+  backgroundColor: '$surface3',
+  overflow: 'hidden',
+})
+
+const Marker = styled(Flex, {
+  position: 'absolute',
+  top: -4,
+  bottom: -4,
+  right: 0,
+  width: 2,
+  backgroundColor: '$neutral3',
+  opacity: 0.35,
+})
+
+const SHEEN_STYLE = { animation: 'lp-sheen 2.8s ease-in-out infinite' } as const
+
+// requestAnimationFrame count-up to `target`, eased.
+function useCountUp(target: number, durationMs = 1100): number {
+  const [val, setVal] = useState(0)
+  const fromRef = useRef(0)
+  useEffect(() => {
+    const from = fromRef.current
+    let raf = 0
+    const start = performance.now()
+    const tick = (now: number) => {
+      const t = Math.min((now - start) / durationMs, 1)
+      const eased = 1 - Math.pow(1 - t, 3)
+      const next = from + (target - from) * eased
+      setVal(next)
+      if (t < 1) {
+        raf = requestAnimationFrame(tick)
+      } else {
+        fromRef.current = target
+      }
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [target, durationMs])
+  return val
+}
+
+interface BondingCurveHeroProps {
+  progress: number
+  graduated: boolean
+  tokensRemaining: string
+  onInfo: () => void
+}
+
+export function BondingCurveHero({ progress, graduated, tokensRemaining, onInfo }: BondingCurveHeroProps) {
+  const pct = graduated ? 100 : Math.min(Math.max(progress, 0), 100)
+  const animatedPct = useCountUp(pct)
+
+  // Animate the fill width from 0 -> pct on mount / change.
+  const [fillW, setFillW] = useState(0)
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setFillW(pct))
+    return () => cancelAnimationFrame(id)
+  }, [pct])
+
+  const accentColor = graduated ? '$statusSuccess' : '$accent1'
+
+  return (
+    <Panel>
+      <Flex flexDirection="row" justifyContent="space-between" alignItems="flex-end" gap="$spacing16" flexWrap="wrap">
+        <Flex gap="$spacing2">
+          <Text variant="subheading2" color="$neutral1" fontWeight="700">
+            Bonding curve
+          </Text>
+          <Text variant="body2" color="$neutral2">
+            {graduated ? 'Graduated to JuiceSwap V2' : 'Progress to graduation'}
+          </Text>
+        </Flex>
+        <Flex flexDirection="row" alignItems="baseline" gap="$spacing2">
+          <Text variant="heading2" color={accentColor} fontWeight="700" $sm={{ fontSize: 28, lineHeight: 32 }}>
+            {animatedPct.toFixed(graduated ? 0 : 2)}
+          </Text>
+          <Text variant="subheading2" color={accentColor} fontWeight="700">
+            %
+          </Text>
+        </Flex>
+      </Flex>
+
+      <Track>
+        <Flex
+          height="100%"
+          borderRadius="$rounded8"
+          overflow="hidden"
+          position="relative"
+          style={{
+            width: `${fillW}%`,
+            background: getProgressGradient(pct),
+            transition: 'width 1.4s cubic-bezier(0.22, 1, 0.36, 1)',
+          }}
+        >
+          <Flex
+            position="absolute"
+            top={0}
+            bottom={0}
+            width={60}
+            style={{
+              ...SHEEN_STYLE,
+              background: 'linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.55) 50%, rgba(255,255,255,0) 100%)',
+            }}
+          />
+        </Flex>
+        {!graduated && <Marker />}
+      </Track>
+
+      <Flex flexDirection="row" justifyContent="space-between" alignItems="center" gap="$spacing8" flexWrap="wrap">
+        {graduated ? (
+          <Text variant="body3" color="$statusSuccess" fontWeight="600">
+            Liquidity permanently locked in V2
+          </Text>
+        ) : (
+          <Flex
+            flexDirection="row"
+            alignItems="center"
+            gap="$spacing6"
+            cursor="pointer"
+            animation="quick"
+            flexShrink={1}
+            onPress={onInfo}
+            hoverStyle={{ opacity: 0.7 }}
+          >
+            <Text variant="body3" color="$neutral3" numberOfLines={1}>
+              Graduates at 100% · 1% fee
+            </Text>
+            <InfoCircle size={14} color="$neutral3" />
+          </Flex>
+        )}
+        {!graduated && (
+          <Text variant="body3" color="$neutral2" fontWeight="600">
+            {tokensRemaining} tokens remaining
+          </Text>
+        )}
+      </Flex>
+    </Panel>
+  )
+}

--- a/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
+++ b/apps/web/src/pages/Launchpad/components/BuySellPanel.tsx
@@ -36,6 +36,16 @@ const PanelContainer = styled(Flex, {
   gap: '$spacing16',
   overflow: 'hidden',
   minWidth: 0,
+  variants: {
+    matchChartHeight: {
+      true: {
+        minHeight: 524,
+        height: '100%',
+        padding: '$spacing24',
+        gap: '$spacing20',
+      },
+    },
+  } as const,
 })
 
 const TabContainer = styled(Flex, {
@@ -44,6 +54,14 @@ const TabContainer = styled(Flex, {
   padding: '$spacing4',
   backgroundColor: '$surface3',
   borderRadius: '$rounded12',
+  variants: {
+    large: {
+      true: {
+        padding: '$spacing6',
+        borderRadius: '$rounded16',
+      },
+    },
+  } as const,
 })
 
 const Tab = styled(Flex, {
@@ -57,6 +75,12 @@ const Tab = styled(Flex, {
     active: {
       true: {
         backgroundColor: '$accent1',
+      },
+    },
+    large: {
+      true: {
+        paddingVertical: '$spacing16',
+        borderRadius: '$rounded12',
       },
     },
   } as const,
@@ -208,6 +232,8 @@ interface BuySellPanelProps {
   chainId: number | undefined
   /** Bonding curve reserves - used for excess JUSD warning */
   reserves: BondingCurveReserves | undefined
+  /** Enlarges the panel for token detail layouts where it sits beside a chart. */
+  matchChartHeight?: boolean
   onTransactionComplete?: () => void
   onGraduateComplete?: () => void
 }
@@ -220,6 +246,7 @@ export function BuySellPanel({
   canGraduate,
   chainId,
   reserves,
+  matchChartHeight = false,
   onTransactionComplete,
   onGraduateComplete,
 }: BuySellPanelProps) {
@@ -694,7 +721,7 @@ export function BuySellPanel({
 
   if (graduated) {
     return (
-      <PanelContainer>
+      <PanelContainer matchChartHeight={matchChartHeight}>
         <Text variant="body1" color="$neutral1" textAlign="center">
           This token has graduated to JuiceSwap V2
         </Text>
@@ -711,14 +738,14 @@ export function BuySellPanel({
   }
 
   return (
-    <PanelContainer>
-      <TabContainer>
-        <Tab active={isBuy} onPress={() => setIsBuy(true)}>
+    <PanelContainer matchChartHeight={matchChartHeight}>
+      <TabContainer large={matchChartHeight}>
+        <Tab active={isBuy} large={matchChartHeight} onPress={() => setIsBuy(true)}>
           <Text variant="buttonLabel3" color={isBuy ? '$white' : '$neutral2'}>
             Buy
           </Text>
         </Tab>
-        <Tab active={!isBuy} onPress={() => setIsBuy(false)}>
+        <Tab active={!isBuy} large={matchChartHeight} onPress={() => setIsBuy(false)}>
           <Text variant="buttonLabel3" color={!isBuy ? '$white' : '$neutral2'}>
             Sell
           </Text>

--- a/apps/web/src/pages/Launchpad/components/LiveTicker.tsx
+++ b/apps/web/src/pages/Launchpad/components/LiveTicker.tsx
@@ -1,4 +1,5 @@
 import { useRecentLaunchpadTrades, type LaunchpadTrade } from 'hooks/useLaunchpadTokens'
+import { useLaunchpadAnimation } from 'pages/Launchpad/useLaunchpadMotion'
 import { useMemo } from 'react'
 import { Flex, Text, styled } from 'ui/src'
 import { formatUnits } from 'viem'
@@ -88,13 +89,22 @@ export function LiveTicker({ chainId }: { chainId?: number }) {
   // Duplicate the list so the -50% translate loops seamlessly.
   const loop = useMemo(() => [...trades, ...trades], [trades])
 
+  // Only spend frames on the marquee when it is on screen, the tab is
+  // visible, and the user hasn't asked for reduced motion — otherwise
+  // freeze it (a static, readable trade list) to spare low-end devices.
+  const { ref, active } = useLaunchpadAnimation()
+  const trackStyle = useMemo(
+    () => ({ ...TICKER_ANIMATION, animationPlayState: active ? 'running' : 'paused' }) as const,
+    [active],
+  )
+
   if (trades.length === 0) {
     return null
   }
 
   return (
-    <Viewport>
-      <Track style={TICKER_ANIMATION}>
+    <Viewport ref={ref}>
+      <Track style={trackStyle}>
         <LivePulse>
           <Dot backgroundColor="$statusSuccess" />
           <Text variant="body3" color="$statusSuccess" fontWeight="700" letterSpacing={0.6}>

--- a/apps/web/src/pages/Launchpad/components/LiveTicker.tsx
+++ b/apps/web/src/pages/Launchpad/components/LiveTicker.tsx
@@ -1,0 +1,110 @@
+import { useRecentLaunchpadTrades, type LaunchpadTrade } from 'hooks/useLaunchpadTokens'
+import { useMemo } from 'react'
+import { Flex, Text, styled } from 'ui/src'
+import { formatUnits } from 'viem'
+
+const Viewport = styled(Flex, {
+  position: 'relative',
+  width: '100%',
+  overflow: 'hidden',
+  paddingVertical: '$spacing12',
+  borderTopWidth: 1,
+  borderBottomWidth: 1,
+  borderColor: '$surface3',
+  // fade both edges so items scroll in/out softly
+  '$platform-web': {
+    maskImage: 'linear-gradient(90deg, transparent 0%, #000 5%, #000 95%, transparent 100%)',
+    WebkitMaskImage: 'linear-gradient(90deg, transparent 0%, #000 5%, #000 95%, transparent 100%)',
+  },
+})
+
+const Track = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing20',
+  width: 'max-content',
+  pointerEvents: 'none',
+})
+
+// Tamagui intercepts the `animation` prop (even under $platform-web) and drops
+// the raw CSS string, so the marquee is driven via an inline style instead,
+// referencing the global `launchpad-ticker` keyframe in global.css.
+const TICKER_ANIMATION = { animation: 'launchpad-ticker 75s linear infinite' } as const
+
+const Dot = styled(Flex, {
+  width: 7,
+  height: 7,
+  borderRadius: '$roundedFull',
+})
+
+const LivePulse = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing6',
+  paddingRight: '$spacing16',
+  marginRight: '$spacing4',
+  borderRightWidth: 1,
+  borderRightColor: '$surface3',
+  flexShrink: 0,
+})
+
+function shortAddr(a: string): string {
+  return `${a.slice(0, 6)}…${a.slice(-4)}`
+}
+
+function compact(n: number): string {
+  return Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 }).format(n)
+}
+
+function TradeItem({ trade }: { trade: LaunchpadTrade }) {
+  const amount = useMemo(() => {
+    try {
+      return compact(Number(formatUnits(BigInt(trade.tokenAmount), 18)))
+    } catch {
+      return '0'
+    }
+  }, [trade.tokenAmount])
+  const color = trade.isBuy ? '$statusSuccess' : '$statusCritical'
+  return (
+    <Flex flexDirection="row" alignItems="center" gap="$spacing8" flexShrink={0}>
+      <Dot backgroundColor={color} />
+      <Text variant="body3" color="$neutral2">
+        {shortAddr(trade.trader)}
+      </Text>
+      <Text variant="body3" color={color} fontWeight="600">
+        {trade.isBuy ? 'bought' : 'sold'}
+      </Text>
+      <Text variant="body3" color="$neutral1" fontWeight="600">
+        {amount} ${trade.tokenSymbol || trade.tokenName || '???'}
+      </Text>
+    </Flex>
+  )
+}
+
+export function LiveTicker({ chainId }: { chainId?: number }) {
+  const { data } = useRecentLaunchpadTrades({ limit: 24, chainId })
+  const trades = useMemo(() => data?.trades ?? [], [data])
+
+  // Duplicate the list so the -50% translate loops seamlessly.
+  const loop = useMemo(() => [...trades, ...trades], [trades])
+
+  if (trades.length === 0) {
+    return null
+  }
+
+  return (
+    <Viewport>
+      <Track style={TICKER_ANIMATION}>
+        <LivePulse>
+          <Dot backgroundColor="$statusSuccess" />
+          <Text variant="body3" color="$statusSuccess" fontWeight="700" letterSpacing={0.6}>
+            LIVE
+          </Text>
+        </LivePulse>
+        {loop.map((trade, i) => (
+          <TradeItem key={`${trade.id}-${i}`} trade={trade} />
+        ))}
+      </Track>
+    </Viewport>
+  )
+}

--- a/apps/web/src/pages/Launchpad/components/SpotlightCard.tsx
+++ b/apps/web/src/pages/Launchpad/components/SpotlightCard.tsx
@@ -1,0 +1,171 @@
+import { useBondingCurveToken } from 'hooks/useBondingCurveToken'
+import { useLaunchpadTokenPrice } from 'hooks/useLaunchpadTokenPrice'
+import { type LaunchpadToken } from 'hooks/useLaunchpadTokens'
+import { TokenLogo } from 'pages/Launchpad/components/TokenLogo'
+import {
+  GraduatedBadge,
+  PrimaryButton,
+  ProgressBar,
+  ProgressFill,
+  SecondaryButton,
+  getProgressGradient,
+} from 'pages/Launchpad/components/shared'
+import { useCallback, useMemo } from 'react'
+import { useNavigate } from 'react-router'
+import { Flex, Text, styled } from 'ui/src'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { formatUnits } from 'viem'
+
+const Panel = styled(Flex, {
+  position: 'relative',
+  overflow: 'hidden',
+  borderRadius: '$rounded24',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  backgroundColor: '$surface2',
+  padding: '$spacing24',
+  gap: '$spacing20',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  // warm citrus wash so the featured token reads as the page's centrepiece
+  '$platform-web': {
+    background:
+      'radial-gradient(120% 140% at 0% 0%, rgba(247,145,26,0.10) 0%, rgba(255,179,71,0.03) 38%, rgba(255,255,255,0) 70%)',
+  },
+})
+
+const Eyebrow = styled(Text, {
+  variant: 'body4',
+  color: '$accent1',
+  fontWeight: '700',
+  letterSpacing: 1.2,
+})
+
+const TokenTitle = styled(Text, {
+  variant: 'heading3',
+  color: '$neutral1',
+  fontWeight: '700',
+  numberOfLines: 1,
+})
+
+const Stat = styled(Flex, {
+  gap: '$spacing2',
+})
+
+const StatLabel = styled(Text, {
+  variant: 'body4',
+  color: '$neutral3',
+})
+
+const StatValue = styled(Text, {
+  variant: 'subheading2',
+  color: '$neutral1',
+  fontWeight: '700',
+})
+
+interface SpotlightCardProps {
+  token: LaunchpadToken
+}
+
+export function SpotlightCard({ token }: SpotlightCardProps) {
+  const navigate = useNavigate()
+  const chainId = token.chainId as UniverseChainId
+
+  const { progress, reserves } = useBondingCurveToken(token.address, chainId)
+  const { marketCapFormatted: marketCap } = useLaunchpadTokenPrice({
+    tokenAddress: token.address,
+    graduated: token.graduated,
+    v2Pair: token.v2Pair ?? undefined,
+    baseAsset: token.baseAsset,
+    bondingCurveReserves: reserves,
+    chainId,
+  })
+
+  const goToToken = useCallback(() => {
+    navigate(`/launchpad/${token.address}`)
+  }, [navigate, token.address])
+
+  const volume = useMemo(() => {
+    const value = Number(formatUnits(BigInt(token.totalVolumeBase), 18))
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+  }, [token.totalVolumeBase])
+
+  const totalTrades = token.totalBuys + token.totalSells
+  const pct = token.graduated ? 100 : progress
+
+  return (
+    <Panel>
+      <TokenLogo metadataURI={token.metadataURI} symbol={token.symbol} size={84} />
+
+      <Flex flex={1} minWidth={260} gap="$spacing12">
+        <Flex flexDirection="row" alignItems="center" gap="$spacing8" flexWrap="wrap">
+          <Eyebrow>TRENDING NOW</Eyebrow>
+          {token.canGraduate && !token.graduated && (
+            <GraduatedBadge backgroundColor="$accent2" size="sm">
+              <Text variant="body4" color="$accent1" fontWeight="700">
+                Graduating
+              </Text>
+            </GraduatedBadge>
+          )}
+          {token.graduated && (
+            <GraduatedBadge size="sm">
+              <Text variant="body4" color="$statusSuccess" fontWeight="700">
+                Graduated
+              </Text>
+            </GraduatedBadge>
+          )}
+        </Flex>
+
+        <Flex flexDirection="row" alignItems="baseline" gap="$spacing8">
+          <TokenTitle>{token.name || 'Unknown Token'}</TokenTitle>
+          <Text variant="subheading2" color="$neutral2">
+            ${token.symbol || '???'}
+          </Text>
+        </Flex>
+
+        <Flex gap="$spacing6">
+          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+            <Text variant="body3" color="$neutral2">
+              {token.graduated ? 'Graduated to JuiceSwap V2' : 'Progress to graduation'}
+            </Text>
+            <Text variant="body1" color={token.graduated ? '$statusSuccess' : '$accent1'} fontWeight="700">
+              {pct.toFixed(1)}%
+            </Text>
+          </Flex>
+          <ProgressBar size="lg">
+            <ProgressFill size="lg" style={{ width: `${Math.min(pct, 100)}%`, background: getProgressGradient(pct) }} />
+          </ProgressBar>
+        </Flex>
+
+        <Flex flexDirection="row" gap="$spacing24" flexWrap="wrap">
+          <Stat>
+            <StatLabel>Market cap</StatLabel>
+            <StatValue>${marketCap}</StatValue>
+          </Stat>
+          <Stat>
+            <StatLabel>Volume</StatLabel>
+            <StatValue>${volume}</StatValue>
+          </Stat>
+          <Stat>
+            <StatLabel>Trades</StatLabel>
+            <StatValue>{totalTrades.toLocaleString()}</StatValue>
+          </Stat>
+        </Flex>
+      </Flex>
+
+      <Flex gap="$spacing8" minWidth={170} $sm={{ width: '100%' }}>
+        <PrimaryButton fill onPress={goToToken}>
+          <Text variant="buttonLabel2" color="$white">
+            {token.graduated ? 'Trade on Swap' : 'Buy'}
+          </Text>
+        </PrimaryButton>
+        <SecondaryButton fill onPress={goToToken}>
+          <Text variant="buttonLabel2" color="$accent1">
+            View token
+          </Text>
+        </SecondaryButton>
+      </Flex>
+    </Panel>
+  )
+}

--- a/apps/web/src/pages/Launchpad/components/TokenCard.tsx
+++ b/apps/web/src/pages/Launchpad/components/TokenCard.tsx
@@ -7,9 +7,7 @@ import {
   GraduatedBadge,
   ProgressBar,
   ProgressFill,
-  StatLabel,
   StatRow,
-  StatValue,
   getProgressGradient,
 } from 'pages/Launchpad/components/shared'
 import { useCallback, useMemo } from 'react'
@@ -28,16 +26,28 @@ const TokenName = styled(Text, {
   variant: 'body1',
   color: '$neutral1',
   fontWeight: '600',
+  numberOfLines: 1,
 })
 
 const TokenSymbol = styled(Text, {
   variant: 'body3',
   color: '$neutral2',
+  numberOfLines: 1,
 })
 
-const GraduatedText = styled(Text, {
-  variant: 'body4',
-  color: '$statusSuccess',
+const Divider = styled(Flex, {
+  height: 1,
+  backgroundColor: '$surface3',
+})
+
+const StatLabel = styled(Text, {
+  variant: 'body3',
+  color: '$neutral2',
+})
+
+const StatValue = styled(Text, {
+  variant: 'body3',
+  color: '$neutral1',
   fontWeight: '600',
 })
 
@@ -72,7 +82,6 @@ export function TokenCard({ token }: TokenCardProps) {
     return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
   }, [token.totalVolumeBase])
 
-  // Format creator address
   const creatorShort = useMemo(() => {
     return `${token.creator.slice(0, 6)}...${token.creator.slice(-4)}`
   }, [token.creator])
@@ -94,65 +103,76 @@ export function TokenCard({ token }: TokenCardProps) {
     return `${Math.floor(diff / 86400)}d ago`
   }, [token.createdAt])
 
-  // Total trades from indexed data
   const totalTrades = token.totalBuys + token.totalSells
+  const pct = token.graduated ? 100 : progress
 
   return (
-    <Card interactive graduated={token.graduated} onPress={handleClick}>
+    <Card interactive graduated={token.graduated} onPress={handleClick} gap="$spacing16">
       <TokenHeader>
-        <TokenLogo metadataURI={token.metadataURI} symbol={token.symbol} size={48} />
-        <Flex flex={1} gap="$spacing2">
-          <Flex flexDirection="row" alignItems="center" gap="$spacing8">
-            <TokenName>{token.name || 'Unknown Token'}</TokenName>
-            {token.canGraduate && !token.graduated && (
-              <GraduatedBadge backgroundColor="$accent2">
-                <GraduatedText color="$accent1">Ready!</GraduatedText>
-              </GraduatedBadge>
-            )}
-          </Flex>
+        <TokenLogo metadataURI={token.metadataURI} symbol={token.symbol} size={44} />
+        <Flex flex={1} gap="$spacing2" minWidth={0}>
+          <TokenName>{token.name || 'Unknown Token'}</TokenName>
           <TokenSymbol>${token.symbol || '???'}</TokenSymbol>
+        </Flex>
+        <Flex alignItems="flex-end" gap="$spacing2" flexShrink={0}>
+          <Text variant="subheading2" color="$neutral1" fontWeight="700">
+            ${marketCap}
+          </Text>
+          <StatLabel variant="body4" color="$neutral3">
+            Market cap
+          </StatLabel>
         </Flex>
       </TokenHeader>
 
-      <Flex gap="$spacing4">
-        <StatRow>
-          <StatLabel variant="body3">{token.graduated ? 'Graduated' : 'Progress to graduation'}</StatLabel>
-          <StatValue variant="body3">{token.graduated ? '100%' : `${progress.toFixed(1)}%`}</StatValue>
-        </StatRow>
-        <ProgressBar>
+      <Flex gap="$spacing8">
+        <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+          <Flex flexDirection="row" alignItems="center" gap="$spacing6">
+            <Text variant="body3" color="$neutral2">
+              {token.graduated ? 'Graduated to V2' : 'Bonding curve'}
+            </Text>
+            {token.canGraduate && !token.graduated && (
+              <GraduatedBadge backgroundColor="$accent2" size="sm">
+                <Text variant="body4" color="$accent1" fontWeight="700">
+                  Ready
+                </Text>
+              </GraduatedBadge>
+            )}
+          </Flex>
+          <Text variant="body2" color={token.graduated ? '$statusSuccess' : '$accent1'} fontWeight="700">
+            {pct.toFixed(1)}%
+          </Text>
+        </Flex>
+        <ProgressBar size="md">
           <ProgressFill
+            size="md"
             style={{
-              width: `${token.graduated ? 100 : Math.min(progress, 100)}%`,
-              background: getProgressGradient(token.graduated ? 100 : progress),
+              width: `${Math.min(pct, 100)}%`,
+              background: getProgressGradient(pct),
             }}
           />
         </ProgressBar>
       </Flex>
 
-      <StatRow>
-        <StatLabel variant="body3">Market Cap</StatLabel>
-        <StatValue variant="body3">{marketCap} JUSD</StatValue>
-      </StatRow>
+      <Divider />
 
-      <StatRow>
-        <StatLabel variant="body3">Volume</StatLabel>
-        <StatValue variant="body3">{volume} JUSD</StatValue>
-      </StatRow>
-
-      <StatRow>
-        <StatLabel variant="body3">Trades</StatLabel>
-        <StatValue variant="body3">{totalTrades}</StatValue>
-      </StatRow>
-
-      <StatRow>
-        <StatLabel variant="body3">Creator</StatLabel>
-        <StatValue variant="body3">{creatorShort}</StatValue>
-      </StatRow>
-
-      <StatRow>
-        <StatLabel variant="body3">Created</StatLabel>
-        <StatValue variant="body3">{timeAgo}</StatValue>
-      </StatRow>
+      <Flex gap="$spacing8">
+        <StatRow>
+          <StatLabel>Volume</StatLabel>
+          <StatValue>${volume}</StatValue>
+        </StatRow>
+        <StatRow>
+          <StatLabel>Trades</StatLabel>
+          <StatValue>{totalTrades.toLocaleString()}</StatValue>
+        </StatRow>
+        <StatRow>
+          <StatLabel>Creator</StatLabel>
+          <StatValue>{creatorShort}</StatValue>
+        </StatRow>
+        <StatRow>
+          <StatLabel>Created</StatLabel>
+          <StatValue>{timeAgo}</StatValue>
+        </StatRow>
+      </Flex>
     </Card>
   )
 }

--- a/apps/web/src/pages/Launchpad/components/shared.tsx
+++ b/apps/web/src/pages/Launchpad/components/shared.tsx
@@ -1,7 +1,85 @@
 /**
- * Shared styled components for Launchpad pages
+ * Shared styled components for Launchpad pages.
+ *
+ * Design language follows the JuiceSwap brand: citrus-orange accent ($accent1
+ * = #F7911A), the signature citrus gradient (green -> amber -> deep orange), the
+ * Pacifico script for "juice" display accents, and Uniswap-grade clean surfaces.
+ * Mirrors the patterns in pages/Landing/sections/Hero.tsx so the Launchpad reads
+ * as the same product.
  */
 import { Flex, Text, styled } from 'ui/src'
+
+// ============================================================================
+// Brand tokens (kept here so every Launchpad surface stays on-brand)
+// ============================================================================
+
+// Signature citrus gradient: fresh green -> amber -> deep orange. Same stops as
+// the landing hero (HeroGradientTitle) and the "graduation" progress story.
+export const CITRUS_GRADIENT = 'linear-gradient(90deg, #63C87A 0%, #FFB347 50%, #FF7C3A 100%)'
+
+// Warm "juice pour" gradient for hero/section backdrops (deep -> light orange).
+export const JUICE_GRADIENT = 'linear-gradient(135deg, #FF7C3A 0%, #F7911A 45%, #FFB62E 100%)'
+
+// ============================================================================
+// Page backdrop — the subtle citrus wash anchored to the top of every launchpad
+// page. Single source of truth so the listing and Create read as one product.
+//
+// The glow MUST fade to zero alpha before the viewport edges: the page container
+// clips with overflow:hidden, so any residual alpha at x=0/x=100% gets sliced
+// into a hard vertical seam (most visible in dark mode). We therefore (a) keep
+// the radial on a single hue fading to alpha 0, and (b) feather the left/right
+// with a horizontal mask so the wash dissolves into the surface instead of
+// hitting a wall.
+// ============================================================================
+
+const BACKDROP_MASK = 'linear-gradient(to right, transparent 0%, #000 18%, #000 82%, transparent 100%)'
+
+export const LaunchpadBackdrop = styled(Flex, {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  height: 560,
+  zIndex: 0,
+  pointerEvents: 'none',
+  '$platform-web': {
+    background:
+      'radial-gradient(120% 90% at 50% 0%, rgba(247,145,26,0.13) 0%, rgba(255,179,71,0.05) 40%, rgba(247,145,26,0) 72%)',
+    maskImage: BACKDROP_MASK,
+    WebkitMaskImage: BACKDROP_MASK,
+  },
+})
+
+// ============================================================================
+// Display type — Pacifico script with the citrus gradient clipped to the text.
+// Use for short "juice" accent words ("Squeeze", "Juice", "Graduated"). Web
+// applies the gradient fill; native falls back to the accent color.
+// ============================================================================
+
+export const JuiceScriptText = styled(
+  Text as any,
+  {
+    name: 'JuiceScriptText',
+    color: '$accent1',
+    fontWeight: '400',
+    // Pacifico has tall ascenders/descenders; the gradient is clipped to the
+    // text box, so a generous lineHeight is required or descenders (q, y, f)
+    // fall outside the filled box and render transparent ("cut off"). The
+    // landing hero uses ~1.77x for the same reason.
+    '$platform-web': {
+      fontFamily: '"Pacifico", sans-serif',
+      color: 'transparent',
+      backgroundImage: CITRUS_GRADIENT,
+      backgroundRepeat: 'no-repeat',
+      backgroundClip: 'text',
+      WebkitBackgroundClip: 'text',
+      WebkitTextFillColor: 'transparent',
+      display: 'inline-block',
+      overflow: 'visible',
+      paddingBottom: '0.18em',
+    },
+  } as any,
+) as any
 
 // ============================================================================
 // Stats Components (used in TokenCard, TokenDetail, Create)
@@ -22,15 +100,28 @@ export const StatValue = styled(Text, {
   fontWeight: '500',
 })
 
+// A self-contained stat "tile" for headline metrics (launchpad header, chart
+// stats grid). Bordered surface, big value over a muted label.
+export const StatTile = styled(Flex, {
+  flex: 1,
+  minWidth: 132,
+  gap: '$spacing4',
+  padding: '$spacing16',
+  backgroundColor: '$surface1',
+  borderRadius: '$rounded16',
+  borderWidth: 1,
+  borderColor: '$surface3',
+})
+
 // ============================================================================
 // Progress Bar Components (used in TokenCard, TokenDetail)
 // ============================================================================
 
-// Generate gradient from Hero orange to a color based on progress (orange -> green)
+// Generate a gradient from deep citrus orange toward fresh green as a token
+// fills its bonding curve and gets closer to graduation ("ripening").
 export function getProgressGradient(progress: number): string {
   const clampedProgress = Math.min(Math.max(progress, 0), 100) / 100
-  // Hero orange RGB: 255, 124, 58
-  // JuiceSwap green RGB: 99, 200, 122
+  // Hero orange RGB: 255, 124, 58  ->  JuiceSwap green RGB: 99, 200, 122
   const r = Math.round(255 - (255 - 99) * clampedProgress)
   const g = Math.round(124 + (200 - 124) * clampedProgress)
   const b = Math.round(58 + (122 - 58) * clampedProgress)
@@ -44,6 +135,7 @@ export const ProgressBar = styled(Flex, {
     size: {
       sm: { height: 8, borderRadius: '$rounded4' },
       md: { height: 12, borderRadius: '$rounded8' },
+      lg: { height: 16, borderRadius: '$rounded12' },
     },
   } as const,
   defaultVariants: { size: 'sm' },
@@ -56,6 +148,7 @@ export const ProgressFill = styled(Flex, {
     size: {
       sm: { borderRadius: '$rounded4' },
       md: { borderRadius: '$rounded8' },
+      lg: { borderRadius: '$rounded12' },
     },
   } as const,
   defaultVariants: { size: 'sm' },
@@ -76,9 +169,10 @@ export const Card = styled(Flex, {
     interactive: {
       true: {
         cursor: 'pointer',
+        animation: 'quick',
         hoverStyle: {
           borderColor: '$accent1',
-          backgroundColor: '$surface3',
+          y: -2,
         },
         pressStyle: {
           scale: 0.98,
@@ -89,6 +183,88 @@ export const Card = styled(Flex, {
       true: {
         borderTopWidth: 2,
         borderTopColor: '$statusSuccess',
+      },
+    },
+    emphasis: {
+      // accent-edged card for the "primary" surface (e.g. chart card)
+      true: {
+        borderTopWidth: 2,
+        borderTopColor: '$accent1',
+      },
+    },
+  } as const,
+})
+
+// ============================================================================
+// Buttons (unified primary/secondary, fixes hover that hid the label)
+// ============================================================================
+
+const ButtonBase = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '$spacing8',
+  borderRadius: '$rounded12',
+  cursor: 'pointer',
+  flexShrink: 0,
+  animation: 'quick',
+  userSelect: 'none',
+  variants: {
+    size: {
+      sm: { height: 36, paddingHorizontal: '$spacing16' },
+      md: { height: 44, paddingHorizontal: '$spacing20' },
+      lg: { height: 48, paddingHorizontal: '$spacing24' },
+    },
+    fill: {
+      true: { width: '100%' },
+    },
+    disabled: {
+      true: { cursor: 'not-allowed', opacity: 0.6, pointerEvents: 'none' },
+    },
+  } as const,
+  defaultVariants: { size: 'md' },
+})
+
+// Solid citrus button. Hover darkens (does NOT fade to a transparent fill,
+// which previously made the white label disappear).
+export const PrimaryButton = styled(ButtonBase, {
+  backgroundColor: '$accent1',
+  hoverStyle: { backgroundColor: '$accent1Hovered' },
+  pressStyle: { backgroundColor: '$accent1Hovered', scale: 0.99 },
+})
+
+// Soft citrus button on a pale orange fill, for secondary actions.
+export const SecondaryButton = styled(ButtonBase, {
+  backgroundColor: '$accent2',
+  borderWidth: 1,
+  borderColor: '$accent1',
+  hoverStyle: { backgroundColor: '$accent2Hovered' },
+  pressStyle: { scale: 0.99 },
+})
+
+// ============================================================================
+// Pills (filters, sort, segmented controls) — single source of truth so the
+// launchpad listing and token detail controls look identical.
+// ============================================================================
+
+export const Pill = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing6',
+  paddingHorizontal: '$spacing16',
+  paddingVertical: '$spacing8',
+  borderRadius: '$roundedFull',
+  cursor: 'pointer',
+  backgroundColor: '$surface2',
+  borderWidth: 1,
+  borderColor: '$surface3',
+  animation: 'quick',
+  hoverStyle: { borderColor: '$accent1' },
+  variants: {
+    active: {
+      true: {
+        backgroundColor: '$accent2',
+        borderColor: '$accent1',
       },
     },
   } as const,
@@ -104,6 +280,7 @@ export const BackButton = styled(Flex, {
   gap: '$spacing8',
   cursor: 'pointer',
   paddingVertical: '$spacing8',
+  animation: 'quick',
   hoverStyle: {
     opacity: 0.7,
   },
@@ -114,8 +291,11 @@ export const BackButton = styled(Flex, {
 // ============================================================================
 
 export const GraduatedBadge = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing4',
   backgroundColor: '$statusSuccess2',
-  borderRadius: '$rounded8',
+  borderRadius: '$roundedFull',
   variants: {
     size: {
       sm: { paddingHorizontal: '$spacing8', paddingVertical: '$spacing4' },
@@ -123,4 +303,16 @@ export const GraduatedBadge = styled(Flex, {
     },
   } as const,
   defaultVariants: { size: 'sm' },
+})
+
+// Trust signal pill — the launchpad's anti-rug wedge (locked liquidity,
+// immutable metadata, JUSD-backed). Success-tinted, icon + short label.
+export const TrustBadge = styled(Flex, {
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$spacing6',
+  paddingHorizontal: '$spacing12',
+  paddingVertical: '$spacing6',
+  borderRadius: '$roundedFull',
+  backgroundColor: '$statusSuccess2',
 })

--- a/apps/web/src/pages/Launchpad/index.tsx
+++ b/apps/web/src/pages/Launchpad/index.tsx
@@ -27,6 +27,7 @@ const PageContainer = styled(Flex, {
   paddingTop: '$spacing24',
   paddingBottom: '$spacing60',
   paddingHorizontal: '$spacing20',
+  $sm: { paddingHorizontal: '$spacing12' },
 })
 
 const ContentWrapper = styled(Flex, {
@@ -66,6 +67,7 @@ const ControlsRow = styled(Flex, {
   alignItems: 'center',
   flexWrap: 'wrap',
   gap: '$spacing12',
+  $sm: { flexDirection: 'column', alignItems: 'stretch', justifyContent: 'flex-start' },
 })
 
 const PillGroup = styled(Flex, {
@@ -187,7 +189,7 @@ export default function Launchpad() {
         <LaunchpadBackdrop />
         <ContentWrapper>
           <TopBar>
-            <Flex gap="$spacing4" flex={1} minWidth={240}>
+            <Flex gap="$spacing4" flex={1} minWidth={240} $sm={{ minWidth: '100%' }}>
               <Eyebrow>JUICESWAP LAUNCHPAD</Eyebrow>
               <JuiceScriptText fontSize={46} lineHeight={68} $md={{ fontSize: 40, lineHeight: 60 }} $sm={{ fontSize: 32, lineHeight: 48 }}>
                 freshly squeezed
@@ -197,7 +199,7 @@ export default function Launchpad() {
                 active · {(stats?.graduatedTokens ?? 0).toLocaleString()} graduated
               </StatsLine>
             </Flex>
-            <PrimaryButton size="lg" onPress={handleCreateToken}>
+            <PrimaryButton size="lg" onPress={handleCreateToken} $sm={{ width: '100%' }}>
               <Plus size="$icon.20" color="$white" />
               <Text variant="buttonLabel2" color="$white">
                 Create Token

--- a/apps/web/src/pages/Launchpad/index.tsx
+++ b/apps/web/src/pages/Launchpad/index.tsx
@@ -1,4 +1,3 @@
-import { DropdownSelector, InternalMenuItem } from 'components/DropdownSelector'
 import { useAccount } from 'hooks/useAccount'
 import {
   useLaunchpadStats,
@@ -6,115 +5,80 @@ import {
   type LaunchpadFilterType,
   type LaunchpadSortType,
 } from 'hooks/useLaunchpadTokens'
+import { LiveTicker } from 'pages/Launchpad/components/LiveTicker'
+import { SpotlightCard } from 'pages/Launchpad/components/SpotlightCard'
 import { TokenCard } from 'pages/Launchpad/components/TokenCard'
+import { JuiceScriptText, LaunchpadBackdrop, Pill, PrimaryButton } from 'pages/Launchpad/components/shared'
 import { FILTER_OPTIONS, SORT_OPTIONS } from 'pages/Launchpad/constants'
 import { useCallback, useState } from 'react'
-import { Check } from 'react-feather'
 import { useNavigate } from 'react-router'
-import { Flex, Text, styled, useMedia, useSporeColors } from 'ui/src'
+import { Flex, Text, styled } from 'ui/src'
 import { Plus } from 'ui/src/components/icons/Plus'
-import { fonts } from 'ui/src/theme/fonts'
 import { useEnabledChains } from 'uniswap/src/features/chains/hooks/useEnabledChains'
 import Trace from 'uniswap/src/features/telemetry/Trace'
 import { InterfacePageName } from 'uniswap/src/features/telemetry/constants'
 
 const PageContainer = styled(Flex, {
+  position: 'relative',
+  overflow: 'hidden',
   width: '100%',
   minHeight: '100vh',
   backgroundColor: '$surface1',
-  paddingTop: '$spacing20',
+  paddingTop: '$spacing24',
   paddingBottom: '$spacing60',
   paddingHorizontal: '$spacing20',
 })
 
 const ContentWrapper = styled(Flex, {
+  position: 'relative',
+  zIndex: 1,
   maxWidth: 1200,
   width: '100%',
   alignSelf: 'center',
-  gap: '$spacing32',
+  gap: '$spacing24',
 })
 
-const HeaderSection = styled(Flex, {
-  gap: '$spacing16',
-  alignItems: 'center',
-  justifyContent: 'space-between',
+const TopBar = styled(Flex, {
   flexDirection: 'row',
+  alignItems: 'flex-end',
+  justifyContent: 'space-between',
+  gap: '$spacing20',
   flexWrap: 'wrap',
-  paddingBottom: '$spacing24',
-  borderBottomWidth: 1,
-  borderBottomColor: '$surface3',
   animation: 'quick',
-  enterStyle: {
-    opacity: 0,
-    y: 20,
-  },
+  enterStyle: { opacity: 0, y: 12 },
 })
 
-const TitleSection = styled(Flex, {
-  gap: '$spacing8',
-  flex: 1,
-  minWidth: 0,
+const Eyebrow = styled(Text, {
+  variant: 'body3',
+  color: '$accent1',
+  fontWeight: '700',
+  letterSpacing: 1.4,
 })
 
-const MainTitle = styled(Text, {
-  variant: 'heading2',
-  color: '$neutral1',
-  fontWeight: 'bold',
-})
-
-const Subtitle = styled(Text, {
+const StatsLine = styled(Text, {
   variant: 'body2',
   color: '$neutral2',
 })
 
-const CreateButton = styled(Flex, {
+const ControlsRow = styled(Flex, {
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+  gap: '$spacing12',
+})
+
+const PillGroup = styled(Flex, {
   flexDirection: 'row',
   alignItems: 'center',
   gap: '$spacing8',
-  paddingHorizontal: '$spacing24',
-  paddingVertical: '$spacing16',
-  backgroundColor: '$accent1',
-  borderRadius: '$rounded12',
-  cursor: 'pointer',
-  flexShrink: 0,
-  pressStyle: {
-    backgroundColor: '$accent2',
-  },
-  hoverStyle: {
-    backgroundColor: '$accent2',
-  },
-})
-
-const FilterTabs = styled(Flex, {
-  flexDirection: 'row',
-  gap: '$spacing8',
   flexWrap: 'wrap',
-  animation: 'quick',
-  enterStyle: {
-    opacity: 0,
-    y: 20,
-  },
 })
 
-const FilterTab = styled(Flex, {
-  paddingHorizontal: '$spacing16',
-  paddingVertical: '$spacing8',
-  borderRadius: '$rounded12',
-  cursor: 'pointer',
-  backgroundColor: '$surface2',
-  borderWidth: 1,
-  borderColor: '$surface3',
-  hoverStyle: {
-    borderColor: '$accent1',
-  },
-  variants: {
-    active: {
-      true: {
-        backgroundColor: '$accent2',
-        borderColor: '$accent1',
-      },
-    },
-  } as const,
+const GroupLabel = styled(Text, {
+  variant: 'body3',
+  color: '$neutral3',
+  fontWeight: '600',
 })
 
 const TokenGrid = styled(Flex, {
@@ -122,23 +86,14 @@ const TokenGrid = styled(Flex, {
   flexWrap: 'wrap',
   gap: '$spacing16',
   animation: 'quick',
-  enterStyle: {
-    opacity: 0,
-    y: 20,
-  },
+  enterStyle: { opacity: 0, y: 16 },
 })
 
 const TokenCardWrapper = styled(Flex, {
   width: 'calc(25% - 12px)',
-  $lg: {
-    width: 'calc(33.333% - 11px)',
-  },
-  $md: {
-    width: 'calc(50% - 8px)',
-  },
-  $sm: {
-    width: '100%',
-  },
+  $lg: { width: 'calc(33.333% - 11px)' },
+  $md: { width: 'calc(50% - 8px)' },
+  $sm: { width: '100%' },
 })
 
 const SkeletonCard = styled(Flex, {
@@ -146,8 +101,8 @@ const SkeletonCard = styled(Flex, {
   borderRadius: '$rounded16',
   borderWidth: 1,
   borderColor: '$surface3',
-  padding: '$spacing16',
-  gap: '$spacing12',
+  padding: '$spacing20',
+  gap: '$spacing16',
 })
 
 const SkeletonBox = styled(Flex, {
@@ -160,37 +115,7 @@ const EmptyState = styled(Flex, {
   alignItems: 'center',
   justifyContent: 'center',
   padding: '$spacing48',
-  gap: '$spacing16',
-})
-
-const StatsBar = styled(Flex, {
-  flexDirection: 'row',
-  gap: '$spacing24',
-  flexWrap: 'wrap',
-  animation: 'quick',
-  enterStyle: {
-    opacity: 0,
-    y: 20,
-  },
-})
-
-const StatItem = styled(Flex, {
-  gap: '$spacing4',
-})
-
-const StatValue = styled(Text, {
-  variant: 'heading3',
-  color: '$neutral1',
-  fontWeight: '600',
-  $sm: {
-    fontSize: fonts.subheading1.fontSize,
-    lineHeight: fonts.subheading1.lineHeight,
-  },
-})
-
-const StatLabel = styled(Text, {
-  variant: 'body3',
-  color: '$neutral2',
+  gap: '$spacing8',
 })
 
 const TOKENS_PER_PAGE = 20
@@ -199,15 +124,13 @@ function TokenCardSkeleton() {
   return (
     <SkeletonCard>
       <Flex flexDirection="row" alignItems="center" gap="$spacing12">
-        <SkeletonBox width={48} height={48} borderRadius="$roundedFull" />
+        <SkeletonBox width={44} height={44} borderRadius="$roundedFull" />
         <Flex flex={1} gap="$spacing8">
           <SkeletonBox width="60%" height={20} />
           <SkeletonBox width="40%" height={16} />
         </Flex>
       </Flex>
-      <Flex gap="$spacing4">
-        <SkeletonBox width="100%" height={8} />
-      </Flex>
+      <SkeletonBox width="100%" height={12} />
       <SkeletonBox width="100%" height={16} />
       <SkeletonBox width="70%" height={16} />
     </SkeletonCard>
@@ -221,15 +144,11 @@ export default function Launchpad() {
   const [filter, setFilter] = useState<LaunchpadFilterType>('all')
   const [sort, setSort] = useState<LaunchpadSortType>('volume')
   const [page, setPage] = useState(0)
-  const [openMenu, setOpenMenu] = useState<'filter' | 'sort' | null>(null)
-  const media = useMedia()
-  const colors = useSporeColors()
 
-  // Use the user's connected chain, or fall back to default chain if not connected
-  // This ensures we always filter by a specific chain and never show mixed testnet/mainnet tokens
+  // Use the user's connected chain, or fall back to default chain if not connected,
+  // so we never show mixed testnet/mainnet tokens.
   const chainId = account.chainId ?? defaultChainId
 
-  // Fetch tokens from Ponder API with filtering by current chain
   const { data: tokensData, isLoading: tokensLoading } = useLaunchpadTokens({
     filter,
     page,
@@ -238,6 +157,10 @@ export default function Launchpad() {
     sort,
   })
   const { data: stats, isLoading: statsLoading } = useLaunchpadStats(chainId)
+
+  // Featured "trending" token = the highest-volume active launch (independent of filters).
+  const { data: featuredData } = useLaunchpadTokens({ filter: 'active', page: 0, limit: 1, chainId, sort: 'volume' })
+  const featured = featuredData?.tokens[0]
 
   const tokens = tokensData?.tokens || []
   const pagination = tokensData?.pagination
@@ -261,156 +184,54 @@ export default function Launchpad() {
   return (
     <Trace logImpression page={InterfacePageName.LaunchpadPage}>
       <PageContainer>
+        <LaunchpadBackdrop />
         <ContentWrapper>
-          <HeaderSection>
-            <TitleSection>
-              <MainTitle>Launchpad</MainTitle>
-              <Subtitle>Launch tokens with bonding curves. Graduate to JuiceSwap V2 with locked liquidity.</Subtitle>
-            </TitleSection>
-            <CreateButton onPress={handleCreateToken}>
-              <Plus size="$icon.16" color="$white" />
-              <Text variant="buttonLabel4" color="$white">
+          <TopBar>
+            <Flex gap="$spacing4" flex={1} minWidth={240}>
+              <Eyebrow>JUICESWAP LAUNCHPAD</Eyebrow>
+              <JuiceScriptText fontSize={46} lineHeight={68} $md={{ fontSize: 40, lineHeight: 60 }} $sm={{ fontSize: 32, lineHeight: 48 }}>
+                freshly squeezed
+              </JuiceScriptText>
+              <StatsLine>
+                {(stats?.totalTokens ?? 0).toLocaleString()} launches · {(stats?.activeTokens ?? 0).toLocaleString()}{' '}
+                active · {(stats?.graduatedTokens ?? 0).toLocaleString()} graduated
+              </StatsLine>
+            </Flex>
+            <PrimaryButton size="lg" onPress={handleCreateToken}>
+              <Plus size="$icon.20" color="$white" />
+              <Text variant="buttonLabel2" color="$white">
                 Create Token
               </Text>
-            </CreateButton>
-          </HeaderSection>
+            </PrimaryButton>
+          </TopBar>
 
-          <StatsBar>
-            <StatItem>
-              <StatValue>{stats?.totalTokens || 0}</StatValue>
-              <StatLabel>Total Tokens</StatLabel>
-            </StatItem>
-            <StatItem>
-              <StatValue>{stats?.activeTokens || 0}</StatValue>
-              <StatLabel>Active</StatLabel>
-            </StatItem>
-            <StatItem>
-              <StatValue>{stats?.graduatingTokens || 0}</StatValue>
-              <StatLabel>Graduating</StatLabel>
-            </StatItem>
-            <StatItem>
-              <StatValue>{stats?.graduatedTokens || 0}</StatValue>
-              <StatLabel>Graduated</StatLabel>
-            </StatItem>
-          </StatsBar>
+          {featured && <SpotlightCard token={featured} />}
 
-          <Flex gap="$spacing24">
-            <Flex
-              flexDirection="row"
-              justifyContent="space-between"
-              alignItems="center"
-              flexWrap="wrap"
-              gap="$spacing16"
-            >
-              {media.sm ? (
-                <Flex
-                  row
-                  gap="$spacing12"
-                  alignItems="center"
-                  flexWrap="nowrap"
-                  width="100%"
-                  justifyContent="space-between"
-                >
-                  <DropdownSelector
-                    isOpen={openMenu === 'filter'}
-                    toggleOpen={(open) => setOpenMenu(open ? 'filter' : null)}
-                    menuLabel={
-                      <Text variant="buttonLabel3" width="max-content">
-                        {FILTER_OPTIONS.find((o) => o.value === filter)?.label ?? 'All'}
-                      </Text>
-                    }
-                    dropdownStyle={{ width: 200 }}
-                    buttonStyle={{ height: 40, width: 'max-content' }}
-                    containerStyle={{ width: 'auto' }}
-                    adaptToSheet
-                    allowFlip
-                    alignRight={!media.lg}
-                  >
-                    {FILTER_OPTIONS.map((opt) => (
-                      <InternalMenuItem
-                        key={opt.value}
-                        onPress={() => {
-                          handleFilterChange(opt.value)
-                          setOpenMenu(null)
-                        }}
-                      >
-                        {opt.label}
-                        {filter === opt.value && <Check size={16} color={colors.accent1.val} />}
-                      </InternalMenuItem>
-                    ))}
-                  </DropdownSelector>
-                  <DropdownSelector
-                    isOpen={openMenu === 'sort'}
-                    toggleOpen={(open) => setOpenMenu(open ? 'sort' : null)}
-                    menuLabel={
-                      <Text variant="buttonLabel3" width="max-content">
-                        {SORT_OPTIONS.find((o) => o.value === sort)?.label ?? 'Volume'}
-                      </Text>
-                    }
-                    dropdownStyle={{ width: 160 }}
-                    buttonStyle={{ height: 40, width: 'max-content' }}
-                    containerStyle={{ width: 'auto' }}
-                    allowFlip
-                    alignRight={!media.lg}
-                  >
-                    {SORT_OPTIONS.map((opt) => (
-                      <InternalMenuItem
-                        key={opt.value}
-                        onPress={() => {
-                          handleSortChange(opt.value)
-                          setOpenMenu(null)
-                        }}
-                      >
-                        {opt.label}
-                        {sort === opt.value && <Check size={16} color={colors.accent1.val} />}
-                      </InternalMenuItem>
-                    ))}
-                  </DropdownSelector>
-                </Flex>
-              ) : (
-                <>
-                  <FilterTabs>
-                    <FilterTab active={filter === 'all'} onPress={() => handleFilterChange('all')}>
-                      <Text variant="body2" color={filter === 'all' ? '$accent1' : '$neutral2'}>
-                        All
-                      </Text>
-                    </FilterTab>
-                    <FilterTab active={filter === 'active'} onPress={() => handleFilterChange('active')}>
-                      <Text variant="body2" color={filter === 'active' ? '$accent1' : '$neutral2'}>
-                        Active
-                      </Text>
-                    </FilterTab>
-                    <FilterTab active={filter === 'graduating'} onPress={() => handleFilterChange('graduating')}>
-                      <Text variant="body2" color={filter === 'graduating' ? '$accent1' : '$neutral2'}>
-                        Graduating Soon
-                      </Text>
-                    </FilterTab>
-                    <FilterTab active={filter === 'graduated'} onPress={() => handleFilterChange('graduated')}>
-                      <Text variant="body2" color={filter === 'graduated' ? '$accent1' : '$neutral2'}>
-                        Graduated
-                      </Text>
-                    </FilterTab>
-                  </FilterTabs>
-                  <FilterTabs>
-                    <FilterTab active={sort === 'volume'} onPress={() => handleSortChange('volume')}>
-                      <Text variant="body2" color={sort === 'volume' ? '$accent1' : '$neutral2'}>
-                        Volume
-                      </Text>
-                    </FilterTab>
-                    <FilterTab active={sort === 'newest'} onPress={() => handleSortChange('newest')}>
-                      <Text variant="body2" color={sort === 'newest' ? '$accent1' : '$neutral2'}>
-                        Newest
-                      </Text>
-                    </FilterTab>
-                    <FilterTab active={sort === 'trades'} onPress={() => handleSortChange('trades')}>
-                      <Text variant="body2" color={sort === 'trades' ? '$accent1' : '$neutral2'}>
-                        Trades
-                      </Text>
-                    </FilterTab>
-                  </FilterTabs>
-                </>
-              )}
-            </Flex>
+          <LiveTicker chainId={chainId} />
+
+          <Flex gap="$spacing20">
+            <ControlsRow>
+              <PillGroup>
+                <GroupLabel>Show</GroupLabel>
+                {FILTER_OPTIONS.map((opt) => (
+                  <Pill key={opt.value} active={filter === opt.value} onPress={() => handleFilterChange(opt.value)}>
+                    <Text variant="buttonLabel3" color={filter === opt.value ? '$accent1' : '$neutral2'}>
+                      {opt.label}
+                    </Text>
+                  </Pill>
+                ))}
+              </PillGroup>
+              <PillGroup>
+                <GroupLabel>Sort</GroupLabel>
+                {SORT_OPTIONS.map((opt) => (
+                  <Pill key={opt.value} active={sort === opt.value} onPress={() => handleSortChange(opt.value)}>
+                    <Text variant="buttonLabel3" color={sort === opt.value ? '$accent1' : '$neutral2'}>
+                      {opt.label}
+                    </Text>
+                  </Pill>
+                ))}
+              </PillGroup>
+            </ControlsRow>
 
             {isLoading ? (
               <TokenGrid>
@@ -426,7 +247,7 @@ export default function Launchpad() {
                   No tokens yet
                 </Text>
                 <Text variant="body2" color="$neutral2">
-                  Be the first to create a token on the launchpad!
+                  Be the first to squeeze a token onto the launchpad.
                 </Text>
               </EmptyState>
             ) : (
@@ -440,31 +261,28 @@ export default function Launchpad() {
             )}
 
             {pagination && pagination.totalPages > 1 && (
-              <Flex flexDirection="row" justifyContent="center" gap="$spacing8">
-                <FilterTab
+              <Flex flexDirection="row" justifyContent="center" alignItems="center" gap="$spacing8">
+                <Pill
                   onPress={page === 0 ? undefined : () => setPage(Math.max(0, page - 1))}
-                  style={{ opacity: page === 0 ? 0.5 : 1, cursor: page === 0 ? 'not-allowed' : 'pointer' }}
+                  opacity={page === 0 ? 0.5 : 1}
+                  cursor={page === 0 ? 'not-allowed' : 'pointer'}
                 >
-                  <Text variant="body2" color="$neutral2">
+                  <Text variant="buttonLabel3" color="$neutral2">
                     Previous
                   </Text>
-                </FilterTab>
-                <FilterTab>
-                  <Text variant="body2" color="$neutral1">
-                    Page {page + 1} of {pagination.totalPages}
-                  </Text>
-                </FilterTab>
-                <FilterTab
+                </Pill>
+                <Text variant="body3" color="$neutral2">
+                  Page {page + 1} of {pagination.totalPages}
+                </Text>
+                <Pill
                   onPress={page + 1 >= pagination.totalPages ? undefined : () => setPage(page + 1)}
-                  style={{
-                    opacity: page + 1 >= pagination.totalPages ? 0.5 : 1,
-                    cursor: page + 1 >= pagination.totalPages ? 'not-allowed' : 'pointer',
-                  }}
+                  opacity={page + 1 >= pagination.totalPages ? 0.5 : 1}
+                  cursor={page + 1 >= pagination.totalPages ? 'not-allowed' : 'pointer'}
                 >
-                  <Text variant="body2" color="$neutral2">
+                  <Text variant="buttonLabel3" color="$neutral2">
                     Next
                   </Text>
-                </FilterTab>
+                </Pill>
               </Flex>
             )}
           </Flex>

--- a/apps/web/src/pages/Launchpad/useLaunchpadMotion.ts
+++ b/apps/web/src/pages/Launchpad/useLaunchpadMotion.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/**
+ * Tracks the OS/browser "reduce motion" accessibility setting. Low-end
+ * phones in battery-saver mode commonly enable this, so honouring it is
+ * both an a11y win and a performance win — it lets us drop the
+ * launchpad's continuous marquee/shimmer/sheen animations entirely.
+ *
+ * SSR-safe (returns false until mounted) and listens for live changes.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined
+    }
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const update = (): void => setReduced(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+  return reduced
+}
+
+/**
+ * Gate for the launchpad's continuous (infinite) animations.
+ *
+ * Returns a callback `ref` to attach to the animated element plus an
+ * `active` flag that is true only when it is actually worth spending
+ * frames: the user does not prefer reduced motion, the tab is visible,
+ * and the element is on screen. Off-screen marquees/shimmers on an old
+ * GPU burn battery for nothing — callers pause via `animationPlayState`
+ * (or skip rendering decorative overlays) when `active` is false.
+ *
+ * A callback ref (not a ref object) so elements that mount late — e.g.
+ * the ticker, which renders nothing until trades arrive — still get
+ * observed the moment they appear.
+ *
+ * `reduced` is surfaced separately so callers can fully remove a
+ * decorative element (rather than just freeze it mid-frame) when the
+ * user opts out of motion.
+ */
+export function useLaunchpadAnimation(): {
+  ref: (el: unknown) => void
+  active: boolean
+  reduced: boolean
+} {
+  const [node, setNode] = useState<Element | null>(null)
+  const reduced = usePrefersReducedMotion()
+  const [inView, setInView] = useState(true)
+  const [visible, setVisible] = useState(true)
+
+  // `unknown` keeps the callback assignable to any host ref type
+  // (Tamagui types refs as TamaguiElement); narrowed at runtime.
+  const ref = useCallback((el: unknown) => {
+    setNode(el instanceof Element ? el : null)
+  }, [])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined
+    }
+    const onVisibility = (): void => setVisible(!document.hidden)
+    onVisibility()
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => document.removeEventListener('visibilitychange', onVisibility)
+  }, [])
+
+  useEffect(() => {
+    if (!node) {
+      return undefined
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries.length) {
+          return
+        }
+        const [entry] = entries
+        setInView(entry.isIntersecting)
+      },
+      { threshold: 0 },
+    )
+    io.observe(node)
+    return () => io.disconnect()
+  }, [node])
+
+  return { ref, active: !reduced && inView && visible, reduced }
+}


### PR DESCRIPTION
## Summary

Two parts, stacked into one launchpad upgrade:

### 1. Launchpad token charts
Price chart on the token detail page (USD/JUSD toggle, interval pills, lightweight-charts), candle data wiring, and supporting hook/ABI updates.

### 2. Brand revamp (new design)
State-of-the-art redesign of the launchpad on the JuiceSwap brand (citrus accent `#F7911A`, signature citrus gradient, Pacifico display accent, Basel UI, light-first surfaces):
- **Listing**: Pacifico "freshly squeezed" hero, citrus backdrop wash, `SpotlightCard` (trending token), `LiveTicker`, pill filter/sort, restyled `TokenCard` grid.
- **Token detail**: restyled layout, `BondingCurveHero` with the graduation-progress citrus gradient and the "liquidity permanently locked" trust signal, `ActivityTable`.
- **Create**: Pacifico hero, anti-rug trust badges (locked liquidity, immutable metadata, JUSD-backed, 1% flat fee), shared `Card`/`PrimaryButton`.
- **Shared design system**: `shared.tsx` brand tokens + components (citrus gradient, `JuiceScriptText`, `Card`, `PrimaryButton`, `Pill`, `TrustBadge`, `LaunchpadBackdrop`) so every launchpad surface stays on-brand.

### 3. Mobile polish (responsive, mobile-only)
Desktop layout is unchanged — every rule lives in `$sm`/`$md` max-width media props (no `isMobile` hook).
- **Token detail**: on mobile the two columns collapse via `display: contents` and each panel is reordered with `$md={{ order }}` so the sequence is **identity → stats → bonding curve → Buy/Sell → chart → activity → token info → about**. The Buy/Sell + Connect-Wallet action is now reachable without scrolling past the (empty) chart and the long trade list.
- **Recent activity**: capped to ~420px with internal scroll on mobile so it no longer dominates the page; desktop keeps full height.
- **Listing**: full-width "Create Token" button on its own row at `$sm`; filter/sort controls stack cleanly.
- **Tighter page padding** at `$sm` across listing, create, and detail.

## Stack

Dev buy stacks on top of this: JuiceSwapxyz/bapp#772 (base = this branch). Backend: JuiceSwapxyz/ponder#140, JuiceSwapxyz/api#268.

