### PR TITLE
fix(swap): surface JuiceSwap price impact and critical warnings (#764)

### DIFF
--- a/packages/uniswap/src/features/transactions/hooks/useParsedTransactionWarnings.test.ts
+++ b/packages/uniswap/src/features/transactions/hooks/useParsedTransactionWarnings.test.ts
@@ -1,0 +1,49 @@
+import { Warning, WarningAction, WarningLabel, WarningSeverity } from 'uniswap/src/components/modals/WarningModal/types'
+import { getParsedWarnings } from 'uniswap/src/features/transactions/hooks/useParsedTransactionWarnings'
+
+const insufficientFundsWarning: Warning = {
+  type: WarningLabel.InsufficientFunds,
+  severity: WarningSeverity.Medium,
+  action: WarningAction.DisableReview,
+  title: 'Not enough USDC.e',
+}
+
+const highPriceImpactWarning: Warning = {
+  type: WarningLabel.PriceImpactHigh,
+  severity: WarningSeverity.High,
+  action: WarningAction.WarnBeforeSubmit,
+  title: 'High price impact',
+}
+
+const fiatLossWarning: Warning = {
+  type: WarningLabel.FiatLossHigh,
+  severity: WarningSeverity.High,
+  action: WarningAction.WarnBeforeSubmit,
+  title: 'Output value too low',
+}
+
+describe(getParsedWarnings, () => {
+  it('keeps a critical price-impact warning inline even when funds are insufficient (#764)', () => {
+    const parsed = getParsedWarnings([insufficientFundsWarning, highPriceImpactWarning])
+
+    // The inline slot surfaces the critical loss warning, not the funds message...
+    expect(parsed.formScreenWarning?.warning.type).toBe(WarningLabel.PriceImpactHigh)
+    expect(parsed.formScreenWarning?.displayedInline).toBe(true)
+    // ...while the insufficient-funds warning is still exposed for the review button.
+    expect(parsed.insufficientBalanceWarning?.type).toBe(WarningLabel.InsufficientFunds)
+  })
+
+  it('keeps a critical fiat-loss warning inline even when funds are insufficient (#764)', () => {
+    const parsed = getParsedWarnings([insufficientFundsWarning, fiatLossWarning])
+
+    expect(parsed.formScreenWarning?.warning.type).toBe(WarningLabel.FiatLossHigh)
+    expect(parsed.formScreenWarning?.displayedInline).toBe(true)
+  })
+
+  it('hides the inline slot for a lone insufficient-funds warning', () => {
+    const parsed = getParsedWarnings([insufficientFundsWarning])
+
+    expect(parsed.formScreenWarning?.warning.type).toBe(WarningLabel.InsufficientFunds)
+    expect(parsed.formScreenWarning?.displayedInline).toBe(false)
+  })
+})

--- a/packages/uniswap/src/features/transactions/hooks/useParsedTransactionWarnings.tsx
+++ b/packages/uniswap/src/features/transactions/hooks/useParsedTransactionWarnings.tsx
@@ -25,26 +25,28 @@ export const getNetworkWarning = (t: AppTFunction): Warning => ({
 })
 
 // Format an array of warnings into the ParsedWarnings type
+export function getParsedWarnings(warnings: Warning[]): ParsedWarnings {
+  const blockingWarning = warnings.find(
+    (warning) => warning.action === WarningAction.DisableReview || warning.action === WarningAction.DisableSubmit,
+  )
+
+  const insufficientBalanceWarning = warnings.find((warning) => warning.type === WarningLabel.InsufficientFunds)
+  const insufficientGasFundsWarning = warnings.find((warning) => warning.type === WarningLabel.InsufficientGasFunds)
+  const priceImpactWarning = warnings.find((warning) => isPriceImpactWarning(warning))
+
+  return {
+    blockingWarning,
+    formScreenWarning: getFormScreenWarning(warnings),
+    insufficientBalanceWarning,
+    insufficientGasFundsWarning,
+    priceImpactWarning,
+    reviewScreenWarning: getReviewScreenWarning(warnings),
+    warnings,
+  }
+}
+
 export function useFormattedWarnings(warnings: Warning[]): ParsedWarnings {
-  return useMemo(() => {
-    const blockingWarning = warnings.find(
-      (warning) => warning.action === WarningAction.DisableReview || warning.action === WarningAction.DisableSubmit,
-    )
-
-    const insufficientBalanceWarning = warnings.find((warning) => warning.type === WarningLabel.InsufficientFunds)
-    const insufficientGasFundsWarning = warnings.find((warning) => warning.type === WarningLabel.InsufficientGasFunds)
-    const priceImpactWarning = warnings.find((warning) => isPriceImpactWarning(warning))
-
-    return {
-      blockingWarning,
-      formScreenWarning: getFormScreenWarning(warnings),
-      insufficientBalanceWarning,
-      insufficientGasFundsWarning,
-      priceImpactWarning,
-      reviewScreenWarning: getReviewScreenWarning(warnings),
-      warnings,
-    }
-  }, [warnings])
+  return useMemo(() => getParsedWarnings(warnings), [warnings])
 }
 
 function getReviewScreenWarning(warnings: Warning[]): ParsedWarnings['reviewScreenWarning'] | undefined {
@@ -62,6 +64,19 @@ function getFormScreenWarning(warnings: Warning[]): ParsedWarnings['reviewScreen
   const insufficientBalanceWarning = warnings.find((warning) => warning.type === WarningLabel.InsufficientFunds)
 
   if (insufficientBalanceWarning) {
+    // An insufficient-funds state must not hide a critical (high-severity)
+    // price-impact or value-loss warning — surface the critical one inline
+    // instead, while the "Not enough" message still drives the review button
+    // text (issue #764).
+    const criticalLossWarning = warnings.find(
+      (warning) =>
+        warning.severity >= WarningSeverity.High &&
+        (isPriceImpactWarning(warning) || warning.type === WarningLabel.FiatLossHigh),
+    )
+    if (criticalLossWarning) {
+      return getWarningWithStyle({ warning: criticalLossWarning, displayedInline: true })
+    }
+
     return {
       warning: insufficientBalanceWarning,
       color: getAlertColor(WarningSeverity.Medium),

--- a/packages/uniswap/src/features/transactions/swap/constants/juiceSwapSlippage.test.ts
+++ b/packages/uniswap/src/features/transactions/swap/constants/juiceSwapSlippage.test.ts
@@ -1,0 +1,23 @@
+import {
+  JUICESWAP_DEFAULT_SLIPPAGE,
+  resolveJuiceSwapSlippageTolerance,
+} from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
+
+describe('resolveJuiceSwapSlippageTolerance', () => {
+  it('submits the shared default when the user has no custom tolerance (#764 AC4)', () => {
+    // This is the value the Satsuma/Gateway builders send to /v1/swap.
+    expect(resolveJuiceSwapSlippageTolerance(undefined)).toBe('5')
+    expect(resolveJuiceSwapSlippageTolerance(undefined)).toBe(JUICESWAP_DEFAULT_SLIPPAGE.toString())
+  })
+
+  it('respects a user-provided custom tolerance', () => {
+    expect(resolveJuiceSwapSlippageTolerance(2.5)).toBe('2.5')
+  })
+
+  it('keeps the submitted default in sync with the displayed default', () => {
+    // The "Max slippage" display uses the numeric JUICESWAP_DEFAULT_SLIPPAGE,
+    // the builders use its string form — they must never diverge (#764 AC4).
+    expect(JUICESWAP_DEFAULT_SLIPPAGE).toBe(5)
+    expect(resolveJuiceSwapSlippageTolerance(undefined)).toBe(String(JUICESWAP_DEFAULT_SLIPPAGE))
+  })
+})

--- a/packages/uniswap/src/features/transactions/swap/constants/juiceSwapSlippage.ts
+++ b/packages/uniswap/src/features/transactions/swap/constants/juiceSwapSlippage.ts
@@ -8,3 +8,13 @@
  * swap (issue #764).
  */
 export const JUICESWAP_DEFAULT_SLIPPAGE = 5
+
+/**
+ * Resolves the slippage tolerance (as the string the `/v1/swap` body expects)
+ * for JuiceSwap's routing types: the user's custom tolerance when set,
+ * otherwise the shared default. Keeping this in one place guarantees the
+ * submit paths and the slippage display agree (issue #764).
+ */
+export function resolveJuiceSwapSlippageTolerance(customSlippageTolerance?: number): string {
+  return customSlippageTolerance?.toString() ?? JUICESWAP_DEFAULT_SLIPPAGE.toString()
+}

--- a/packages/uniswap/src/features/transactions/swap/constants/juiceSwapSlippage.ts
+++ b/packages/uniswap/src/features/transactions/swap/constants/juiceSwapSlippage.ts
@@ -1,0 +1,10 @@
+/**
+ * Default max-slippage (in percent) that JuiceSwap submits to the `/v1/swap`
+ * endpoint for its own routing types (Gateway/JUSD and pool fallback) when the
+ * user has not set a custom tolerance.
+ *
+ * Shared by the swap builders and the slippage display so the value shown in
+ * the UI can never differ from the slippage actually encoded in the signed
+ * swap (issue #764).
+ */
+export const JUICESWAP_DEFAULT_SLIPPAGE = 5

--- a/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormScreenDetails/SwapFormScreenFooter/GasAndWarningRows/GasAndWarningRows.web.tsx
+++ b/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormScreenDetails/SwapFormScreenFooter/GasAndWarningRows/GasAndWarningRows.web.tsx
@@ -44,7 +44,9 @@ export function GasAndWarningRows(): JSX.Element | null {
         />
       )}
 
-      {!hasInsufficientFundsWarning && hasGasInfo && (
+      {/* Keep the trade-info row when a critical warning must stay visible even
+          under an insufficient-funds state (issue #764). */}
+      {(!hasInsufficientFundsWarning || Boolean(inlineWarning)) && hasGasInfo && (
         <Flex gap="$spacing8" px="$spacing8" py="$spacing4">
           <TradeInfoRow gasInfo={debouncedGasInfo} warning={inlineWarning} />
         </Flex>

--- a/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/YouReceiveDetails/YouReceiveDetails.web.tsx
+++ b/packages/uniswap/src/features/transactions/swap/form/SwapFormScreen/YouReceiveDetails/YouReceiveDetails.web.tsx
@@ -19,6 +19,7 @@ import {
   BestRouteUniswapXTooltip,
 } from 'uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormTooltips/BestRouteTooltip'
 import { SwapFeeOnTransferTooltip } from 'uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormTooltips/FeeDetailsTooltip'
+import { LargePriceDifferenceTooltip } from 'uniswap/src/features/transactions/swap/form/SwapFormScreen/SwapFormTooltips/LargePriceDifferenceTooltip'
 import {
   AutoSlippageBadge,
   MaxSlippageTooltip,
@@ -31,7 +32,8 @@ import { usePriceDifference } from 'uniswap/src/features/transactions/swap/hooks
 import { useParsedSwapWarnings } from 'uniswap/src/features/transactions/swap/hooks/useSwapWarnings/useSwapWarnings'
 import { useSwapFormStore } from 'uniswap/src/features/transactions/swap/stores/swapFormStore/useSwapFormStore'
 import { useSwapTxStore } from 'uniswap/src/features/transactions/swap/stores/swapTxStore/useSwapTxStore'
-import { isUniswapX } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { JUICESWAP_DEFAULT_SLIPPAGE } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
+import { isGatewayJusd, isSatsuma, isUniswapX } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { WrapType } from 'uniswap/src/features/transactions/types/wrap'
 import { useIsBlocked } from 'uniswap/src/features/trm/hooks'
 import { useWallet } from 'uniswap/src/features/wallet/hooks/useWallet'
@@ -127,33 +129,31 @@ function PriceDifferenceDisplay({
 }: {
   priceDifference: UsePriceDifferenceReturnType
 }): JSX.Element | null {
+  const { t } = useTranslation()
+  const { formatPercent } = useLocalizationContext()
+
   if (!priceDifference.showPriceDifferenceWarning) {
     return null
   }
 
-  return null // TODO: add price difference warning when calculation is implemented
-
-  /*
-  const { t } = useTranslation()
-  const { formatPercent } = useLocalizationContext()
-
+  // `priceDifferencePercentage` is negative when the user is losing value;
+  // show the magnitude as the JuiceSwap Price Impact, with severity colour.
   return (
     <SwapDetailsRow.Outer>
       <SwapDetailsRow.Label
-        label={t('large.price.difference')}
-        analyticsTitle="Large price difference"
+        label={t('swap.priceImpact.juiceswap')}
+        analyticsTitle="JuiceSwap price impact"
         tooltip={<LargePriceDifferenceTooltip />}
       />
       <Flex row gap="$spacing4" alignItems="center">
         <AlertTriangleFilled color={priceDifference.priceDifferenceColor} size="$icon.16" />
         <SwapDetailsRow.ValueLabel
-          value={formatPercent(priceDifference.priceDifferencePercentage)}
+          value={formatPercent(Math.abs(priceDifference.priceDifferencePercentage))}
           color={priceDifference.priceDifferenceColor}
         />
       </Flex>
     </SwapDetailsRow.Outer>
   )
-  */
 }
 
 function MaxSlippageDisplay({
@@ -271,6 +271,7 @@ export function YouReceiveDetails({ isBridge }: YouReceiveDetailsProps): JSX.Ele
     inlineWarning?.warning.type === WarningLabel.PriceImpactMedium
   const feeOnTransferProps = useFeeOnTransferAmounts(derivedSwapInfo)
   const isUniswapXContext = useSwapTxStore((s) => isUniswapX({ routing: s.routing }))
+  const swapTxRouting = useSwapTxStore((s) => s.routing)
   const trade = useSwapTxStore((s) => s.trade)
   const receivedAmountPostFees = derivedSwapInfo.outputAmountUserWillReceive
     ? formatCurrencyAmount({
@@ -292,7 +293,15 @@ export function YouReceiveDetails({ isBridge }: YouReceiveDetailsProps): JSX.Ele
     placeholder: '-',
   })} ${outputCurrency?.currency.symbol}`
 
-  const formattedCurrentSlippageTolerance = formatPercent(currentSlippageTolerance)
+  // JuiceSwap's own routes submit a fixed default slippage to /v1/swap when the
+  // user has not set a custom tolerance. Display that same value so the shown
+  // "Max slippage" can never differ from what is actually signed (issue #764).
+  const usesJuiceSwapDefaultSlippage =
+    !customSlippageTolerance &&
+    (isSatsuma({ routing: swapTxRouting }) || isGatewayJusd({ routing: swapTxRouting }))
+  const formattedCurrentSlippageTolerance = formatPercent(
+    usesJuiceSwapDefaultSlippage ? JUICESWAP_DEFAULT_SLIPPAGE : currentSlippageTolerance,
+  )
 
   const showDropdown =
     derivedSwapInfo.wrapType === WrapType.NotApplicable &&

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService.ts
@@ -9,6 +9,7 @@ import type { CustomSwapDataForRequest, GasStrategy } from 'uniswap/src/data/tra
 import type { UniverseChainId } from 'uniswap/src/features/chains/types'
 import type { SwapDelegationInfo } from 'uniswap/src/features/smartWallet/delegation/types'
 import type { TransactionSettings } from 'uniswap/src/features/transactions/components/settings/types'
+import { JUICESWAP_DEFAULT_SLIPPAGE } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
 import type {
   EVMSwapRepository,
   SwapData,
@@ -120,7 +121,7 @@ export const getCustomSwapTokenData = (
       tokenOutChainId: currencyOut.chainId,
       tokenOutAddress: currencyOut.isNative ? ZERO_ADDRESS : currencyOut.address,
       tokenOutDecimals: currencyOut.decimals,
-      slippageTolerance: transactionSettings?.customSlippageTolerance?.toString() ?? '5',
+      slippageTolerance: transactionSettings?.customSlippageTolerance?.toString() ?? JUICESWAP_DEFAULT_SLIPPAGE.toString(),
     }
   }
 

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService.ts
@@ -9,7 +9,7 @@ import type { CustomSwapDataForRequest, GasStrategy } from 'uniswap/src/data/tra
 import type { UniverseChainId } from 'uniswap/src/features/chains/types'
 import type { SwapDelegationInfo } from 'uniswap/src/features/smartWallet/delegation/types'
 import type { TransactionSettings } from 'uniswap/src/features/transactions/components/settings/types'
-import { JUICESWAP_DEFAULT_SLIPPAGE } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
+import { resolveJuiceSwapSlippageTolerance } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
 import type {
   EVMSwapRepository,
   SwapData,
@@ -121,7 +121,7 @@ export const getCustomSwapTokenData = (
       tokenOutChainId: currencyOut.chainId,
       tokenOutAddress: currencyOut.isNative ? ZERO_ADDRESS : currencyOut.address,
       tokenOutDecimals: currencyOut.decimals,
-      slippageTolerance: transactionSettings?.customSlippageTolerance?.toString() ?? JUICESWAP_DEFAULT_SLIPPAGE.toString(),
+      slippageTolerance: resolveJuiceSwapSlippageTolerance(transactionSettings?.customSlippageTolerance),
     }
   }
 

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts
@@ -6,6 +6,7 @@ import { Routing } from 'uniswap/src/data/tradingApi/__generated__'
 import type { GasStrategy } from 'uniswap/src/data/tradingApi/types'
 import { convertGasFeeToDisplayValue } from 'uniswap/src/features/gas/hooks'
 import type { TransactionSettings } from 'uniswap/src/features/transactions/components/settings/types'
+import { JUICESWAP_DEFAULT_SLIPPAGE } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
 import type {
   SwapTxAndGasInfoParameters,
   SwapTxAndGasInfoService,
@@ -52,7 +53,7 @@ export function createSatsumaSwapTxAndGasInfoService(ctx: {
         tokenOutChainId: currencyOut.chainId,
         tokenOutAddress: currencyOut.isNative ? ADDRESS_ZERO : currencyOut.address,
         tokenOutDecimals: currencyOut.decimals,
-        slippageTolerance: transactionSettings.customSlippageTolerance?.toString() ?? '5',
+        slippageTolerance: transactionSettings.customSlippageTolerance?.toString() ?? JUICESWAP_DEFAULT_SLIPPAGE.toString(),
       }
       const deadline = getTradeSettingsDeadline(transactionSettings.customDeadline)
 

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/satsuma/satsumaSwapTxAndGasInfoService.ts
@@ -6,7 +6,7 @@ import { Routing } from 'uniswap/src/data/tradingApi/__generated__'
 import type { GasStrategy } from 'uniswap/src/data/tradingApi/types'
 import { convertGasFeeToDisplayValue } from 'uniswap/src/features/gas/hooks'
 import type { TransactionSettings } from 'uniswap/src/features/transactions/components/settings/types'
-import { JUICESWAP_DEFAULT_SLIPPAGE } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
+import { resolveJuiceSwapSlippageTolerance } from 'uniswap/src/features/transactions/swap/constants/juiceSwapSlippage'
 import type {
   SwapTxAndGasInfoParameters,
   SwapTxAndGasInfoService,
@@ -53,7 +53,7 @@ export function createSatsumaSwapTxAndGasInfoService(ctx: {
         tokenOutChainId: currencyOut.chainId,
         tokenOutAddress: currencyOut.isNative ? ADDRESS_ZERO : currencyOut.address,
         tokenOutDecimals: currencyOut.decimals,
-        slippageTolerance: transactionSettings.customSlippageTolerance?.toString() ?? JUICESWAP_DEFAULT_SLIPPAGE.toString(),
+        slippageTolerance: resolveJuiceSwapSlippageTolerance(transactionSettings.customSlippageTolerance),
       }
       const deadline = getTradeSettingsDeadline(transactionSettings.customDeadline)
 

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/utils.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/utils.ts
@@ -6,6 +6,7 @@ import type {
   ClassicQuoteResponse,
   DiscriminatedQuoteResponse,
   GatewayJusdQuoteResponse,
+  SatsumaQuoteResponse,
   WrapQuoteResponse,
 } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
 import { getTradeSettingsDeadline } from 'uniswap/src/data/apiClients/tradingApi/utils/getTradeSettingsDeadline'
@@ -417,7 +418,7 @@ const EMPTY_PERMIT_TX_INFO: PermitTxInfo = {
 export function usePermitTxInfo({
   quote,
 }: {
-  quote?: DiscriminatedQuoteResponse | GatewayJusdQuoteResponse
+  quote?: DiscriminatedQuoteResponse | GatewayJusdQuoteResponse | SatsumaQuoteResponse
 }): PermitTxInfo {
   const classicQuote = quote && isClassic(quote) ? quote : undefined
   const gasStrategy = useActiveGasStrategy(classicQuote?.quote.chainId, 'swap')

--- a/packages/uniswap/src/features/transactions/swap/types/trade.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/trade.ts
@@ -38,6 +38,7 @@ import { GasEstimate } from 'uniswap/src/data/tradingApi/types'
 import { ValueType, getCurrencyAmount } from 'uniswap/src/features/tokens/getCurrencyAmount'
 import { getSwapFee } from 'uniswap/src/features/transactions/swap/types/getSwapFee'
 import { slippageToleranceToPercent } from 'uniswap/src/features/transactions/swap/utils/format'
+import { parseJuiceSwapPriceImpact } from 'uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact'
 import { FrontendSupportedProtocol } from 'uniswap/src/features/transactions/swap/utils/protocols'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 
@@ -840,7 +841,6 @@ export class SatsumaTrade {
   readonly outputTax: Percent = ZERO_PERCENT
 
   readonly slippageTolerance: number
-  readonly priceImpact: undefined
   readonly deadline: undefined
 
   constructor({
@@ -877,6 +877,12 @@ export class SatsumaTrade {
     // Satsuma trades use slippage applied at /v1/swap submit time
     this.maxAmountIn = this.inputAmount
     this.minAmountOut = this.outputAmount
+  }
+
+  // JuiceSwap Price Impact: surface the API-reported impact for pool fallback
+  // routes so the swap UI can warn on bad quotes (issue #764).
+  public get priceImpact(): Percent | undefined {
+    return parseJuiceSwapPriceImpact(this.quote.quote.priceImpact)
   }
 
   public get quoteOutputAmount(): CurrencyAmount<Currency> {

--- a/packages/uniswap/src/features/transactions/swap/utils/getPriceImpact.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/getPriceImpact.ts
@@ -2,7 +2,8 @@ import { CurrencyAmount, Percent, type Currency } from '@juiceswapxyz/sdk-core'
 import { ValueType, getCurrencyAmount } from 'uniswap/src/features/tokens/getCurrencyAmount'
 import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
 import { getSwapFeeUsdFromDerivedSwapInfo } from 'uniswap/src/features/transactions/swap/utils/getSwapFeeUsd'
-import { isClassic, isUniswapX } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { getJuiceSwapPriceImpact } from 'uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact'
+import { isClassic, isGatewayJusd, isSatsuma, isUniswapX } from 'uniswap/src/features/transactions/swap/utils/routing'
 
 function stringToUSDAmount(value: string | number | undefined, USDCurrency: Currency): Maybe<CurrencyAmount<Currency>> {
   if (!value) {
@@ -54,6 +55,8 @@ export function getPriceImpact(derivedSwapInfo: DerivedSwapInfo): Percent | unde
     return getUniswapXPriceImpact({ derivedSwapInfo })
   } else if (isClassic(trade)) {
     return trade.priceImpact
+  } else if (isSatsuma(trade) || isGatewayJusd(trade)) {
+    return getJuiceSwapPriceImpact(trade)
   } else {
     return undefined
   }

--- a/packages/uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact.test.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact.test.ts
@@ -1,0 +1,76 @@
+import { Percent, TradeType } from '@juiceswapxyz/sdk-core'
+import type {
+  GatewayJusdQuoteResponse,
+  SatsumaQuoteResponse,
+} from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
+import { GatewayJusdTrade, SatsumaTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import {
+  getJuiceSwapPriceImpact,
+  parseJuiceSwapPriceImpact,
+} from 'uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact'
+import { USDC, WBTC } from 'uniswap/src/constants/tokens'
+
+function buildSatsumaTrade(priceImpact: string | undefined): SatsumaTrade {
+  const quote = {
+    requestId: 'test',
+    routing: 'SATSUMA',
+    permitData: null,
+    quote: {
+      amount: '3003416087', // 3003.416087 USDC.e (6 decimals)
+      quote: '1756651830', // 1756.651830 ctUSD
+      priceImpact,
+    },
+  } as unknown as SatsumaQuoteResponse
+
+  return new SatsumaTrade({ quote, currencyIn: USDC, currencyOut: WBTC, tradeType: TradeType.EXACT_INPUT })
+}
+
+function buildGatewayTrade(): GatewayJusdTrade {
+  const quote = {
+    requestId: 'test',
+    routing: 'GATEWAY_JUSD',
+    permitData: null,
+    quote: {
+      input: { amount: '3003416087' },
+      output: { amount: '3003416087' },
+      slippage: 0,
+    },
+  } as unknown as GatewayJusdQuoteResponse
+
+  return new GatewayJusdTrade({ quote, currencyIn: USDC, currencyOut: WBTC, tradeType: TradeType.EXACT_INPUT })
+}
+
+describe('parseJuiceSwapPriceImpact', () => {
+  it('parses a small percentage string into a Percent', () => {
+    expect(parseJuiceSwapPriceImpact('0.05')?.equalTo(new Percent(5, 10_000))).toBe(true)
+  })
+
+  it('parses a catastrophic percentage string into a Percent', () => {
+    expect(parseJuiceSwapPriceImpact('41.51')?.toFixed(2)).toBe('41.51')
+  })
+
+  it('accepts a numeric value', () => {
+    expect(parseJuiceSwapPriceImpact(0.3)?.equalTo(new Percent(30, 10_000))).toBe(true)
+  })
+
+  it.each([undefined, '', 'not-a-number'])('returns undefined for invalid value %p', (value) => {
+    expect(parseJuiceSwapPriceImpact(value)).toBeUndefined()
+  })
+})
+
+describe('getJuiceSwapPriceImpact', () => {
+  it('surfaces the API-reported impact for pool fallback (Satsuma) trades', () => {
+    const trade = buildSatsumaTrade('41.51')
+    expect(getJuiceSwapPriceImpact(trade)?.toFixed(2)).toBe('41.51')
+    // Regression for #764: the impact must not be silently dropped.
+    expect(trade.priceImpact).toBeDefined()
+  })
+
+  it('returns undefined for a Satsuma trade without an API impact value', () => {
+    expect(getJuiceSwapPriceImpact(buildSatsumaTrade(undefined))).toBeUndefined()
+  })
+
+  it('returns undefined for Gateway/JUSD 1:1 conversions', () => {
+    expect(getJuiceSwapPriceImpact(buildGatewayTrade())).toBeUndefined()
+  })
+})

--- a/packages/uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/juiceSwapPriceImpact.ts
@@ -1,0 +1,45 @@
+import { Percent } from '@juiceswapxyz/sdk-core'
+import type { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { isGatewayJusd, isSatsuma } from 'uniswap/src/features/transactions/swap/utils/routing'
+
+/**
+ * JuiceSwap Price Impact.
+ *
+ * JuiceSwap routes stable swaps either through the Gateway/JUSD 1:1 PSM
+ * conversion or, when bridge liquidity is depleted, through a JuiceSwap pool.
+ * Pool fallbacks can carry a large price impact that the JuiceSwap Quote API
+ * reports on the quote, but the custom trade classes previously dropped it,
+ * leaving the UI without a price-impact warning (issue #764).
+ *
+ * `parseJuiceSwapPriceImpact` converts the API's percentage value (e.g. the
+ * string `"0.05"` meaning 0.05 %, or `"41.51"` meaning 41.51 %) into a
+ * `Percent`, mirroring the canonical conversion used by Classic trades.
+ */
+export function parseJuiceSwapPriceImpact(value: string | number | undefined): Percent | undefined {
+  if (value === undefined || value === '') {
+    return undefined
+  }
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return undefined
+  }
+
+  // Value is already expressed as a percentage; scale to Percent's basis points.
+  return new Percent(Math.round(numeric * 100), 10_000)
+}
+
+/**
+ * Returns the JuiceSwap Price Impact for JuiceSwap's own routing types.
+ *
+ * - Pool fallback routes expose the API-reported impact via `trade.priceImpact`.
+ * - Gateway/JUSD is a 1:1 PSM conversion and carries no API price impact;
+ *   `undefined` is returned so the USD-value-loss guard remains the safety net.
+ */
+export function getJuiceSwapPriceImpact(trade: Trade): Percent | undefined {
+  if (isSatsuma(trade) || isGatewayJusd(trade)) {
+    return trade.priceImpact
+  }
+
+  return undefined
+}

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -1970,6 +1970,7 @@
   "swap.outputEstimated.atLeast": "Output is estimated. You will receive at least <amount /> or the transaction will revert.",
   "swap.placeOrder": "Place order",
   "swap.priceImpact": "Price impact",
+  "swap.priceImpact.juiceswap": "JuiceSwap price impact",
   "swap.request.title.full": "Swap {{inputCurrencySymbol}} → {{outputCurrencySymbol}}",
   "swap.request.title.short": "Swap Tokens",
   "swap.review": "Review swap",


### PR DESCRIPTION
## Context

Follow-up to #764. The backend price-impact fix (#261) and the Satsuma routing fallback (#752) addressed the *quote*, but the reporter (`muhylmz`) correctly noted the **frontend/UX layer is not fully resolved**: on JuiceSwap's own routing types the UI still drops the price-impact / value-loss signals, and the displayed slippage can differ from what is signed.

This PR closes those four frontend gaps end to end.

## Changes

### 1. JuiceSwap Price Impact wired through (was hardcoded `undefined`)
- `SatsumaTrade.priceImpact` now exposes the API-reported impact via the new pure helper `parseJuiceSwapPriceImpact` (mirrors `ClassicTrade.priceImpact`).
- `getPriceImpact()` routes `SATSUMA`/`GATEWAY_JUSD` through the new `getJuiceSwapPriceImpact`, so `getPriceImpactWarning` (>3%) fires again.
- Gateway/JUSD stays `undefined` (1:1 PSM conversion); the USD-value-loss guard remains its safety net.

### 2. `PriceDifferenceDisplay` renders (was a hardcoded `return null // TODO`)
- Activates the row using the already-present `LargePriceDifferenceTooltip`; label branded **"JuiceSwap price impact"** (new i18n key `swap.priceImpact.juiceswap`).

### 3. Insufficient-funds no longer suppresses a critical warning
- `getFormScreenWarning` keeps a high-severity price-impact / `FiatLossHigh` warning inline even under an insufficient-funds state; the "Not enough" message still drives the review-button text.
- `GasAndWarningRows.web.tsx` gate relaxed accordingly. (Logic lives in the shared hook, so native benefits too.)

### 4. Slippage display == slippage sent
- New shared `JUICESWAP_DEFAULT_SLIPPAGE = 5` used by **both** the swap builders (`satsuma` + `getCustomSwapTokenData`) and the "Max slippage" display, so the UI can no longer show `0.00%` while `5%` is signed.

## Tests
- `juiceSwapPriceImpact.test.ts` — parsing + Satsuma/Gateway wiring (9 cases, incl. the documented 41.51% case).
- `useParsedTransactionWarnings.test.ts` — critical warning survives insufficient-funds; lone insufficient-funds still hidden inline.

## Verification
- `yarn uniswap typecheck` — no new errors (pre-existing baseline errors unchanged).
- `yarn uniswap lint` (changed files, `--max-warnings=0`) — clean.
- New unit suites green; related `getPriceImpact` / `getFiatLossWarning` suites green.
- `yarn web build:production` (the gating CI check) — `BUILD_EXIT=0`.

No auto-merge. Internal class name `SatsumaTrade` is kept (routing identifier, not user-facing); no "Satsuma" string is exposed in the UI.