### PR TITLE
feat(points): take Juice Points live, keep the NFT hidden, show real points

### DIFF
--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/NFTs/NFTItem.tsx
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/NFTs/NFTItem.tsx
@@ -33,7 +33,7 @@ export function NFT({
     currentPfp.tokenId === asset.tokenId
 
   const canSetPfp =
-    WebFeatureFlags.JUICE_POINTS_PROGRAM &&
+    WebFeatureFlags.JUICE_POINTS_NFT &&
     !!account.address &&
     !!asset.imageUrl &&
     !!asset.asset_contract.address &&

--- a/apps/web/src/components/AccountDrawer/Points/api.test.ts
+++ b/apps/web/src/components/AccountDrawer/Points/api.test.ts
@@ -1,0 +1,38 @@
+import { fetchPointsForAddress } from 'components/AccountDrawer/Points/api'
+
+const ADDRESS = '0x1111111111111111111111111111111111111111'
+
+/**
+ * The header points ticker and points UI must reflect the wallet's real points
+ * from the ponder API — never a fabricated mock. On API failure we show zeros,
+ * not pseudo-random numbers (which previously surfaced as a bogus ~1,400).
+ */
+describe('fetchPointsForAddress — real-API points', () => {
+  const realFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = realFetch
+    vi.restoreAllMocks()
+  })
+
+  it('returns the real total reported by the ponder API', async () => {
+    const body = {
+      total: 4242,
+      swaps: { count: 3, points: 300 },
+      liquidity: { days: 1, points: 50, currentUsdValue: 80, meetsMinimum: true },
+    }
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => body }) as unknown as typeof fetch
+
+    const result = await fetchPointsForAddress(ADDRESS)
+    expect(result.total).toBe(4242)
+  })
+
+  it('returns zeros (never a fabricated mock) when the API is unreachable', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+
+    const result = await fetchPointsForAddress(ADDRESS)
+    expect(result.total).toBe(0)
+    expect(result.swaps.count).toBe(0)
+    expect(result.liquidity.points).toBe(0)
+  })
+})

--- a/apps/web/src/components/AccountDrawer/Points/api.ts
+++ b/apps/web/src/components/AccountDrawer/Points/api.ts
@@ -25,16 +25,18 @@ import {
  *   - Detect and exclude wash-trading patterns (same EOA via different routers,
  *     A→B→A round-trips, etc.).
  *
- * Expected endpoints (ponder service):
+ * Endpoints (ponder service):
  *   GET {BASE}/points/{address}      -> PointsApiResponse
  *   GET {BASE}/points/leaderboard    -> LeaderboardApiResponse
  *
- * BASE is read from REACT_APP_PONDER_JUICESWAP_URL.
- * Toggle with REACT_APP_JUICE_POINTS_API_ENABLED=true (defaults to mock).
+ * BASE comes from REACT_APP_PONDER_JUICESWAP_URL (primary, prod ponder).
+ * REACT_APP_PONDER_FALLBACK_JUICESWAP_URL (dev ponder) is tried if the
+ * primary fails — same pattern as packages/uniswap/src/data/apiClients/ponderApi.
  *
- * Until the backend ships these endpoints the fetchers fall back to a deterministic
- * mock (see `mockPoints` / `mockLeaderboard`) so the UI is fully functional during
- * development.
+ * On total API failure we return zeros (NOT mock random data) so the header
+ * ticker and points UI never show a fabricated balance. Set
+ * REACT_APP_JUICE_POINTS_DEV_MOCK=true to opt into the deterministic mock for
+ * fully offline development.
  */
 
 interface PointsApiResponse {
@@ -63,14 +65,12 @@ interface LeaderboardApiResponse {
   updatedAt: number
 }
 
-const POINTS_API_BASE = process.env.REACT_APP_PONDER_JUICESWAP_URL || ''
-const POINTS_API_ENABLED = process.env.REACT_APP_JUICE_POINTS_API_ENABLED === 'true'
+const PRIMARY_BASE = process.env.REACT_APP_PONDER_JUICESWAP_URL || 'https://ponder.juiceswap.com'
+const FALLBACK_BASE = process.env.REACT_APP_PONDER_FALLBACK_JUICESWAP_URL || 'https://dev.ponder.juiceswap.com'
+const DEV_MOCK_ENABLED = process.env.REACT_APP_JUICE_POINTS_DEV_MOCK === 'true'
 const REQUEST_TIMEOUT_MS = 5_000
 
-async function safeFetch<T>(url: string): Promise<T | undefined> {
-  if (!POINTS_API_ENABLED || !POINTS_API_BASE) {
-    return undefined
-  }
+async function tryFetch<T>(url: string): Promise<T | undefined> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
   try {
@@ -84,6 +84,27 @@ async function safeFetch<T>(url: string): Promise<T | undefined> {
   } finally {
     clearTimeout(timer)
   }
+}
+
+async function fetchWithFallback<T>(path: string): Promise<T | undefined> {
+  for (const base of [PRIMARY_BASE, FALLBACK_BASE]) {
+    if (!base) {
+      continue
+    }
+    const result = await tryFetch<T>(`${base}${path}`)
+    if (result !== undefined) {
+      return result
+    }
+  }
+  return undefined
+}
+
+// Real zero — shown when the points API is unreachable, so the UI reflects the
+// wallet's actual (unknown/0) standing instead of a fabricated mock value.
+const ZERO_POINTS: PointsBreakdown = {
+  total: 0,
+  swaps: { count: 0, points: 0 },
+  liquidity: { days: 0, points: 0, currentUsdValue: 0, meetsMinimum: false },
 }
 
 function pseudoRandomFromAddress(address: string, max: number): number {
@@ -150,15 +171,18 @@ function mockLeaderboard(): LeaderboardData {
 }
 
 export async function fetchPointsForAddress(address: string): Promise<PointsBreakdown> {
-  const apiResponse = await safeFetch<PointsApiResponse>(`${POINTS_API_BASE}/points/${address.toLowerCase()}`)
+  const apiResponse = await fetchWithFallback<PointsApiResponse>(`/points/${address.toLowerCase()}`)
   if (apiResponse) {
     return apiResponse
   }
-  return mockPoints(address)
+  if (DEV_MOCK_ENABLED) {
+    return mockPoints(address)
+  }
+  return ZERO_POINTS
 }
 
 export async function fetchLeaderboard(): Promise<LeaderboardData> {
-  const apiResponse = await safeFetch<LeaderboardApiResponse>(`${POINTS_API_BASE}/points/leaderboard`)
+  const apiResponse = await fetchWithFallback<LeaderboardApiResponse>('/points/leaderboard')
   if (apiResponse) {
     return {
       entries: apiResponse.entries,
@@ -166,5 +190,8 @@ export async function fetchLeaderboard(): Promise<LeaderboardData> {
       updatedAt: apiResponse.updatedAt,
     }
   }
-  return mockLeaderboard()
+  if (DEV_MOCK_ENABLED) {
+    return mockLeaderboard()
+  }
+  return { entries: [], total: 0, updatedAt: Date.now() }
 }

--- a/apps/web/src/components/Identicon/StatusIcon.tsx
+++ b/apps/web/src/components/Identicon/StatusIcon.tsx
@@ -78,7 +78,9 @@ export default function StatusIcon({
   const effectiveAddress = address ?? account?.address
   const pfp = usePfp(effectiveAddress)
   const hasSocks = useHasSocks()
-  const showPfp = WebFeatureFlags.JUICE_POINTS_PROGRAM && pfp
+  // NFT-as-PFP is an NFT surface — kept behind the NFT-reveal flag so the
+  // points program can be live while the NFT stays hidden.
+  const showPfp = WebFeatureFlags.JUICE_POINTS_NFT && pfp
   return (
     <IconWrapper size={size} data-testid="StatusIconRoot">
       {showPfp ? (

--- a/apps/web/src/components/NavBar/Tabs/TabsContent.tsx
+++ b/apps/web/src/components/NavBar/Tabs/TabsContent.tsx
@@ -5,7 +5,6 @@ import { useTheme } from 'lib/styled-components'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router'
 import { useIsBAppsCampaignVisible } from 'services/bappsCampaign/hooks'
-import { useIsFirstSqueezerCampaignVisible } from 'services/firstSqueezerCampaign/hooks'
 import { useIsJuicerCampaignVisible } from 'services/juicerCampaign/hooks'
 import { Text } from 'ui/src'
 import { Compass } from 'ui/src/components/icons/Compass'
@@ -29,7 +28,6 @@ export const useTabsContent = (): TabsSection[] => {
   const { pathname } = useLocation()
   const theme = useTheme()
   const showBAppsTab = useIsBAppsCampaignVisible()
-  const showFirstSqueezerTab = useIsFirstSqueezerCampaignVisible()
   const showJuicerTab = useIsJuicerCampaignVisible()
   const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
 
@@ -129,10 +127,10 @@ export const useTabsContent = (): TabsSection[] => {
     })
   }
 
-  // Add Juicer NFT tab if campaign is visible (replaces First Squeezer in the navbar).
-  // The First Squeezer route still exists for previously eligible wallets, but it
-  // is no longer surfaced in the primary navigation.
-  if (showJuicerTab || showFirstSqueezerTab) {
+  // Add Juicer NFT tab only when the NFT is unlocked (useIsJuicerCampaignVisible
+  // requires JUICE_POINTS_NFT). While the NFT is hidden, the tab stays out of the
+  // primary navigation even though the points program is live.
+  if (showJuicerTab) {
     conditionalTabs.push({
       title: 'Juicer NFT',
       href: '/juicer',

--- a/apps/web/src/constants/featureFlags.ts
+++ b/apps/web/src/constants/featureFlags.ts
@@ -19,8 +19,16 @@ export const WebFeatureFlags = {
   // Or use ?cross-chain-swaps=false in URL to disable temporarily
   CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS !== 'false', // Default to true unless explicitly disabled
 
-  // Enable/disable Juice Points program (Points UI, Leaderboard route, NFT PFP)
-  // Set REACT_APP_JUICE_POINTS_PROGRAM=true in .env to enable
+  // Enable/disable Juice Points program (Points UI, Leaderboard route, header
+  // points ticker). Default ON so users can collect and see their points.
+  // Set REACT_APP_JUICE_POINTS_PROGRAM=false in .env to disable.
   // Re-enablement checklist (incl. public discovery surfaces): see issue #748
-  JUICE_POINTS_PROGRAM: process.env.REACT_APP_JUICE_POINTS_PROGRAM === 'true', // Default to false unless explicitly enabled
+  JUICE_POINTS_PROGRAM: process.env.REACT_APP_JUICE_POINTS_PROGRAM !== 'false', // Default to true unless explicitly disabled
+
+  // Enable/disable the NFT acquisition surfaces that ride on top of the points
+  // program: the Juicer NFT page + nav tab, the Juicer/First Squeezer NFT
+  // claim/mint sections, and NFT-as-profile-picture. Kept OFF so people only
+  // collect points while the NFT stays hidden until it is manually unlocked.
+  // Set REACT_APP_JUICE_POINTS_NFT=true in .env to reveal.
+  JUICE_POINTS_NFT: process.env.REACT_APP_JUICE_POINTS_NFT === 'true', // Default to false unless explicitly enabled
 } as const

--- a/apps/web/src/pages/FirstSqueezer/FirstSqueezerContent.tsx
+++ b/apps/web/src/pages/FirstSqueezer/FirstSqueezerContent.tsx
@@ -1,4 +1,5 @@
 import { useAccountDrawer } from 'components/AccountDrawer/MiniPortfolio/hooks'
+import { WebFeatureFlags } from 'constants/featureFlags'
 import { ConditionCard } from 'pages/FirstSqueezer/ConditionCard'
 import { NFTClaimSection } from 'pages/FirstSqueezer/NFTClaimSection'
 import {
@@ -236,8 +237,9 @@ export default function FirstSqueezerContent({ account }: FirstSqueezerContentPr
         </Flex>
       </Section>
 
-      {/* NFT Claim Section */}
-      {(progress?.isEligibleForNFT || progress?.nftMinted) && (
+      {/* NFT Claim Section — NFT acquisition is hidden until the NFT is
+          explicitly unlocked (JUICE_POINTS_NFT). Points/progress stay visible. */}
+      {WebFeatureFlags.JUICE_POINTS_NFT && (progress?.isEligibleForNFT || progress?.nftMinted) && (
         <NFTClaimSection
           isEligible={progress.isEligibleForNFT}
           walletAddress={account.address}

--- a/apps/web/src/pages/RouteDefinitions.tsx
+++ b/apps/web/src/pages/RouteDefinitions.tsx
@@ -390,12 +390,13 @@ export const routes: RouteDefinition[] = [
     getDescription: () =>
       'Exclusive to testnet claimers who verify X and Discord to claim the First Squeezer NFT on Citrea Mainnet.',
   }),
-  // Juicer NFT Campaign Page — gated behind the Juice Points program flag
-  // (mirrors #747). Cannot function without the points system live because
-  // the mint requires spending 5,000 JP.
+  // Juicer NFT Campaign Page — gated behind the NFT-reveal flag. The points
+  // program can be live (JUICE_POINTS_PROGRAM) while the NFT stays hidden, so
+  // this page only appears once JUICE_POINTS_NFT is explicitly unlocked. The
+  // mint also requires the points system because it spends 5,000 JP.
   createRouteDefinition({
     path: '/juicer',
-    enabled: () => process.env.REACT_APP_JUICE_POINTS_PROGRAM === 'true',
+    enabled: () => WebFeatureFlags.JUICE_POINTS_NFT,
     getElement: () => <Juicer />,
     getTitle: () => 'Juicer NFT - JuiceSwap',
     getDescription: () =>

--- a/apps/web/src/services/juicerCampaign/hooks.ts
+++ b/apps/web/src/services/juicerCampaign/hooks.ts
@@ -1,3 +1,4 @@
+import { WebFeatureFlags } from 'constants/featureFlags'
 import { useAccount } from 'hooks/useAccount'
 import useSelectChain from 'hooks/useSelectChain'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -145,22 +146,27 @@ export function useIsJuicerCampaignEnded(): boolean {
 }
 
 /**
- * Mirrors `WebFeatureFlags.JUICE_POINTS_PROGRAM` introduced in #747. We read
- * the env var directly so this module stays compilable independent of merge
- * order — once #747 lands, this can be swapped to import `WebFeatureFlags`.
- * Default OFF (must be explicitly enabled per environment).
+ * Whether the Juice Points program is live. Delegates to the shared
+ * `WebFeatureFlags.JUICE_POINTS_PROGRAM` (default ON).
  */
 export function isJuicePointsProgramEnabled(): boolean {
-  return process.env.REACT_APP_JUICE_POINTS_PROGRAM === 'true'
+  return WebFeatureFlags.JUICE_POINTS_PROGRAM
 }
 
 export function useIsJuicerCampaignVisible(): boolean {
   const { defaultChainId } = useEnabledChains()
   const isCampaignTimeActive = useIsJuicerTimeActive()
-  // The Juicer NFT depends on the JP program (5,000 JP cost + 500 JP
-  // meme-token bonus). If the JP program is dark in this environment the
-  // Juicer flow stays hidden too.
-  return isJuicePointsProgramEnabled() && isCampaignTimeActive && defaultChainId === UniverseChainId.CitreaMainnet
+  // The points program can be live while the NFT stays hidden: people collect
+  // points, but the Juicer NFT flow only surfaces once it is explicitly
+  // unlocked (JUICE_POINTS_NFT). It still depends on the points program being
+  // live (5,000 JP cost + 500 JP meme-token bonus), an active window and
+  // Citrea Mainnet.
+  return (
+    WebFeatureFlags.JUICE_POINTS_NFT &&
+    isJuicePointsProgramEnabled() &&
+    isCampaignTimeActive &&
+    defaultChainId === UniverseChainId.CitreaMainnet
+  )
 }
 
 // eslint-disable-next-line import/no-unused-modules


### PR DESCRIPTION
Takes the Juice Points program live while keeping every NFT-acquisition surface hidden until explicitly unlocked.

- `JUICE_POINTS_PROGRAM` now defaults **ON** — leaderboard, header points ticker and account-drawer points are live.
- New `JUICE_POINTS_NFT` flag (default **OFF**) gates all NFT surfaces: the Juicer NFT page + nav tab, the Juicer/First Squeezer claim sections, and NFT-as-PFP. People collect points; the NFT stays hidden until `REACT_APP_JUICE_POINTS_NFT=true`.
- Header points come from the real ponder API (primary + fallback) and fall back to **zeros, never a fabricated mock** (kills the bogus ~1,400). The deterministic mock is now opt-in via `REACT_APP_JUICE_POINTS_DEV_MOCK`.
- Adds focused tests for the points API behavior.

Big Brother DRY: no defects (all 12 acceptance criteria satisfied, flags correct, lint clean, tests green).