### PR TITLE
feat(swap): client-side JUSD direct-pool fallback when gateway is paused

### DIFF
--- a/apps/web/src/state/sagas/transactions/swapSaga.ts
+++ b/apps/web/src/state/sagas/transactions/swapSaga.ts
@@ -66,6 +66,7 @@ import {
   isClassic,
   isErc20ChainSwap,
   isGatewayJusd,
+  isJusdDirectPool,
   isLightningBridge,
   isWbtcBridge,
 } from 'uniswap/src/features/transactions/swap/utils/routing'
@@ -311,8 +312,10 @@ function* swap(params: SwapParams) {
         }
         case TransactionStepType.SwapTransaction:
         case TransactionStepType.SwapTransactionAsync: {
-          // Gateway trades execute like Classic trades but have different routing type
-          if (!isGatewayJusd(swapTxContext)) {
+          // Gateway and direct-pool trades execute like Classic trades (single ERC20-router call
+          // from swapTxContext.txRequests) but carry a custom routing type, so skip the strict
+          // routing assertion for them.
+          if (!isGatewayJusd(swapTxContext) && !isJusdDirectPool(swapTxContext)) {
             requireRouting(trade, [Routing.CLASSIC, Routing.BRIDGE])
           }
           yield* call(handleSwapTransactionStep, {
@@ -328,8 +331,8 @@ function* swap(params: SwapParams) {
           break
         }
         case TransactionStepType.SwapTransactionBatched: {
-          // Gateway trades execute like Classic trades but have different routing type
-          if (!isGatewayJusd(swapTxContext)) {
+          // Gateway and direct-pool trades execute like Classic trades but carry a custom routing type.
+          if (!isGatewayJusd(swapTxContext) && !isJusdDirectPool(swapTxContext)) {
             requireRouting(trade, [Routing.CLASSIC, Routing.BRIDGE])
           }
           yield* call(handleSwapTransactionBatchedStep, {

--- a/docs/jusd-liquidity-migration.md
+++ b/docs/jusd-liquidity-migration.md
@@ -1,0 +1,108 @@
+# JUSD liquidity migration: redeem svJUSD → JUSD, seed a JUSD/WCBTC pool
+
+**Status (verified on-chain, 2026-07-02):** selling JUSD on Citrea Mainnet is broken. This document
+explains why, why the fix requires converting the existing svJUSD liquidity back into raw JUSD and
+seeding a **new JUSD/WCBTC pool**, and how PR
+[#775](https://github.com/JuiceSwapxyz/bapp/pull/775) resolves every resulting problem once that
+pool exists.
+
+## 1. What is broken, exactly
+
+The quote API (`/v1/quote`) special-cases the JUSD token address and always routes it through the
+JuiceSwap Gateway, regardless of the `protocols` the client requests:
+
+```
+sell JUSD:  JUSD --Savings.save()--> svJUSD --V3 pool--> cBTC     ← reverts
+buy  JUSD:  cBTC --V3 pool--> svJUSD --withdraw()--> JUSD         ← still works
+```
+
+The savings interest rate is currently **0%** (`SavingsGateway.currentRatePPM() == 0` at
+`0x22FE239892eBC8805DA8f05eD3bc6aF75332b60b`, re-verified 2026-07-02). At a 0% rate the vault's
+deposit leg (`Savings.save()` / `SavingsVaultJUSD._deposit()`) reverts with `ModuleDisabled()`.
+Since every JUSD *sell* must first wrap JUSD into svJUSD through that exact leg, **selling JUSD is
+impossible** — the API returns `GATEWAY_*_DISABLED` and the app shows a dead end. Buying JUSD keeps
+working because the redeem/withdraw leg of the vault is not gated on the rate.
+
+Two structural facts follow from this:
+
+1. **All on-chain JUSD liquidity is in the wrong token.** The only existing pool is
+   **svJUSD/cBTC**. That pool is only reachable *through* the Gateway wrap — the exact component
+   that is paused. For a JUSD seller, that liquidity might as well not exist.
+2. **No Gateway-free trading route exists.** There is no raw JUSD/WCBTC pool at any fee tier
+   (factory `getPool` returns the zero address for 0.05%, 0.3% and 1% — re-verified 2026-07-02).
+
+## 2. Why svJUSD must become JUSD again
+
+svJUSD is an ERC-4626 vault share, not money: it can only be created and redeemed through the
+Gateway. Holding LP liquidity as svJUSD made sense while the savings rate was positive (LPs earned
+the rate on top of fees) and the Gateway wrapped every trade transparently. Both premises are gone:
+
+- **The yield is 0%.** `currentRatePPM() == 0` — svJUSD earns nothing over raw JUSD.
+- **The wrapper is the single point of failure.** Every JUSD trade dies in `save()`. As long as the
+  tradeable pool is denominated in svJUSD, JUSD trading is coupled to the Gateway's pause state.
+  Denominating the pool in raw JUSD removes that coupling permanently: the pool keeps working at a
+  0% rate, at a positive rate, and during any future Gateway pause.
+- **Redemption is open.** Only the deposit leg is disabled; `redeem()` works. The vault currently
+  holds **≈ 2,721.4 JUSD** backing **≈ 2,641.7 svJUSD** (1 svJUSD ≈ 1.0302 JUSD), so the seed
+  liquidity is sitting right there and can be unwrapped today.
+
+In short: svJUSD → JUSD is not a workaround, it is the correction. The savings vault goes back to
+being what it is (an optional yield product), and trading liquidity goes where it belongs (a plain
+V3 pool).
+
+## 3. Why a new pool is required
+
+The client-side fallback shipped in #775 trades **raw JUSD ↔ WCBTC directly against a JuiceSwap V3
+pool via SwapRouter02** (`0x565eD3D57fe40f78A46f348C220121AE093c3cF8`), with zero dependency on the
+API or the Gateway. That route needs a funded JUSD/WCBTC pool — and none exists. Until one is
+seeded, the fallback deliberately stays inert (`getJusdDirectPoolQuote` resolves to `null`) and
+users see an honest "JUSD swaps temporarily paused" message instead of the old generic error.
+
+Creating the pool is a one-time, permissionless operation. `scripts/seed-jusd-wcbtc-pool.mjs`
+performs the full migration in one run.
+
+## 4. Runbook: seeding the pool
+
+> The script moves real funds. Review every step; never commit or paste the private key anywhere.
+
+1. **Fund a wallet** with the svJUSD (or raw JUSD) earmarked as liquidity, WCBTC (wrap native cBTC
+   beforehand if needed), and a little cBTC for gas.
+2. **Dry-run** — prints the computed price, ticks and amounts, sends nothing:
+
+   ```bash
+   PRIVATE_KEY=0x... \
+   JUSD_AMOUNT=1000 \
+   WCBTC_AMOUNT=0.017 \
+   FEE_TIER=3000 \
+   CBTC_PRICE_USD=<current cBTC/USD price> \
+   node scripts/seed-jusd-wcbtc-pool.mjs --dry-run
+   ```
+
+   `JUSD_AMOUNT / WCBTC_AMOUNT` must match `CBTC_PRICE_USD` (e.g. 1000 JUSD ↔ 1000 / price WCBTC),
+   otherwise the pool opens off-market and gets arbitraged immediately.
+3. **Execute** (drop `--dry-run`). The script then:
+   1. redeems the wallet's entire svJUSD balance back to raw JUSD (`redeem()` on the vault) — this
+      is the svJUSD → JUSD conversion from section 2;
+   2. approves the position manager;
+   3. creates and initializes the JUSD/WCBTC pool at the chosen fee tier if it doesn't exist;
+   4. mints a full-range liquidity position to the wallet.
+4. **Verify**: factory `getPool(JUSD, WCBTC, 3000)` returns a non-zero address with non-zero
+   liquidity. No app deployment or config change is needed — the fallback detects the pool on the
+   next quote poll and activates itself.
+
+## 5. What #775 fixes once the pool exists
+
+| Problem today | After #775 + seeded pool |
+|---|---|
+| Selling JUSD is impossible (Gateway `save()` reverts `ModuleDisabled`) | JUSD sells route through the JUSD/WCBTC pool via SwapRouter02 — no Gateway, no API involved |
+| Generic "This trade cannot be completed" dead end | Until the pool exists: honest "JUSD swaps temporarily paused" message with the API's real reason |
+| JUSD trading fully coupled to api.juiceswap.com and the Gateway pause state | Quote is computed from on-chain pool state; calldata is built locally against the verified SwapRouter02 ABI |
+| Any future Gateway pause breaks JUSD sells again | Fallback engages automatically on any `GATEWAY_*_DISABLED` quote error — permanent safety net |
+| Risk of displayed vs. executed slippage diverging | Single slippage source: the displayed "minimum received" is byte-identical to the on-chain `amountOutMinimum` |
+
+Deliberately unchanged: buying JUSD (works today, keeps its route), all non-JUSD pairs, and all
+other quote errors (rate limits, amount-too-small, transient failures surface exactly as before —
+the fallback never masks them).
+
+Seeding the pool and merging the PR are independent — either order works, the feature simply
+activates when both are live.

--- a/packages/uniswap/src/components/modals/WarningModal/types.ts
+++ b/packages/uniswap/src/components/modals/WarningModal/types.ts
@@ -54,6 +54,7 @@ export enum WarningLabel {
   BlockedToken = 'blocked_token',
   NoQuotesFound = 'no_quotes_found',
   ExceedsLimit = 'exceeds_limit',
+  GatewayJusdDisabled = 'gateway_jusd_disabled',
 }
 
 export interface Warning {

--- a/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
@@ -203,6 +203,33 @@ export type SatsumaQuoteResponse = {
   permitData: null
 }
 
+// DIRECT_POOL is a client-side routing type: unlike SATSUMA/GATEWAY the quote is NOT emitted by
+// the api. It is computed locally in `tradeService.getTrade` from on-chain JUSD/WCBTC pool state
+// (see features/transactions/swap/utils/jusdDirectPool.ts) and carries everything the local swap
+// service needs to build calldata without any further network calls.
+export type DirectPoolQuote = {
+  chainId: number
+  swapper: string
+  // Raw (wei) input/output amounts computed from the pool.
+  amountIn: string
+  amountOut: string
+  // On-chain pool + routing details used to build the SwapRouter02 calldata.
+  poolAddress: string
+  fee: number
+  tokenIn: string
+  tokenOut: string
+  // True when the user selected native cBTC as output (requires unwrapWETH9).
+  outputIsNative: boolean
+  slippageToleranceBps: number
+}
+
+export type DirectPoolQuoteResponse = {
+  requestId: string
+  quote: DirectPoolQuote
+  routing: 'DIRECT_POOL'
+  permitData: null
+}
+
 export type WrapQuoteResponse<T extends Routing.WRAP | Routing.UNWRAP> = QuoteResponse & {
   quote: WrapUnwrapQuote
   routing: T

--- a/packages/uniswap/src/features/transactions/swap/analytics.ts
+++ b/packages/uniswap/src/features/transactions/swap/analytics.ts
@@ -22,6 +22,7 @@ import type { ClassicTrade, Trade } from 'uniswap/src/features/transactions/swap
 import { SwapEventType, timestampTracker } from 'uniswap/src/features/transactions/swap/utils/SwapEventTimestampTracker'
 import { getSwapFeeUsd } from 'uniswap/src/features/transactions/swap/utils/getSwapFeeUsd'
 import {
+  DIRECT_POOL_ROUTING,
   GATEWAY_JUSD_ROUTING,
   SATSUMA_ROUTING,
   TradeRouting,
@@ -390,6 +391,9 @@ export function tradeRoutingToFillType({
   }
   if (routing === SATSUMA_ROUTING) {
     return 'classic' // SATSUMA is a same-chain direct swap via Algebra pool, report as classic
+  }
+  if (routing === DIRECT_POOL_ROUTING) {
+    return 'classic' // DIRECT_POOL is a same-chain direct V3 swap, report as classic
   }
 
   switch (routing) {

--- a/packages/uniswap/src/features/transactions/swap/hooks/useSwapWarnings/getSwapWarningFromError.ts
+++ b/packages/uniswap/src/features/transactions/swap/hooks/useSwapWarnings/getSwapWarningFromError.ts
@@ -1,6 +1,6 @@
 import { TFunction } from 'i18next'
 import { Warning, WarningAction, WarningLabel, WarningSeverity } from 'uniswap/src/components/modals/WarningModal/types'
-import { FetchError, isRateLimitFetchError } from 'uniswap/src/data/apiClients/FetchError'
+import { FetchError, getFetchErrorMessage, isRateLimitFetchError } from 'uniswap/src/data/apiClients/FetchError'
 import { Err404 } from 'uniswap/src/data/tradingApi/__generated__'
 
 import { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
@@ -41,6 +41,25 @@ export function getSwapWarningFromError({
         action: WarningAction.DisableReview,
         title: t('swap.warning.insufficientBridgeLiquidity.title'),
         message: t('swap.warning.insufficientBridgeLiquidity.message'),
+      }
+    }
+
+    // JUSD Gateway deposit/withdrawal paused (e.g. savings rate is 0%).
+    // This is a deliberate protocol-level pause, not a routing failure — surface the
+    // real reason instead of the generic "trade cannot be completed" message.
+    if (typeof error.data?.error === 'string' && /^GATEWAY_.*_DISABLED$/.test(error.data.error)) {
+      return {
+        type: WarningLabel.GatewayJusdDisabled,
+        severity: WarningSeverity.Medium,
+        action: WarningAction.DisableReview,
+        title: t('swap.warning.gatewayJusdDisabled.title'),
+        message: t('swap.warning.gatewayJusdDisabled.message', {
+          // Prefer the human-readable `detail` field over the raw `error` code.
+          reason:
+            (typeof error.data?.detail === 'string' ? error.data.detail : undefined) ??
+            getFetchErrorMessage(error) ??
+            t('swap.warning.gatewayJusdDisabled.title'),
+        }),
       }
     }
 

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfo.ts
@@ -1,0 +1,100 @@
+import type { Address } from 'viem'
+import { Routing } from 'uniswap/src/data/tradingApi/__generated__'
+import type { GasFeeResult } from 'uniswap/src/features/gas/types'
+import type { ClassicSwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
+import type { ClassicTrade, JusdDirectPoolTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import {
+  buildJusdDirectPoolSwapTx,
+  buildJusdRouterApprovalTx,
+} from 'uniswap/src/features/transactions/swap/utils/jusdDirectPool'
+import { DIRECT_POOL_ROUTING } from 'uniswap/src/features/transactions/swap/utils/routing'
+import { validateTransactionRequest } from 'uniswap/src/features/transactions/swap/utils/trade'
+import type { ValidatedTransactionRequest } from 'uniswap/src/features/transactions/types/transactionRequests'
+
+// Gas for these txns is paid at execution time; we don't have a local estimate here, so surface a
+// zero-valued (but valid) gas fee result. NOTE: this under-reports gas in the review UI. It does
+// not affect the actual on-chain gas the user pays.
+const ZERO_GAS_FEE_RESULT: GasFeeResult = {
+  value: '0',
+  displayValue: '0',
+  isLoading: false,
+  error: null,
+}
+
+/**
+ * Builds a Classic-shaped SwapTxAndGasInfo for a JUSD direct-pool trade from local data only — no
+ * api calls. `allowance` is the caller's current JUSD allowance to SwapRouter02; when insufficient
+ * we attach a plain ERC20 approve (SwapRouter02 pulls via `transferFrom`, so no Permit2 is
+ * involved).
+ *
+ * Slippage is taken from `trade.quote.quote.slippageToleranceBps` — the value baked from the user's
+ * live setting at getTrade time and the SAME one that backs `trade.minAmountOut`. So the executed
+ * `amountOutMinimum` is always exactly the "minimum received" the review UI promised: single source
+ * of truth, no display/execution divergence.
+ *
+ * The result rides the same Classic validation/step path as Satsuma/Gateway (see
+ * validateSwapTxContext / generateSwapTransactionSteps).
+ */
+export function buildJusdDirectPoolSwapTxAndGasInfo({
+  trade,
+  allowance,
+}: {
+  trade: JusdDirectPoolTrade
+  allowance: bigint
+}): ClassicSwapTxAndGasInfo {
+  const { quote } = trade.quote
+  const chainId = quote.chainId
+  const swapper = quote.swapper as Address
+  const amountIn = BigInt(quote.amountIn)
+
+  const swapTx = buildJusdDirectPoolSwapTx({
+    quote: {
+      poolAddress: quote.poolAddress as Address,
+      fee: quote.fee,
+      amountIn,
+      amountOut: BigInt(quote.amountOut),
+      tokenIn: quote.tokenIn as Address,
+      tokenOut: quote.tokenOut as Address,
+    },
+    recipient: swapper,
+    slippageToleranceBps: quote.slippageToleranceBps,
+    outputIsNative: quote.outputIsNative,
+  })
+
+  const swapTxRequest: ValidatedTransactionRequest = {
+    to: swapTx.to,
+    from: swapper,
+    data: swapTx.data,
+    value: swapTx.value.toString(),
+    chainId,
+  }
+
+  // Approve SwapRouter02 for JUSD when the current allowance can't cover this swap. We approve the
+  // exact input amount rather than MaxUint256 to keep the grant tight; a re-quote after the user
+  // raises the amount re-checks and re-approves.
+  const needsApproval = allowance < amountIn
+  const approvalCall = buildJusdRouterApprovalTx(amountIn)
+  const approveTxRequest: ValidatedTransactionRequest | undefined = needsApproval
+    ? validateTransactionRequest({
+        to: approvalCall.to,
+        from: swapper,
+        data: approvalCall.data,
+        value: approvalCall.value.toString(),
+        chainId,
+      })
+    : undefined
+
+  return {
+    routing: DIRECT_POOL_ROUTING as unknown as Routing.CLASSIC,
+    trade: trade as unknown as ClassicTrade,
+    gasFee: ZERO_GAS_FEE_RESULT,
+    gasFeeEstimation: {},
+    approveTxRequest,
+    revocationTxRequest: undefined,
+    txRequests: [swapTxRequest],
+    permit: undefined,
+    swapRequestArgs: undefined,
+    unsigned: false,
+    includesDelegation: false,
+  }
+}

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfoService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfoService.ts
@@ -1,0 +1,33 @@
+import type { Address } from 'viem'
+import { buildJusdDirectPoolSwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfo'
+import type {
+  SwapTxAndGasInfoParameters,
+  SwapTxAndGasInfoService,
+} from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService'
+import type { SwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
+import type { JusdDirectPoolTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { getJusdRouterAllowance } from 'uniswap/src/features/transactions/swap/utils/jusdDirectPool'
+
+/**
+ * Direct-pool swap service — handles the client-side JUSD-sell fallback. Unlike the Satsuma/Gateway
+ * services it makes NO api call: the swap calldata is built locally from the trade's on-chain quote
+ * (see directPoolSwapTxAndGasInfo), and slippage comes from the quote itself (baked from the user's
+ * live setting at getTrade time). The only network read here is the JUSD→SwapRouter02 allowance,
+ * used to decide whether an approve step is needed.
+ */
+export function createDirectPoolSwapTxAndGasInfoService(): SwapTxAndGasInfoService<JusdDirectPoolTrade> {
+  const service: SwapTxAndGasInfoService<JusdDirectPoolTrade> = {
+    async getSwapTxAndGasInfo(params: SwapTxAndGasInfoParameters<JusdDirectPoolTrade>): Promise<SwapTxAndGasInfo> {
+      const { trade } = params
+      const owner = trade.quote.quote.swapper
+
+      // If the wallet isn't connected yet the swapper is an empty placeholder; treat as no allowance
+      // so the review screen shows the approve step until the real account re-quotes.
+      const allowance = owner ? await getJusdRouterAllowance(owner as Address) : BigInt(0)
+
+      return buildJusdDirectPoolSwapTxAndGasInfo({ trade, allowance })
+    },
+  }
+
+  return service
+}

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/hooks.ts
@@ -15,6 +15,7 @@ import { useTokenApprovalInfo } from 'uniswap/src/features/transactions/swap/rev
 import { createBitcoinBridgeSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/bitcoin/bitcoinBridgeSwapTxAndGasInfoService'
 import { createBridgeSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/bridge/bridgeSwapTxAndGasInfoService'
 import { createClassicSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/classic/classicSwapTxAndGasInfoService'
+import { createDirectPoolSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfoService'
 import { FALLBACK_SWAP_REQUEST_POLL_INTERVAL_MS } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/constants'
 import { createErc20ChainSwapTxAndGasInfoService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/erc20ChainSwap/erc20ChainSwapTxAndGasInfoService'
 import { createEVMSwapInstructionsService } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/evm/evmSwapInstructionsService'
@@ -39,6 +40,7 @@ import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/typ
 import type { SwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
 import type { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
 import {
+  DIRECT_POOL_ROUTING,
   GATEWAY_JUICE_IN_ROUTING,
   GATEWAY_JUICE_OUT_ROUTING,
   GATEWAY_JUSD_ROUTING,
@@ -156,6 +158,10 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
     })
   }, [swapConfig.gasStrategy, transactionSettings])
 
+  const directPoolSwapTxInfoService = useMemo(() => {
+    return createDirectPoolSwapTxAndGasInfoService()
+  }, [])
+
   const services = useMemo(() => {
     return {
       [Routing.CLASSIC]: classicSwapTxInfoService,
@@ -178,6 +184,8 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
       [GATEWAY_JUICE_OUT_ROUTING]: gatewayJusdSwapTxInfoService as unknown as SwapTxAndGasInfoService,
       // Satsuma direct routing (USDC.e/ctUSD on Citrea Mainnet)
       [SATSUMA_ROUTING]: satsumaSwapTxInfoService as unknown as SwapTxAndGasInfoService,
+      // Direct-pool routing (client-side JUSD-sell fallback when the Gateway is paused)
+      [DIRECT_POOL_ROUTING]: directPoolSwapTxInfoService as unknown as SwapTxAndGasInfoService,
     } satisfies RoutingServicesMap
   }, [
     classicSwapTxInfoService,
@@ -189,6 +197,7 @@ export function useSwapTxAndGasInfoService(): SwapTxAndGasInfoService {
     erc20ChainSwapTxInfoService,
     gatewayJusdSwapTxInfoService,
     satsumaSwapTxInfoService,
+    directPoolSwapTxInfoService,
   ])
 
   return useMemo(() => {

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/swapTxAndGasInfoService.ts
@@ -3,7 +3,11 @@ import type { ApprovalTxInfo } from 'uniswap/src/features/transactions/swap/revi
 import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
 import type { SwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
 import type { Trade } from 'uniswap/src/features/transactions/swap/types/trade'
-import type { GatewayJusdRouting, SatsumaRouting } from 'uniswap/src/features/transactions/swap/utils/routing'
+import type {
+  DirectPoolRouting,
+  GatewayJusdRouting,
+  SatsumaRouting,
+} from 'uniswap/src/features/transactions/swap/utils/routing'
 
 export type SwapTxAndGasInfoParameters<T extends Trade = Trade> = {
   derivedSwapInfo: DerivedSwapInfo
@@ -16,16 +20,18 @@ export interface SwapTxAndGasInfoService<T extends Trade = Trade> {
   getSwapTxAndGasInfo: (ctx: SwapTxAndGasInfoParameters<T>) => Promise<SwapTxAndGasInfo>
 }
 
-// Include both Routing enum values and custom routing types like GATEWAY_JUSD and SATSUMA
+// Include both Routing enum values and custom routing types like GATEWAY_JUSD, SATSUMA and DIRECT_POOL
 export type RoutingServicesMap = { [K in Routing]: SwapTxAndGasInfoService<Trade & { routing: K }> } & {
   [K in GatewayJusdRouting]: SwapTxAndGasInfoService<Trade & { routing: K }>
 } & {
   [K in SatsumaRouting]: SwapTxAndGasInfoService<Trade & { routing: K }>
+} & {
+  [K in DirectPoolRouting]: SwapTxAndGasInfoService<Trade & { routing: K }>
 }
 
 export function createSwapTxAndGasInfoService(ctx: { services: RoutingServicesMap }): SwapTxAndGasInfoService<Trade> {
   function getServiceForTrade<T extends Trade>(trade: T): SwapTxAndGasInfoService<T> {
-    const service = ctx.services[trade.routing as Routing | GatewayJusdRouting | SatsumaRouting]
+    const service = ctx.services[trade.routing as Routing | GatewayJusdRouting | SatsumaRouting | DirectPoolRouting]
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!service) {
       throw new Error(`Unsupported routing: ${trade.routing}`)

--- a/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/utils.ts
+++ b/packages/uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/utils.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import type {
   BridgeQuoteResponse,
   ClassicQuoteResponse,
+  DirectPoolQuoteResponse,
   DiscriminatedQuoteResponse,
   GatewayJusdQuoteResponse,
   SatsumaQuoteResponse,
@@ -418,7 +419,9 @@ const EMPTY_PERMIT_TX_INFO: PermitTxInfo = {
 export function usePermitTxInfo({
   quote,
 }: {
-  quote?: DiscriminatedQuoteResponse | GatewayJusdQuoteResponse | SatsumaQuoteResponse
+  // Accepts any trade quote; only Classic quotes carry a permit, everything else (Gateway,
+  // Satsuma, DIRECT_POOL, bridges, …) falls through to EMPTY_PERMIT_TX_INFO.
+  quote?: DiscriminatedQuoteResponse | GatewayJusdQuoteResponse | SatsumaQuoteResponse | DirectPoolQuoteResponse
 }): PermitTxInfo {
   const classicQuote = quote && isClassic(quote) ? quote : undefined
   const gasStrategy = useActiveGasStrategy(classicQuote?.quote.chainId, 'swap')

--- a/packages/uniswap/src/features/transactions/swap/services/tradeService/tradeService.ts
+++ b/packages/uniswap/src/features/transactions/swap/services/tradeService/tradeService.ts
@@ -13,6 +13,7 @@ import {
   validateParsedInput,
   type ValidatedTradeInput,
 } from 'uniswap/src/features/transactions/swap/services/tradeService/transformations/buildQuoteRequest'
+import { tryBuildJusdDirectPoolTrade } from 'uniswap/src/features/transactions/swap/services/tradeService/transformations/buildJusdDirectPoolTrade'
 import { transformQuoteToTrade } from 'uniswap/src/features/transactions/swap/services/tradeService/transformations/transformQuoteToTrade'
 import {
   IndicativeTrade,
@@ -59,6 +60,16 @@ interface TradeServiceContext {
   getEnabledChains: () => UniverseChainId[]
   getIsL2ChainId: (chainId?: UniverseChainId) => boolean
   getMinAutoSlippageToleranceL2: () => number
+}
+
+/**
+ * True when a fetchQuote error is the JuiceSwap Gateway being deliberately paused (e.g. savings
+ * rate 0%), surfaced by the api as `{ error: "GATEWAY_*_DISABLED", … }`. Kept intentionally narrow
+ * so the direct-pool fallback never masks unrelated failures.
+ */
+function isGatewayDisabledError(error: unknown): boolean {
+  const data = (error as { data?: { error?: unknown } } | undefined)?.data
+  return typeof data?.error === 'string' && /^GATEWAY_.*_DISABLED$/.test(data.error)
 }
 
 export function createTradeService(ctx: TradeServiceContext): TradeService {
@@ -120,7 +131,24 @@ export function createTradeService(ctx: TradeServiceContext): TradeService {
         quoteRequestArgs = flattenQuoteRequestResult(quoteRequestParams)
 
         // Step 4: Fetch quote from API
-        const quoteResponse = await tradeRepository.fetchQuote(quoteRequestArgs)
+        let quoteResponse
+        try {
+          quoteResponse = await tradeRepository.fetchQuote(quoteRequestArgs)
+        } catch (fetchError) {
+          // JUSD-sell fallback — narrowly scoped to the paused-gateway condition only. When the
+          // JuiceSwap Gateway is disabled (savings rate 0% -> `GATEWAY_*_DISABLED`), JUSD can't be
+          // sold via the api, so we build a trade from a real on-chain JUSD/WCBTC V3 pool instead.
+          // We deliberately do NOT fall back on other errors (rate limits, transient failures,
+          // amount-too-small): those must surface unchanged rather than silently rerouting the user
+          // into a possibly-thin pool.
+          if (isGatewayDisabledError(fetchError)) {
+            const directPoolTrade = await tryBuildJusdDirectPoolTrade(validatedInput, input.customSlippageTolerance)
+            if (directPoolTrade) {
+              return { trade: directPoolTrade, gasEstimate: undefined }
+            }
+          }
+          throw fetchError
+        }
 
         // Step 5: Transform quote to trade
         const result = transformQuoteToTrade({

--- a/packages/uniswap/src/features/transactions/swap/services/tradeService/transformations/buildJusdDirectPoolTrade.ts
+++ b/packages/uniswap/src/features/transactions/swap/services/tradeService/transformations/buildJusdDirectPoolTrade.ts
@@ -1,0 +1,94 @@
+import type { Address } from 'viem'
+import type { DirectPoolQuoteResponse } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
+import { TradeType } from 'uniswap/src/data/tradingApi/__generated__'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+import { isUniverseChainId } from 'uniswap/src/features/chains/utils'
+import type { ValidatedTradeInput } from 'uniswap/src/features/transactions/swap/services/tradeService/transformations/buildQuoteRequest'
+import { JusdDirectPoolTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import {
+  getJusdDirectPoolQuote,
+  isJusdDirectPoolSupported,
+  slippagePercentToBps,
+} from 'uniswap/src/features/transactions/swap/utils/jusdDirectPool'
+
+/**
+ * Client-side fallback for selling JUSD when the JuiceSwap Gateway quote fails (e.g. the gateway is
+ * paused because the savings rate is 0%). Reads a real on-chain JUSD/WCBTC V3 pool and, if one is
+ * seeded, returns a locally-constructed `JusdDirectPoolTrade`. Returns `null` when the pair/chain is
+ * not supported, the trade is not exact-input, or no funded pool exists yet — in which case the
+ * caller should surface the original gateway error.
+ *
+ * This performs read-only RPC calls only; it never mutates state.
+ */
+export async function tryBuildJusdDirectPoolTrade(
+  validatedInput: ValidatedTradeInput,
+  customSlippageTolerance: number | undefined,
+): Promise<JusdDirectPoolTrade | null> {
+  const { currencyIn, currencyOut, amount, requestTradeType, activeAccountAddress } = validatedInput
+
+  // The direct-pool math is exact-input only.
+  if (requestTradeType !== TradeType.EXACT_INPUT) {
+    return null
+  }
+
+  const chainId = currencyIn.chainId
+  if (!isUniverseChainId(chainId) || chainId !== UniverseChainId.CitreaMainnet) {
+    return null
+  }
+
+  if (
+    !isJusdDirectPoolSupported({
+      chainId,
+      tokenInAddress: validatedInput.tokenInAddress as Address,
+      tokenOutAddress: validatedInput.tokenOutAddress as Address,
+    })
+  ) {
+    return null
+  }
+
+  const amountInRaw = BigInt(amount.quotient.toString())
+
+  // The fallback must never mask the caller's original gateway error: any RPC/read failure here
+  // resolves to `null` so the caller re-throws the gateway error instead of a confusing pool error.
+  let poolQuote
+  try {
+    poolQuote = await getJusdDirectPoolQuote(amountInRaw)
+  } catch {
+    return null
+  }
+  if (!poolQuote) {
+    return null
+  }
+
+  // Bake the user's live slippage into the quote so display (minAmountOut/slippageTolerance) and
+  // execution (amountOutMinimum) share one value and can never diverge. getTrade re-runs each poll
+  // with the current setting, so this stays current within one poll interval after a change.
+  const slippageToleranceBps = slippagePercentToBps(customSlippageTolerance)
+
+  const quote: DirectPoolQuoteResponse = {
+    // requestId is used as the swap-tx-info query key; it includes the slippage so the swap tx
+    // refetches when the user changes slippage, and is otherwise stable per (amountIn, amountOut).
+    requestId: `direct-pool-${poolQuote.tokenIn}-${poolQuote.tokenOut}-${poolQuote.fee}-${poolQuote.amountIn.toString()}-${poolQuote.amountOut.toString()}-${slippageToleranceBps}`,
+    routing: 'DIRECT_POOL',
+    permitData: null,
+    quote: {
+      chainId,
+      swapper: activeAccountAddress ?? '',
+      amountIn: poolQuote.amountIn.toString(),
+      amountOut: poolQuote.amountOut.toString(),
+      poolAddress: poolQuote.poolAddress,
+      fee: poolQuote.fee,
+      tokenIn: poolQuote.tokenIn,
+      tokenOut: poolQuote.tokenOut,
+      outputIsNative: currencyOut.isNative,
+      slippageToleranceBps,
+    },
+  }
+
+  return new JusdDirectPoolTrade({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType: TradeType.EXACT_INPUT,
+  })
+}

--- a/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useJusdDirectPoolSwapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useJusdDirectPoolSwapTxAndGasInfo.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import type { Address } from 'viem'
+import { buildJusdDirectPoolSwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/directPool/directPoolSwapTxAndGasInfo'
+import type { SwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
+import type { JusdDirectPoolTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { getJusdRouterAllowance } from 'uniswap/src/features/transactions/swap/utils/jusdDirectPool'
+import { ONE_SECOND_MS } from 'utilities/src/time/time'
+
+/**
+ * Legacy-path equivalent of `createDirectPoolSwapTxAndGasInfoService`. Reads the JUSD→SwapRouter02
+ * allowance on-chain, then builds the direct-pool swap tx (+ approve, if needed) entirely locally.
+ * Slippage comes from the trade's quote (baked from the user's live setting at getTrade time), so
+ * this path and the service path produce identical `amountOutMinimum`. Returns `undefined` when
+ * `trade` is not a direct-pool trade so the caller can fall through.
+ */
+export function useJusdDirectPoolSwapTxAndGasInfo(trade: JusdDirectPoolTrade | undefined): SwapTxAndGasInfo | undefined {
+  const owner = trade?.quote.quote.swapper as Address | undefined
+
+  const { data: allowance } = useQuery({
+    queryKey: ['jusdDirectPoolAllowance', owner, trade?.quote.quote.amountIn],
+    queryFn: async (): Promise<string> => {
+      if (!owner) {
+        return '0'
+      }
+      const value = await getJusdRouterAllowance(owner)
+      return value.toString()
+    },
+    enabled: Boolean(trade && owner),
+    staleTime: 15 * ONE_SECOND_MS,
+    gcTime: 60 * ONE_SECOND_MS,
+  })
+
+  return useMemo(() => {
+    if (!trade) {
+      return undefined
+    }
+    // Until the allowance read resolves, assume none so the review screen shows the approve step
+    // rather than a swap that would revert; it re-renders once the real allowance arrives.
+    const allowanceValue = allowance ? BigInt(allowance) : BigInt(0)
+    return buildJusdDirectPoolSwapTxAndGasInfo({ trade, allowance: allowanceValue })
+  }, [trade, allowance])
+}

--- a/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useSwapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useSwapTxAndGasInfo.ts
@@ -11,6 +11,7 @@ import {
   getWrapTxAndGasInfo,
   usePermitTxInfo,
 } from 'uniswap/src/features/transactions/swap/review/services/swapTxAndGasInfoService/utils'
+import { useJusdDirectPoolSwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useJusdDirectPoolSwapTxAndGasInfo'
 import { useTransactionRequestInfo } from 'uniswap/src/features/transactions/swap/stores/swapTxStore/hooks/useTransactionRequestInfo'
 import type { DerivedSwapInfo } from 'uniswap/src/features/transactions/swap/types/derivedSwapInfo'
 import type { SwapTxAndGasInfo } from 'uniswap/src/features/transactions/swap/types/swapTxAndGasInfo'
@@ -22,7 +23,8 @@ import type {
   UniswapXTrade,
   WrapTrade,
 } from 'uniswap/src/features/transactions/swap/types/trade'
-import { isGatewayJusd, isSatsuma } from 'uniswap/src/features/transactions/swap/utils/routing'
+import type { JusdDirectPoolTrade } from 'uniswap/src/features/transactions/swap/types/trade'
+import { isGatewayJusd, isJusdDirectPool, isSatsuma } from 'uniswap/src/features/transactions/swap/utils/routing'
 import { AccountDetails } from 'uniswap/src/features/wallet/types/AccountDetails'
 import { CurrencyField } from 'uniswap/src/types/currency'
 
@@ -60,10 +62,20 @@ export function useSwapTxAndGasInfo({
 
   const permitTxInfo = usePermitTxInfo({ quote: trade?.quote })
 
+  // Direct-pool JUSD-sell fallback: built entirely client-side (no api call). The hook no-ops when
+  // the trade isn't a direct-pool trade, so it's safe to call unconditionally.
+  const directPoolTxAndGasInfo = useJusdDirectPoolSwapTxAndGasInfo(
+    trade && isJusdDirectPool(trade) ? (trade as JusdDirectPoolTrade) : undefined,
+  )
+
   return useMemo(() => {
     // Early return if trade is null/undefined to avoid accessing properties on null
     if (!trade) {
       return getFallbackSwapTxAndGasInfo({ swapTxInfo, approvalTxInfo })
+    }
+
+    if (isJusdDirectPool(trade) && directPoolTxAndGasInfo) {
+      return directPoolTxAndGasInfo
     }
 
     // Handle Gateway JUSD and Satsuma routing (string literals, not in the
@@ -113,5 +125,5 @@ export function useSwapTxAndGasInfo({
       default:
         return getFallbackSwapTxAndGasInfo({ swapTxInfo, approvalTxInfo })
     }
-  }, [approvalTxInfo, permitTxInfo, swapTxInfo, trade, bitcoinDestinationAddress])
+  }, [approvalTxInfo, permitTxInfo, swapTxInfo, trade, bitcoinDestinationAddress, directPoolTxAndGasInfo])
 }

--- a/packages/uniswap/src/features/transactions/swap/types/swapTxAndGasInfo.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/swapTxAndGasInfo.ts
@@ -2,7 +2,7 @@ import { Routing, CreateSwapRequest } from "uniswap/src/data/tradingApi/__genera
 import { GasEstimate } from "uniswap/src/data/tradingApi/types"
 import { GasFeeResult, ValidatedGasFeeResult, validateGasFeeResult } from "uniswap/src/features/gas/types"
 import { BridgeTrade, BitcoinBridgeTrade, LightningBridgeTrade, ClassicTrade, GatewayJusdTrade, UniswapXTrade, UnwrapTrade, WrapTrade } from "uniswap/src/features/transactions/swap/types/trade"
-import { isBridge, isBitcoinBridge, isErc20ChainSwap, isLightningBridge, isClassic, isGatewayJusd, isSatsuma, isUniswapX, isWrap, isWbtcBridge, GatewayJusdRouting } from "uniswap/src/features/transactions/swap/utils/routing"
+import { isBridge, isBitcoinBridge, isErc20ChainSwap, isLightningBridge, isClassic, isGatewayJusd, isJusdDirectPool, isSatsuma, isUniswapX, isWrap, isWbtcBridge, GatewayJusdRouting } from "uniswap/src/features/transactions/swap/utils/routing"
 import { isInterface } from "utilities/src/platform"
 import { Prettify } from "viem"
 import { ValidatedPermit } from "uniswap/src/features/transactions/swap/utils/trade"
@@ -196,14 +196,13 @@ function validateSwapTxContext(swapTxContext: SwapTxAndGasInfo): ValidatedSwapTx
       return validateClassicStyleSwap<ClassicSwapTxAndGasInfo, ValidatedClassicSwapTxAndGasInfo>({
         swapTxContext, context: swapTxContext, gasFee
       })
-    } else if (isGatewayJusd(swapTxContext) || isSatsuma(swapTxContext)) {
-      // Satsuma trades take the same validation path as Gateway-JUSD: both are
-      // string-literal routing variants that go through the JuiceSwap API
-      // /swap endpoint and produce a single ERC20-router call. There is no
-      // dedicated SatsumaSwapTxAndGasInfo type — `getClassicSwapTxAndGasInfo`
-      // (called from useSwapTxAndGasInfo) builds a ClassicSwapTxAndGasInfo-
-      // shaped object with the trade's routing carried through, so the cast
-      // here is structurally sound at runtime.
+    } else if (isGatewayJusd(swapTxContext) || isSatsuma(swapTxContext) || isJusdDirectPool(swapTxContext)) {
+      // Satsuma, Gateway-JUSD and DIRECT_POOL all take the Classic validation
+      // path: they are string-literal routing variants that produce a
+      // ClassicSwapTxAndGasInfo-shaped object (single ERC20-router call, no
+      // Permit2 sign). Satsuma/Gateway build theirs from the api /swap
+      // endpoint; DIRECT_POOL builds its txRequests + approve locally
+      // (see directPoolSwapTxAndGasInfo). The cast is structurally sound at runtime.
       return validateClassicStyleSwap<GatewayJusdSwapTxAndGasInfo, ValidatedGatewayJusdSwapTxAndGasInfo>({
         swapTxContext, context: swapTxContext as unknown as GatewayJusdSwapTxAndGasInfo, gasFee
       })

--- a/packages/uniswap/src/features/transactions/swap/types/trade.ts
+++ b/packages/uniswap/src/features/transactions/swap/types/trade.ts
@@ -18,6 +18,7 @@ import { MAX_AUTO_SLIPPAGE_TOLERANCE } from 'uniswap/src/constants/transactions'
 import {
   BridgeQuoteResponse,
   ClassicQuoteResponse,
+  DirectPoolQuoteResponse,
   DutchQuoteResponse,
   DutchV3QuoteResponse,
   GatewayJusdQuoteResponse,
@@ -436,6 +437,7 @@ export type Trade<
   | BridgeTrade
   | GatewayJusdTrade
   | SatsumaTrade
+  | JusdDirectPoolTrade
   | BitcoinBridgeTrade
   | LightningBridgeTrade
   | WrapTrade
@@ -883,6 +885,89 @@ export class SatsumaTrade {
   // routes so the swap UI can warn on bad quotes (issue #764).
   public get priceImpact(): Percent | undefined {
     return parseJuiceSwapPriceImpact(this.quote.quote.priceImpact)
+  }
+
+  public get quoteOutputAmount(): CurrencyAmount<Currency> {
+    return this.outputAmount
+  }
+
+  public get quoteOutputAmountUserWillReceive(): CurrencyAmount<Currency> {
+    return this.outputAmount
+  }
+}
+
+/**
+ * JusdDirectPoolTrade handles the client-side JUSD-sell fallback. Unlike SatsumaTrade/GatewayJusdTrade
+ * (whose quotes are emitted by the api), this trade's quote is computed locally in
+ * `tradeService.getTrade` from on-chain JUSD/WCBTC pool state when the JuiceSwap Gateway is paused.
+ * The swap calldata is likewise built locally (see utils/jusdDirectPool.ts) — there is no api call.
+ */
+export class JusdDirectPoolTrade {
+  readonly quote: DirectPoolQuoteResponse
+  readonly inputAmount: CurrencyAmount<Currency>
+  readonly outputAmount: CurrencyAmount<Currency>
+  readonly maxAmountIn: CurrencyAmount<Currency>
+  readonly minAmountOut: CurrencyAmount<Currency>
+  readonly executionPrice: Price<Currency, Currency>
+
+  readonly tradeType: TradeType
+  // Custom literal type to keep this distinct from ClassicTrade in unions
+  readonly routing = 'DIRECT_POOL' as const
+  readonly indicative = false
+  readonly swapFee?: SwapFee
+  readonly inputTax: Percent = ZERO_PERCENT
+  readonly outputTax: Percent = ZERO_PERCENT
+
+  readonly slippageTolerance: number
+  readonly priceImpact: undefined
+  readonly deadline: undefined
+
+  constructor({
+    quote,
+    currencyIn,
+    currencyOut,
+    tradeType,
+  }: {
+    quote: DirectPoolQuoteResponse
+    currencyIn: Currency
+    currencyOut: Currency
+    tradeType: TradeType
+  }) {
+    this.quote = quote
+
+    const inputRaw = quote.quote.amountIn
+    const outputRaw = quote.quote.amountOut
+    if (!inputRaw || !outputRaw) {
+      throw new Error('Error parsing direct-pool quote currency amounts')
+    }
+
+    const inputAmount = getCurrencyAmount({ value: inputRaw, valueType: ValueType.Raw, currency: currencyIn })
+    const outputAmount = getCurrencyAmount({ value: outputRaw, valueType: ValueType.Raw, currency: currencyOut })
+    if (!inputAmount || !outputAmount) {
+      throw new Error('Error parsing direct-pool quote currency amounts')
+    }
+
+    this.inputAmount = inputAmount
+    this.outputAmount = outputAmount
+    this.executionPrice = new Price(currencyIn, currencyOut, inputRaw, outputRaw)
+    this.tradeType = tradeType
+
+    // Single source of truth for slippage: `quote.slippageToleranceBps` is baked from the user's
+    // live setting at getTrade time and is the SAME value the swap calldata uses for
+    // amountOutMinimum (see directPoolSwapTxAndGasInfo). So `slippageTolerance` (display %) and
+    // `minAmountOut` (the "minimum received" the UI promises) both reflect the real on-chain floor
+    // — no divergence between what the user sees and what executes.
+    const bps = quote.quote.slippageToleranceBps
+    this.slippageTolerance = bps / 100
+    const minOutRaw = (BigInt(outputRaw) * BigInt(10_000 - bps)) / BigInt(10_000)
+    const minAmountOut = getCurrencyAmount({
+      value: minOutRaw.toString(),
+      valueType: ValueType.Raw,
+      currency: currencyOut,
+    })
+
+    this.maxAmountIn = this.inputAmount
+    this.minAmountOut = minAmountOut ?? this.outputAmount
   }
 
   public get quoteOutputAmount(): CurrencyAmount<Currency> {

--- a/packages/uniswap/src/features/transactions/swap/utils/generateSwapTransactionSteps.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/generateSwapTransactionSteps.ts
@@ -33,6 +33,7 @@ import {
   isClassic,
   isErc20ChainSwap,
   isGatewayJusd,
+  isJusdDirectPool,
   isLightningBridge,
   isSatsuma,
   isUniswapX,
@@ -49,10 +50,11 @@ export function generateSwapTransactionSteps(txContext: SwapTxAndGasInfo, _v4Ena
     const revocation = createRevocationTransactionStep(revocationTxRequest, trade.inputAmount.currency.wrapped)
     const approval = createApprovalTransactionStep({ txRequest: approveTxRequest, amountIn: trade.inputAmount })
 
-    if (isClassic(txContext) || isGatewayJusd(txContext) || isSatsuma(txContext)) {
+    if (isClassic(txContext) || isGatewayJusd(txContext) || isSatsuma(txContext) || isJusdDirectPool(txContext)) {
       // Cast to the union type since TypeScript has trouble narrowing with || on complex unions.
-      // Satsuma rides the same shape as Gateway here (single ERC20-router call, no Permit2 sign);
-      // see validateSwapTxContext in swapTxAndGasInfo.ts for the matching validation branch.
+      // Satsuma/DIRECT_POOL ride the same shape as Gateway here (single ERC20-router call, no
+      // Permit2 sign); DIRECT_POOL additionally carries a plain approve in approveTxRequest.
+      // See validateSwapTxContext in swapTxAndGasInfo.ts for the matching validation branch.
       const classicContext = txContext as ClassicSwapTxAndGasInfo | GatewayJusdSwapTxAndGasInfo
       const { swapRequestArgs } = classicContext
 

--- a/packages/uniswap/src/features/transactions/swap/utils/jusdDirectPool.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/jusdDirectPool.ts
@@ -1,0 +1,370 @@
+/**
+ * Direct-pool fallback for selling JUSD on Citrea Mainnet.
+ *
+ * Background: JuiceSwap's `/v1/quote` API special-cases the JUSD token address and always
+ * routes it through the JuiceSwap Gateway (JUSD <-> svJUSD wrap/unwrap), regardless of what
+ * `protocols` the client requests. The Gateway's JUSD-deposit leg
+ * (`Savings.save()` / `SavingsVaultJUSD._deposit()`) reverts on-chain with `ModuleDisabled()`
+ * whenever the savings interest rate is 0% (confirmed on-chain: `currentRatePPM() == 0` on the
+ * `SavingsGateway` at 0x22FE239892eBC8805DA8f05eD3bc6aF75332b60b). That blocks selling JUSD
+ * (JUSD -> anything) even though buying JUSD still works, because the buy side only needs the
+ * unblocked `withdraw()` leg.
+ *
+ * This module bypasses the Gateway (and the remote API) entirely for the JUSD-sell direction by
+ * reading a real JuiceSwap V3 pool on-chain and computing/executing the swap locally, via the
+ * same JuiceSwap V3 SwapRouter02 contract used by every other pair. It has zero dependency on
+ * api.juiceswap.com and therefore isn't affected by the Gateway's paused state.
+ *
+ * All calldata here is built against SwapRouter02's *verified on-chain ABI*
+ * (0x565eD3D57fe40f78A46f348C220121AE093c3cF8), NOT the @juiceswapxyz/v3-sdk `SwapRouter` helper:
+ * that helper emits the legacy `ISwapRouter.exactInputSingle` struct which carries a `deadline`
+ * field, whereas the deployed SwapRouter02 uses `IV3SwapRouter.exactInputSingle` (no `deadline`)
+ * and enforces deadlines via its `multicall` wrapper instead. Contract-level facts relied on here:
+ *   - `pay()` pulls the input via `safeTransferFrom(tokenIn, msg.sender, pool)` when payer is the
+ *     caller, so a *plain ERC20 approve* of JUSD to SwapRouter02 is sufficient (no Permit2).
+ *   - `Constants.ADDRESS_THIS == address(2)` tells the router to keep the output; `multicall`
+ *     runs via `delegatecall`, preserving `msg.sender`, so a trailing `unwrapWETH9(min)` sends
+ *     native cBTC to the user.
+ *
+ * Prerequisite: a funded JUSD/WCBTC V3 pool must exist on-chain. See
+ * `scripts/seed-jusd-wcbtc-pool.mjs`. Until such a pool exists, `getJusdDirectPoolQuote` resolves
+ * to `null` and callers fall back to the existing generic error message.
+ */
+import { CurrencyAmount, Token } from '@juiceswapxyz/sdk-core'
+import { FeeAmount, Pool } from '@juiceswapxyz/v3-sdk'
+import { createPublicClient, encodeFunctionData, http, zeroAddress, type Address, type PublicClient } from 'viem'
+import { UniverseChainId } from 'uniswap/src/features/chains/types'
+
+export const JUSD_ADDRESS_CITREA_MAINNET: Address = '0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C'
+export const WCBTC_ADDRESS_CITREA_MAINNET: Address = '0x3100000000000000000000000000000000000006'
+export const JUICESWAP_V3_FACTORY_CITREA_MAINNET: Address = '0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82'
+export const JUICESWAP_SWAP_ROUTER02_CITREA_MAINNET: Address = '0x565eD3D57fe40f78A46f348C220121AE093c3cF8'
+// SwapRouter02 `Constants.ADDRESS_THIS` sentinel — tells the router to keep the swap output so a
+// trailing unwrapWETH9 can sweep it out as native cBTC. Verified in the deployed router source.
+const ROUTER_ADDRESS_THIS: Address = '0x0000000000000000000000000000000000000002'
+const CITREA_MAINNET_RPC_URL = 'https://rpc.citreascan.com'
+
+// Fee tiers to probe, in preference order (matches the tiers JuiceSwap already uses for the
+// svJUSD/cBTC pool and its other V3 pairs).
+const CANDIDATE_FEE_TIERS: FeeAmount[] = [FeeAmount.MEDIUM, FeeAmount.LOW, FeeAmount.HIGH]
+
+// Matches the historical JUSD slippage default used across the app (see evmSwapInstructionsService).
+export const DEFAULT_JUSD_SLIPPAGE_PERCENT = 5.5
+
+/** Converts a percent slippage (e.g. 5.5) into basis points (550), clamped to [0, 10000]. */
+export function slippagePercentToBps(percent: number | undefined): number {
+  const pct = percent ?? DEFAULT_JUSD_SLIPPAGE_PERCENT
+  const bps = Math.round(pct * 100)
+  if (!Number.isFinite(bps) || bps < 0) {
+    return Math.round(DEFAULT_JUSD_SLIPPAGE_PERCENT * 100)
+  }
+  return Math.min(bps, 10_000)
+}
+
+const factoryAbi = [
+  {
+    name: 'getPool',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ type: 'address' }, { type: 'address' }, { type: 'uint24' }],
+    outputs: [{ type: 'address' }],
+  },
+] as const
+
+const poolAbi = [
+  {
+    name: 'slot0',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [
+      { type: 'uint160', name: 'sqrtPriceX96' },
+      { type: 'int24', name: 'tick' },
+      { type: 'uint16', name: 'observationIndex' },
+      { type: 'uint16', name: 'observationCardinality' },
+      { type: 'uint16', name: 'observationCardinalityNext' },
+      { type: 'uint8', name: 'feeProtocol' },
+      { type: 'bool', name: 'unlocked' },
+    ],
+  },
+  { name: 'liquidity', type: 'function', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint128' }] },
+] as const
+
+// IV3SwapRouter.ExactInputSingleParams — deliberately WITHOUT a `deadline` field.
+// Verified against the deployed SwapRouter02 ABI at 0x565eD3D57fe40f78A46f348C220121AE093c3cF8.
+const swapRouter02Abi = [
+  {
+    name: 'exactInputSingle',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        name: 'params',
+        type: 'tuple',
+        components: [
+          { name: 'tokenIn', type: 'address' },
+          { name: 'tokenOut', type: 'address' },
+          { name: 'fee', type: 'uint24' },
+          { name: 'recipient', type: 'address' },
+          { name: 'amountIn', type: 'uint256' },
+          { name: 'amountOutMinimum', type: 'uint256' },
+          { name: 'sqrtPriceLimitX96', type: 'uint160' },
+        ],
+      },
+    ],
+    outputs: [{ name: 'amountOut', type: 'uint256' }],
+  },
+  // 1-arg unwrapWETH9: unwraps the router's WCBTC balance and sends native cBTC to msg.sender.
+  {
+    name: 'unwrapWETH9',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [{ name: 'amountMinimum', type: 'uint256' }],
+    outputs: [],
+  },
+  {
+    name: 'multicall',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [{ name: 'data', type: 'bytes[]' }],
+    outputs: [{ name: 'results', type: 'bytes[]' }],
+  },
+] as const
+
+const erc20Abi = [
+  {
+    name: 'approve',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+  {
+    name: 'allowance',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'owner', type: 'address' },
+      { name: 'spender', type: 'address' },
+    ],
+    outputs: [{ type: 'uint256' }],
+  },
+] as const
+
+let cachedClient: PublicClient | undefined
+function getCitreaMainnetPublicClient(): PublicClient {
+  cachedClient ??= createPublicClient({ transport: http(CITREA_MAINNET_RPC_URL) })
+  return cachedClient
+}
+
+export interface JusdDirectPoolQuote {
+  poolAddress: Address
+  fee: FeeAmount
+  amountIn: bigint
+  amountOut: bigint
+  tokenIn: Address
+  tokenOut: Address
+}
+
+/**
+ * True only for the pair/chain this fallback supports: selling JUSD for the chain's native asset
+ * (cBTC) or its wrapped form (WCBTC) on Citrea Mainnet. `tokenOutAddress` is the trading-API token
+ * address, i.e. the zero address for native cBTC.
+ *
+ * Extend deliberately — do not generalize to "any JUSD pair" without re-checking the on-chain
+ * assumptions this module hardcodes.
+ */
+export function isJusdDirectPoolSupported(params: {
+  chainId: UniverseChainId
+  tokenInAddress: Address | undefined
+  tokenOutAddress: Address | undefined
+}): boolean {
+  const { chainId, tokenInAddress, tokenOutAddress } = params
+  if (chainId !== UniverseChainId.CitreaMainnet) {
+    return false
+  }
+  const tokenIn = tokenInAddress?.toLowerCase()
+  const tokenOut = tokenOutAddress?.toLowerCase()
+  if (tokenIn !== JUSD_ADDRESS_CITREA_MAINNET.toLowerCase()) {
+    return false
+  }
+  return (
+    tokenOut === zeroAddress || // native cBTC
+    tokenOut === WCBTC_ADDRESS_CITREA_MAINNET.toLowerCase()
+  )
+}
+
+/**
+ * Finds the best JUSD/WCBTC pool across the candidate fee tiers and computes the exact-input quote
+ * directly from on-chain pool state, using the same `Pool.getOutputAmount` math the rest of this
+ * codebase relies on for parsing CLASSIC routes. "Best" = highest output amount, so thin-liquidity
+ * tiers don't silently give the user a worse price. Returns `null` if no seeded pool exists yet.
+ */
+export async function getJusdDirectPoolQuote(amountIn: bigint): Promise<JusdDirectPoolQuote | null> {
+  if (amountIn <= BigInt(0)) {
+    return null
+  }
+  const client = getCitreaMainnetPublicClient()
+
+  const jusd = new Token(UniverseChainId.CitreaMainnet, JUSD_ADDRESS_CITREA_MAINNET, 18, 'JUSD', 'Juice Dollar')
+  const wcbtc = new Token(UniverseChainId.CitreaMainnet, WCBTC_ADDRESS_CITREA_MAINNET, 18, 'WcBTC', 'Wrapped Citrea BTC')
+  const inputAmount = CurrencyAmount.fromRawAmount(jusd, amountIn.toString())
+
+  let best: JusdDirectPoolQuote | null = null
+
+  for (const fee of CANDIDATE_FEE_TIERS) {
+    const poolAddress = (await client.readContract({
+      address: JUICESWAP_V3_FACTORY_CITREA_MAINNET,
+      abi: factoryAbi,
+      functionName: 'getPool',
+      args: [JUSD_ADDRESS_CITREA_MAINNET, WCBTC_ADDRESS_CITREA_MAINNET, fee],
+    })) as Address
+
+    if (poolAddress === zeroAddress) {
+      continue
+    }
+
+    const [slot0, liquidity] = await Promise.all([
+      client.readContract({ address: poolAddress, abi: poolAbi, functionName: 'slot0' }),
+      client.readContract({ address: poolAddress, abi: poolAbi, functionName: 'liquidity' }),
+    ])
+    const [sqrtPriceX96, tick] = slot0 as readonly [bigint, number, ...unknown[]]
+
+    if ((liquidity as bigint) === BigInt(0) || sqrtPriceX96 === BigInt(0)) {
+      // Pool exists but was never seeded with liquidity (e.g. only initialized, never minted into).
+      continue
+    }
+
+    let amountOut: bigint
+    try {
+      const pool = new Pool(jusd, wcbtc, fee, sqrtPriceX96.toString(), (liquidity as bigint).toString(), tick)
+      const [outputAmount] = await pool.getOutputAmount(inputAmount)
+      amountOut = BigInt(outputAmount.quotient.toString())
+    } catch {
+      // getOutputAmount throws if the swap would exhaust the pool's in-range liquidity (insufficient
+      // depth for this size). Skip this tier rather than aborting the whole quote.
+      continue
+    }
+
+    if (amountOut > BigInt(0) && (!best || amountOut > best.amountOut)) {
+      best = {
+        poolAddress,
+        fee,
+        amountIn,
+        amountOut,
+        tokenIn: JUSD_ADDRESS_CITREA_MAINNET,
+        tokenOut: WCBTC_ADDRESS_CITREA_MAINNET,
+      }
+    }
+  }
+
+  return best
+}
+
+export interface JusdDirectPoolSwapTx {
+  to: Address
+  data: `0x${string}`
+  value: bigint
+}
+
+function applySlippage(amountOut: bigint, slippageToleranceBps: number): bigint {
+  if (slippageToleranceBps < 0 || slippageToleranceBps > 10_000) {
+    throw new Error(`Invalid slippageToleranceBps: ${slippageToleranceBps}`)
+  }
+  return (amountOut * BigInt(10_000 - slippageToleranceBps)) / BigInt(10_000)
+}
+
+/**
+ * Builds calldata against SwapRouter02 for the JUSD-sell swap.
+ *
+ * - `outputIsNative` (user selected cBTC): emits
+ *   `multicall([exactInputSingle(recipient=ADDRESS_THIS), unwrapWETH9(minOut)])` so the user
+ *   receives native cBTC.
+ * - otherwise (user selected WCBTC): emits a bare `exactInputSingle(recipient=user)`.
+ *
+ * `slippageToleranceBps` is applied to `quote.amountOut` to derive `amountOutMinimum`
+ * (e.g. 550 == 5.5%). The caller must ensure SwapRouter02 has a sufficient JUSD allowance first
+ * (see `getJusdRouterAllowance` / `buildJusdRouterApprovalTx`).
+ */
+export function buildJusdDirectPoolSwapTx(params: {
+  quote: JusdDirectPoolQuote
+  // Recipient of the swap output. Used only for the wrapped-output (WCBTC) path; for native output
+  // the trailing unwrapWETH9 always pays msg.sender (the caller), so `recipient` is not encoded.
+  recipient: Address
+  slippageToleranceBps: number
+  outputIsNative: boolean
+}): JusdDirectPoolSwapTx {
+  const { quote, recipient, slippageToleranceBps, outputIsNative } = params
+  const amountOutMinimum = applySlippage(quote.amountOut, slippageToleranceBps)
+
+  if (!outputIsNative) {
+    const data = encodeFunctionData({
+      abi: swapRouter02Abi,
+      functionName: 'exactInputSingle',
+      args: [
+        {
+          tokenIn: quote.tokenIn,
+          tokenOut: quote.tokenOut,
+          fee: quote.fee,
+          recipient,
+          amountIn: quote.amountIn,
+          amountOutMinimum,
+          sqrtPriceLimitX96: BigInt(0),
+        },
+      ],
+    })
+    return { to: JUICESWAP_SWAP_ROUTER02_CITREA_MAINNET, data, value: BigInt(0) }
+  }
+
+  // Native output: swap into the router, then unwrap WCBTC -> cBTC to the user via multicall.
+  const swapCall = encodeFunctionData({
+    abi: swapRouter02Abi,
+    functionName: 'exactInputSingle',
+    args: [
+      {
+        tokenIn: quote.tokenIn,
+        tokenOut: quote.tokenOut,
+        fee: quote.fee,
+        recipient: ROUTER_ADDRESS_THIS,
+        amountIn: quote.amountIn,
+        amountOutMinimum,
+        sqrtPriceLimitX96: BigInt(0),
+      },
+    ],
+  })
+  const unwrapCall = encodeFunctionData({
+    abi: swapRouter02Abi,
+    functionName: 'unwrapWETH9',
+    args: [amountOutMinimum],
+  })
+  const data = encodeFunctionData({
+    abi: swapRouter02Abi,
+    functionName: 'multicall',
+    args: [[swapCall, unwrapCall]],
+  })
+  return { to: JUICESWAP_SWAP_ROUTER02_CITREA_MAINNET, data, value: BigInt(0) }
+}
+
+/** Reads the current JUSD allowance the owner has granted to SwapRouter02. */
+export async function getJusdRouterAllowance(owner: Address): Promise<bigint> {
+  const client = getCitreaMainnetPublicClient()
+  return client.readContract({
+    address: JUSD_ADDRESS_CITREA_MAINNET,
+    abi: erc20Abi,
+    functionName: 'allowance',
+    args: [owner, JUICESWAP_SWAP_ROUTER02_CITREA_MAINNET],
+  }) as Promise<bigint>
+}
+
+/** Builds an ERC20 `approve` call granting SwapRouter02 the given JUSD amount. */
+export function buildJusdRouterApprovalTx(amount: bigint): { to: Address; data: `0x${string}`; value: bigint } {
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [JUICESWAP_SWAP_ROUTER02_CITREA_MAINNET, amount],
+  })
+  return { to: JUSD_ADDRESS_CITREA_MAINNET, data, value: BigInt(0) }
+}

--- a/packages/uniswap/src/features/transactions/swap/utils/jusdDirectPool.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/jusdDirectPool.ts
@@ -29,6 +29,9 @@
  * Prerequisite: a funded JUSD/WCBTC V3 pool must exist on-chain. See
  * `scripts/seed-jusd-wcbtc-pool.mjs`. Until such a pool exists, `getJusdDirectPoolQuote` resolves
  * to `null` and callers fall back to the existing generic error message.
+ *
+ * The full rationale (why the svJUSD liquidity must be redeemed back to raw JUSD, why a new pool
+ * is required, and the seeding runbook) lives in `docs/jusd-liquidity-migration.md`.
  */
 import { CurrencyAmount, Token } from '@juiceswapxyz/sdk-core'
 import { FeeAmount, Pool } from '@juiceswapxyz/v3-sdk'
@@ -156,8 +159,33 @@ const erc20Abi = [
 
 let cachedClient: PublicClient | undefined
 function getCitreaMainnetPublicClient(): PublicClient {
-  cachedClient ??= createPublicClient({ transport: http(CITREA_MAINNET_RPC_URL) })
+  // `batch: true` coalesces concurrent reads into a single JSON-RPC batch request; verified live
+  // against rpc.citreascan.com (all fee-tier probes resolve in one HTTP round trip).
+  cachedClient ??= createPublicClient({ transport: http(CITREA_MAINNET_RPC_URL, { batch: true }) })
   return cachedClient
+}
+
+// V3 factory pool addresses are CREATE2-deterministic and append-only: once `getPool` returns a
+// non-zero address for a (token0, token1, fee) key it can never change, so it's safe to cache for
+// the session. Zero results are deliberately NOT cached — the pool can be created at any moment
+// (that is exactly what scripts/seed-jusd-wcbtc-pool.mjs does) and must be picked up on the next poll.
+const poolAddressByFeeTier = new Map<FeeAmount, Address>()
+
+async function getPoolAddress(client: PublicClient, fee: FeeAmount): Promise<Address> {
+  const cached = poolAddressByFeeTier.get(fee)
+  if (cached) {
+    return cached
+  }
+  const poolAddress = (await client.readContract({
+    address: JUICESWAP_V3_FACTORY_CITREA_MAINNET,
+    abi: factoryAbi,
+    functionName: 'getPool',
+    args: [JUSD_ADDRESS_CITREA_MAINNET, WCBTC_ADDRESS_CITREA_MAINNET, fee],
+  })) as Address
+  if (poolAddress !== zeroAddress) {
+    poolAddressByFeeTier.set(fee, poolAddress)
+  }
+  return poolAddress
 }
 
 export interface JusdDirectPoolQuote {
@@ -197,11 +225,66 @@ export function isJusdDirectPoolSupported(params: {
   )
 }
 
+async function getTierQuote(params: {
+  client: PublicClient
+  fee: FeeAmount
+  inputAmount: CurrencyAmount<Token>
+  jusd: Token
+  wcbtc: Token
+  amountIn: bigint
+}): Promise<JusdDirectPoolQuote | null> {
+  const { client, fee, inputAmount, jusd, wcbtc, amountIn } = params
+
+  const poolAddress = await getPoolAddress(client, fee)
+  if (poolAddress === zeroAddress) {
+    return null
+  }
+
+  const [slot0, liquidity] = await Promise.all([
+    client.readContract({ address: poolAddress, abi: poolAbi, functionName: 'slot0' }),
+    client.readContract({ address: poolAddress, abi: poolAbi, functionName: 'liquidity' }),
+  ])
+  const [sqrtPriceX96, tick] = slot0 as readonly [bigint, number, ...unknown[]]
+
+  if ((liquidity as bigint) === BigInt(0) || sqrtPriceX96 === BigInt(0)) {
+    // Pool exists but was never seeded with liquidity (e.g. only initialized, never minted into).
+    return null
+  }
+
+  let amountOut: bigint
+  try {
+    const pool = new Pool(jusd, wcbtc, fee, sqrtPriceX96.toString(), (liquidity as bigint).toString(), tick)
+    const [outputAmount] = await pool.getOutputAmount(inputAmount)
+    amountOut = BigInt(outputAmount.quotient.toString())
+  } catch {
+    // getOutputAmount throws if the swap would exhaust the pool's in-range liquidity (insufficient
+    // depth for this size). Skip this tier rather than aborting the whole quote.
+    return null
+  }
+
+  if (amountOut <= BigInt(0)) {
+    return null
+  }
+
+  return {
+    poolAddress,
+    fee,
+    amountIn,
+    amountOut,
+    tokenIn: JUSD_ADDRESS_CITREA_MAINNET,
+    tokenOut: WCBTC_ADDRESS_CITREA_MAINNET,
+  }
+}
+
 /**
  * Finds the best JUSD/WCBTC pool across the candidate fee tiers and computes the exact-input quote
  * directly from on-chain pool state, using the same `Pool.getOutputAmount` math the rest of this
  * codebase relies on for parsing CLASSIC routes. "Best" = highest output amount, so thin-liquidity
  * tiers don't silently give the user a worse price. Returns `null` if no seeded pool exists yet.
+ *
+ * All tiers are probed concurrently and the transport batches concurrent reads into one JSON-RPC
+ * batch request, so a full quote costs at most two HTTP round trips (factory lookups + pool state)
+ * per poll — and only one once the pool addresses are cached.
  */
 export async function getJusdDirectPoolQuote(amountIn: bigint): Promise<JusdDirectPoolQuote | null> {
   if (amountIn <= BigInt(0)) {
@@ -213,54 +296,16 @@ export async function getJusdDirectPoolQuote(amountIn: bigint): Promise<JusdDire
   const wcbtc = new Token(UniverseChainId.CitreaMainnet, WCBTC_ADDRESS_CITREA_MAINNET, 18, 'WcBTC', 'Wrapped Citrea BTC')
   const inputAmount = CurrencyAmount.fromRawAmount(jusd, amountIn.toString())
 
+  const tierQuotes = await Promise.all(
+    CANDIDATE_FEE_TIERS.map((fee) => getTierQuote({ client, fee, inputAmount, jusd, wcbtc, amountIn })),
+  )
+
   let best: JusdDirectPoolQuote | null = null
-
-  for (const fee of CANDIDATE_FEE_TIERS) {
-    const poolAddress = (await client.readContract({
-      address: JUICESWAP_V3_FACTORY_CITREA_MAINNET,
-      abi: factoryAbi,
-      functionName: 'getPool',
-      args: [JUSD_ADDRESS_CITREA_MAINNET, WCBTC_ADDRESS_CITREA_MAINNET, fee],
-    })) as Address
-
-    if (poolAddress === zeroAddress) {
-      continue
-    }
-
-    const [slot0, liquidity] = await Promise.all([
-      client.readContract({ address: poolAddress, abi: poolAbi, functionName: 'slot0' }),
-      client.readContract({ address: poolAddress, abi: poolAbi, functionName: 'liquidity' }),
-    ])
-    const [sqrtPriceX96, tick] = slot0 as readonly [bigint, number, ...unknown[]]
-
-    if ((liquidity as bigint) === BigInt(0) || sqrtPriceX96 === BigInt(0)) {
-      // Pool exists but was never seeded with liquidity (e.g. only initialized, never minted into).
-      continue
-    }
-
-    let amountOut: bigint
-    try {
-      const pool = new Pool(jusd, wcbtc, fee, sqrtPriceX96.toString(), (liquidity as bigint).toString(), tick)
-      const [outputAmount] = await pool.getOutputAmount(inputAmount)
-      amountOut = BigInt(outputAmount.quotient.toString())
-    } catch {
-      // getOutputAmount throws if the swap would exhaust the pool's in-range liquidity (insufficient
-      // depth for this size). Skip this tier rather than aborting the whole quote.
-      continue
-    }
-
-    if (amountOut > BigInt(0) && (!best || amountOut > best.amountOut)) {
-      best = {
-        poolAddress,
-        fee,
-        amountIn,
-        amountOut,
-        tokenIn: JUSD_ADDRESS_CITREA_MAINNET,
-        tokenOut: WCBTC_ADDRESS_CITREA_MAINNET,
-      }
+  for (const quote of tierQuotes) {
+    if (quote && (!best || quote.amountOut > best.amountOut)) {
+      best = quote
     }
   }
-
   return best
 }
 

--- a/packages/uniswap/src/features/transactions/swap/utils/routing.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/routing.ts
@@ -11,12 +11,20 @@ export const GATEWAY_JUICE_OUT_ROUTING = 'GATEWAY_JUICE_OUT' as const
 // Satsuma USDC.e/ctUSD pool over the thin JuiceSwap V3 Classic pool.
 export const SATSUMA_ROUTING = 'SATSUMA' as const
 
+// Direct-pool routing — client-side fallback for selling JUSD when the JuiceSwap Gateway is
+// paused (savings rate 0%). The quote and swap calldata are computed locally against a real
+// on-chain JUSD/WCBTC V3 pool, bypassing the remote quote API entirely.
+// See utils/jusdDirectPool.ts.
+export const DIRECT_POOL_ROUTING = 'DIRECT_POOL' as const
+
 export type GatewayJusdRouting =
   | typeof GATEWAY_JUSD_ROUTING
   | typeof GATEWAY_JUICE_IN_ROUTING
   | typeof GATEWAY_JUICE_OUT_ROUTING
 
 export type SatsumaRouting = typeof SATSUMA_ROUTING
+
+export type DirectPoolRouting = typeof DIRECT_POOL_ROUTING
 
 // All Gateway routing variants
 // Note: SUSD is routed through Gateway via registerBridgedToken() - no separate routing type needed
@@ -27,7 +35,7 @@ export const GATEWAY_ROUTING_VARIANTS = [
 ] as const
 
 // TradeRouting encompasses all routing types including custom ones not in the Routing enum
-export type TradeRouting = Routing | GatewayJusdRouting | SatsumaRouting
+export type TradeRouting = Routing | GatewayJusdRouting | SatsumaRouting | DirectPoolRouting
 
 export const UNISWAPX_ROUTING_VARIANTS = [
   Routing.DUTCH_V2,
@@ -51,6 +59,12 @@ export function isGatewayJusd<T extends { routing: TradeRouting }>(obj: T): obj 
 
 export function isSatsuma<T extends { routing: TradeRouting }>(obj: T): obj is T & { routing: SatsumaRouting } {
   return obj.routing === SATSUMA_ROUTING
+}
+
+export function isJusdDirectPool<T extends { routing: TradeRouting }>(
+  obj: T,
+): obj is T & { routing: DirectPoolRouting } {
+  return obj.routing === DIRECT_POOL_ROUTING
 }
 
 export function isBridge<T extends { routing: TradeRouting }>(

--- a/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
+++ b/packages/uniswap/src/features/transactions/swap/utils/tradingApi.ts
@@ -10,6 +10,7 @@ import { Pool as V4Pool, Route as V4Route } from '@juiceswapxyz/v4-sdk'
 import { nativeOnChain } from 'uniswap/src/constants/tokens'
 import type {
   BridgeQuoteResponse,
+  DirectPoolQuoteResponse,
   GatewayJusdQuoteResponse,
   SatsumaQuoteResponse,
 } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
@@ -455,7 +456,8 @@ export function getClassicQuoteFromResponse(
     | ClassicQuoteResponse
     | { routing: Exclude<Routing, Routing.CLASSIC> }
     | GatewayJusdQuoteResponse
-    | SatsumaQuoteResponse,
+    | SatsumaQuoteResponse
+    | DirectPoolQuoteResponse,
 ): ClassicQuote | undefined {
   if (quote && isClassic(quote)) {
     return quote.quote
@@ -467,6 +469,9 @@ export function getClassicQuoteFromResponse(
   if (quote && isSatsuma(quote)) {
     return quote.quote as unknown as ClassicQuote
   }
+  // Direct-pool quotes are locally computed and carry none of the Classic
+  // quote fields (quoteId/gasUseEstimate/routeString), so there is no classic
+  // quote to surface — analytics/history fall back to undefined for those.
   return undefined
 }
 

--- a/packages/uniswap/src/i18n/locales/source/en-US.json
+++ b/packages/uniswap/src/i18n/locales/source/en-US.json
@@ -2030,6 +2030,8 @@
   "swap.warning.expectedFailure.titleMay": "This swap may fail",
   "swap.warning.fiatLoss.message": "The quoted output is worth far less than your input. This usually means the {{outputCurrencySymbol}} pool has very little liquidity for {{inputCurrencySymbol}}. Try a smaller amount or a different token if you don't want to proceed.",
   "swap.warning.fiatLoss.title": "Output value too low ({{lossValue}} loss)",
+  "swap.warning.gatewayJusdDisabled.title": "JUSD swaps temporarily paused",
+  "swap.warning.gatewayJusdDisabled.message": "{{reason}} This is a protocol-level pause, not a liquidity issue on JuiceSwap — please check back later.",
   "swap.warning.insufficientBalance.title": "You don't have enough {{currencySymbol}}",
   "swap.warning.insufficientBridgeLiquidity.title": "Insufficient bridge liquidity",
   "swap.warning.insufficientBridgeLiquidity.message": "The bridge does not have enough tokens to complete this swap. Try a smaller amount or wait for the bridge to be replenished.",

--- a/scripts/seed-jusd-wcbtc-pool.mjs
+++ b/scripts/seed-jusd-wcbtc-pool.mjs
@@ -1,0 +1,284 @@
+// Seeds a real JUSD/WCBTC JuiceSwap V3 pool on Citrea Mainnet.
+//
+// Prerequisite for the "GATEWAY_DEPOSIT_DISABLED" fallback in
+// packages/uniswap/src/features/transactions/swap/utils/jusdDirectPool.ts —
+// that fallback only activates once this pool exists on-chain with real liquidity.
+//
+// This moves REAL funds. Run manually, review every step, never commit your key.
+//
+// Usage:
+//   PRIVATE_KEY=0x... \
+//   JUSD_AMOUNT=1000 \
+//   WCBTC_AMOUNT=0.017 \
+//   FEE_TIER=3000 \
+//   CBTC_PRICE_USD=58689 \
+//   node scripts/seed-jusd-wcbtc-pool.mjs --dry-run   # inspect first, remove --dry-run to execute
+
+import { createPublicClient, createWalletClient, http, parseUnits, formatUnits, getContract } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const RPC_URL = 'https://rpc.citreascan.com'
+const CHAIN = {
+  id: 4114,
+  name: 'Citrea Mainnet',
+  nativeCurrency: { name: 'Citrea BTC', symbol: 'cBTC', decimals: 18 },
+  rpcUrls: { default: { http: [RPC_URL] } },
+}
+
+const JUSD = '0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C'
+const WCBTC = '0x3100000000000000000000000000000000000006'
+const SV_JUSD_VAULT = '0x1b70ae756b1089cc5948e4f8a2AD498DF30E897d'
+const NPM = '0x3D3821D358f56395d4053954f98aec0E1F0fa568' // nonfungiblePositionManagerAddress
+const FACTORY = '0xd809b1285aDd8eeaF1B1566Bf31B2B4C4Bba8e82' // v3CoreFactoryAddress
+
+const FEE_TIER = Number(process.env.FEE_TIER ?? 3000) // 0.3%, matches the existing svJUSD/cBTC pool
+const JUSD_AMOUNT = process.env.JUSD_AMOUNT
+const WCBTC_AMOUNT = process.env.WCBTC_AMOUNT
+const CBTC_PRICE_USD = Number(process.env.CBTC_PRICE_USD ?? 58689) // check a live source before running
+const DRY_RUN = process.argv.includes('--dry-run')
+
+if (!process.env.PRIVATE_KEY) {
+  throw new Error('Set PRIVATE_KEY (0x-prefixed) in the environment. Never hardcode it here.')
+}
+if (!JUSD_AMOUNT || !WCBTC_AMOUNT) {
+  throw new Error('Set JUSD_AMOUNT and WCBTC_AMOUNT (human units, e.g. JUSD_AMOUNT=1000 WCBTC_AMOUNT=0.017)')
+}
+
+const account = privateKeyToAccount(process.env.PRIVATE_KEY)
+const publicClient = createPublicClient({ chain: CHAIN, transport: http(RPC_URL) })
+const walletClient = createWalletClient({ account, chain: CHAIN, transport: http(RPC_URL) })
+
+const erc20Abi = [
+  { name: 'balanceOf', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }], outputs: [{ type: 'uint256' }] },
+  { name: 'approve', type: 'function', stateMutability: 'nonpayable', inputs: [{ type: 'address' }, { type: 'uint256' }], outputs: [{ type: 'bool' }] },
+  { name: 'allowance', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }, { type: 'address' }], outputs: [{ type: 'uint256' }] },
+  { name: 'decimals', type: 'function', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint8' }] },
+]
+
+const vaultAbi = [
+  { name: 'redeem', type: 'function', stateMutability: 'nonpayable', inputs: [{ type: 'uint256', name: 'shares' }, { type: 'address', name: 'receiver' }, { type: 'address', name: 'owner' }], outputs: [{ type: 'uint256' }] },
+  { name: 'balanceOf', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }], outputs: [{ type: 'uint256' }] },
+  { name: 'maxRedeem', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }], outputs: [{ type: 'uint256' }] },
+]
+
+const factoryAbi = [
+  { name: 'getPool', type: 'function', stateMutability: 'view', inputs: [{ type: 'address' }, { type: 'address' }, { type: 'uint24' }], outputs: [{ type: 'address' }] },
+]
+
+const npmAbi = [
+  {
+    name: 'createAndInitializePoolIfNecessary',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      { type: 'address', name: 'token0' },
+      { type: 'address', name: 'token1' },
+      { type: 'uint24', name: 'fee' },
+      { type: 'uint160', name: 'sqrtPriceX96' },
+    ],
+    outputs: [{ type: 'address' }],
+  },
+  {
+    name: 'mint',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [
+      {
+        type: 'tuple',
+        name: 'params',
+        components: [
+          { type: 'address', name: 'token0' },
+          { type: 'address', name: 'token1' },
+          { type: 'uint24', name: 'fee' },
+          { type: 'int24', name: 'tickLower' },
+          { type: 'int24', name: 'tickUpper' },
+          { type: 'uint256', name: 'amount0Desired' },
+          { type: 'uint256', name: 'amount1Desired' },
+          { type: 'uint256', name: 'amount0Min' },
+          { type: 'uint256', name: 'amount1Min' },
+          { type: 'address', name: 'recipient' },
+          { type: 'uint256', name: 'deadline' },
+        ],
+      },
+    ],
+    outputs: [
+      { type: 'uint256', name: 'tokenId' },
+      { type: 'uint128', name: 'liquidity' },
+      { type: 'uint256', name: 'amount0' },
+      { type: 'uint256', name: 'amount1' },
+    ],
+  },
+  {
+    name: 'deposit',
+    type: 'function',
+    stateMutability: 'payable',
+    inputs: [],
+    outputs: [],
+  },
+]
+
+// Uniswap V3 requires token0 < token1 by address.
+const [token0, token1] = JUSD.toLowerCase() < WCBTC.toLowerCase() ? [JUSD, WCBTC] : [WCBTC, JUSD]
+const jusdIsToken0 = token0 === JUSD
+
+function sqrtPriceX96FromPrice(price) {
+  // price = token1 per token0 (human units, both assumed 18 decimals here)
+  const Q96 = 2n ** 96n
+  // Use a fixed-point sqrt via BigInt: scale price by 1e18, take integer sqrt, then apply Q96.
+  const SCALE = 10n ** 18n
+  const scaledPrice = BigInt(Math.round(price * 1e18))
+  const sqrtScaled = bigIntSqrt(scaledPrice * SCALE) // sqrt(price * 1e18 * 1e18) = sqrt(price) * 1e18
+  return (sqrtScaled * Q96) / SCALE
+}
+
+function bigIntSqrt(value) {
+  if (value < 0n) throw new Error('negative')
+  if (value < 2n) return value
+  let x0 = value / 2n
+  let x1 = (x0 + value / x0) / 2n
+  while (x1 < x0) {
+    x0 = x1
+    x1 = (x0 + value / x0) / 2n
+  }
+  return x0
+}
+
+async function main() {
+  console.log('Account:', account.address)
+
+  // Price of WCBTC in terms of JUSD (JUSD pegged ~$1): 1 JUSD = 1/CBTC_PRICE_USD WCBTC
+  const priceJusdPerWcbtc = CBTC_PRICE_USD
+  const priceToken1PerToken0 = jusdIsToken0 ? 1 / priceJusdPerWcbtc : priceJusdPerWcbtc
+  const sqrtPriceX96 = sqrtPriceX96FromPrice(priceToken1PerToken0)
+  console.log('token0:', token0, jusdIsToken0 ? '(JUSD)' : '(WCBTC)')
+  console.log('token1:', token1, jusdIsToken0 ? '(WCBTC)' : '(JUSD)')
+  console.log('sqrtPriceX96:', sqrtPriceX96.toString())
+
+  const existingPool = await publicClient.readContract({
+    address: FACTORY,
+    abi: factoryAbi,
+    functionName: 'getPool',
+    args: [token0, token1, FEE_TIER],
+  })
+  console.log('Existing pool at this fee tier:', existingPool)
+
+  const jusdWei = parseUnits(JUSD_AMOUNT, 18)
+  const wcbtcWei = parseUnits(WCBTC_AMOUNT, 18)
+  const amount0Desired = jusdIsToken0 ? jusdWei : wcbtcWei
+  const amount1Desired = jusdIsToken0 ? wcbtcWei : jusdWei
+
+  // Full-range position for simplicity on a fresh pool. Fee tier 3000 -> tick spacing 60.
+  const tickSpacing = { 500: 10, 3000: 60, 10000: 200 }[FEE_TIER]
+  if (!tickSpacing) throw new Error(`Unknown tick spacing for fee tier ${FEE_TIER}`)
+  const MIN_TICK = -887272
+  const MAX_TICK = 887272
+  const tickLower = Math.ceil(MIN_TICK / tickSpacing) * tickSpacing
+  const tickUpper = Math.floor(MAX_TICK / tickSpacing) * tickSpacing
+
+  console.log({
+    jusdWei: jusdWei.toString(),
+    wcbtcWei: wcbtcWei.toString(),
+    tickLower,
+    tickUpper,
+    fee: FEE_TIER,
+  })
+
+  if (DRY_RUN) {
+    console.log('\n--dry-run set: no transactions sent. Review the numbers above, then re-run without --dry-run.')
+    return
+  }
+
+  // Step 1: redeem svJUSD -> JUSD if you're holding svJUSD and need more raw JUSD.
+  const svJusdBalance = await publicClient.readContract({
+    address: SV_JUSD_VAULT,
+    abi: vaultAbi,
+    functionName: 'balanceOf',
+    args: [account.address],
+  })
+  console.log('Current svJUSD balance:', formatUnits(svJusdBalance, 18))
+  if (svJusdBalance > 0n) {
+    const maxRedeem = await publicClient.readContract({
+      address: SV_JUSD_VAULT,
+      abi: vaultAbi,
+      functionName: 'maxRedeem',
+      args: [account.address],
+    })
+    console.log('Redeeming', formatUnits(maxRedeem, 18), 'svJUSD shares -> JUSD ...')
+    const redeemHash = await walletClient.writeContract({
+      address: SV_JUSD_VAULT,
+      abi: vaultAbi,
+      functionName: 'redeem',
+      args: [maxRedeem, account.address, account.address],
+    })
+    console.log('redeem tx:', redeemHash)
+    await publicClient.waitForTransactionReceipt({ hash: redeemHash })
+  }
+
+  // Step 2: wrap cBTC -> WCBTC if needed (skipped here — fund the wallet with WCBTC directly,
+  // or add a WETH9.deposit() call for WCBTC_AMOUNT before this script if you're starting from native cBTC).
+
+  // Step 3: approve JUSD and WCBTC to the position manager.
+  for (const [addr, amount] of [[JUSD, jusdWei], [WCBTC, wcbtcWei]]) {
+    const allowance = await publicClient.readContract({
+      address: addr,
+      abi: erc20Abi,
+      functionName: 'allowance',
+      args: [account.address, NPM],
+    })
+    if (allowance < amount) {
+      console.log('Approving', addr, '...')
+      const approveHash = await walletClient.writeContract({
+        address: addr,
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [NPM, amount],
+      })
+      await publicClient.waitForTransactionReceipt({ hash: approveHash })
+    }
+  }
+
+  // Step 4: create + initialize the pool if it doesn't exist yet.
+  if (existingPool === '0x0000000000000000000000000000000000000000') {
+    console.log('Creating and initializing pool ...')
+    const initHash = await walletClient.writeContract({
+      address: NPM,
+      abi: npmAbi,
+      functionName: 'createAndInitializePoolIfNecessary',
+      args: [token0, token1, FEE_TIER, sqrtPriceX96],
+    })
+    console.log('init tx:', initHash)
+    await publicClient.waitForTransactionReceipt({ hash: initHash })
+  }
+
+  // Step 5: mint the liquidity position (full-range, 0 slippage floor for a brand-new pool).
+  console.log('Minting position ...')
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + 1800)
+  const mintHash = await walletClient.writeContract({
+    address: NPM,
+    abi: npmAbi,
+    functionName: 'mint',
+    args: [
+      {
+        token0,
+        token1,
+        fee: FEE_TIER,
+        tickLower,
+        tickUpper,
+        amount0Desired,
+        amount1Desired,
+        amount0Min: 0n,
+        amount1Min: 0n,
+        recipient: account.address,
+        deadline,
+      },
+    ],
+  })
+  console.log('mint tx:', mintHash)
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: mintHash })
+  console.log('Done. Position minted in block', receipt.blockNumber.toString())
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/seed-jusd-wcbtc-pool.mjs
+++ b/scripts/seed-jusd-wcbtc-pool.mjs
@@ -5,6 +5,7 @@
 // that fallback only activates once this pool exists on-chain with real liquidity.
 //
 // This moves REAL funds. Run manually, review every step, never commit your key.
+// Full rationale + runbook: docs/jusd-liquidity-migration.md
 //
 // Usage:
 //   PRIVATE_KEY=0x... \


### PR DESCRIPTION
## Why

Selling JUSD on Citrea Mainnet is broken, and the root cause is structural (verified on-chain 2026-07-02):

- The quote API hardwires every JUSD trade through the Gateway (JUSD ↔ svJUSD wrap).
- The savings rate is **0%** (`SavingsGateway.currentRatePPM() == 0`), which disables the vault's deposit leg — `Savings.save()` reverts with `ModuleDisabled()`. Every JUSD **sell** must pass through exactly that leg, so it dies. Buys keep working (the `withdraw()` leg is not gated).
- The only existing pool is **svJUSD/cBTC** — reachable only *through* the paused Gateway, so its liquidity is useless to JUSD sellers.
- There is **no raw JUSD/WCBTC pool** at any fee tier.

The fix therefore has two halves: the svJUSD liquidity must be **redeemed back to raw JUSD** and used to seed a **new JUSD/WCBTC V3 pool** (redemption is open — the vault holds ≈ 2,721 JUSD behind ≈ 2,642 svJUSD, and at 0% rate svJUSD earns nothing anyway), and the app needs a **Gateway-free route** to trade against that pool. This PR ships the second half and the tooling for the first.

📄 **Full rationale + seeding runbook: [`docs/jusd-liquidity-migration.md`](https://github.com/JuiceSwapxyz/bapp/blob/feat/jusd-direct-pool-fallback/docs/jusd-liquidity-migration.md)** (why svJUSD → JUSD, why a new pool, step-by-step seeding, and the full problem/fix matrix).

## What

Client-side **DIRECT_POOL** routing fallback. On a `GATEWAY_*_DISABLED` quote error, the app reads the on-chain **JUSD/WCBTC V3 pool**, computes quote + slippage locally, and builds **SwapRouter02** calldata directly:

- `multicall([exactInputSingle(recipient=ADDRESS_THIS), unwrapWETH9])` for native cBTC output
- plain ERC20 `approve` (SwapRouter02 pulls via `transferFrom` — **no Permit2**)
- zero dependency on api.juiceswap.com — immune to this and any future Gateway pause

Wired through **both** tx paths (service-based + legacy, per `ServiceBasedSwapTransactionInfo` flag). Slippage is a **single source of truth** (baked from the live setting at `getTrade` time), so the displayed "minimum received" equals the on-chain `amountOutMinimum` exactly.

Quote reads are optimized: all fee tiers are probed concurrently over a batched JSON-RPC transport (verified live against rpc.citreascan.com), and CREATE2-immutable pool addresses are cached — at most two HTTP round trips per quote poll, one once warm.

## What this fixes

| Problem today | After this PR + seeded pool |
|---|---|
| JUSD sells revert (`ModuleDisabled`) | Sells route through the JUSD/WCBTC pool, Gateway-free |
| Generic "This trade cannot be completed" dead end | Honest "JUSD swaps temporarily paused" message until the pool exists |
| JUSD trading coupled to API + Gateway pause state | Quote + calldata built locally from on-chain state |
| Future Gateway pauses break sells again | Fallback auto-engages on any `GATEWAY_*_DISABLED` — permanent safety net |
| Display/execution slippage divergence risk | Single slippage source, mathematically identical values |

Deliberately unchanged: JUSD buys, all non-JUSD pairs, and all other quote errors (rate limits, amount-too-small etc. surface exactly as before — the fallback never masks them).

## Status / dependencies

- ✅ **Standalone against `develop`** — the PR is exactly three commits (feat / perf / docs) rebuilt on top of current `develop` (2026-07-02). The former stack on #772 (dev buy) has been removed; the direct-pool code now relies on the Satsuma/Gateway routing infrastructure that landed on `develop` via #752. No launchpad files in the diff.
- **Inert until the JUSD/WCBTC pool is seeded** (`scripts/seed-jusd-wcbtc-pool.mjs` — runbook in the doc above). No deploy/config needed after seeding; the fallback detects the pool on the next quote poll.
- **E2E untested until the pool exists**; statically/on-chain/mathematically verified (calldata decoded against the deployed SwapRouter02 ABI, slippage consistency proven, chainId/decimals confirmed on-chain).

## Verification

- 0 new type/lint errors (baseline-compared; 1 pre-existing error fixed along the way)
- Adversarial review: `requireRouting` crash in swapSaga fixed; slippage display/execution divergence eliminated; fallback strictly scoped to `GATEWAY_*_DISABLED`; best-pool selection across fee tiers
- RPC batching verified against the live Citrea RPC (all tier probes resolve in one HTTP round trip)
