### PR TITLE
chore: disable Citrea Testnet (5115) as a supported chain

### DIFF
--- a/packages/uniswap/src/features/chains/hooks/useFeatureFlaggedChainIds.ts
+++ b/packages/uniswap/src/features/chains/hooks/useFeatureFlaggedChainIds.ts
@@ -20,7 +20,7 @@ export function createGetFeatureFlaggedChainIds(ctx: { getSoneiumStatus: () => b
     // Example: [ChainId.BLAST]: useFeatureFlag(FeatureFlags.BLAST)
     filterChainIdsByFeatureFlag({
       [UniverseChainId.Soneium]: ctx.getSoneiumStatus(),
-      // Explicitly enable Citrea testnet for quote calculation
-      [UniverseChainId.CitreaTestnet]: true,
+      // Citrea Testnet was sunset — disable it (mainnet only)
+      [UniverseChainId.CitreaTestnet]: false,
     })
 }

--- a/packages/uniswap/src/features/chains/utils.test.ts
+++ b/packages/uniswap/src/features/chains/utils.test.ts
@@ -116,89 +116,55 @@ describe('hexadecimalStringToInt', () => {
 })
 
 describe('getEnabledChains', () => {
-  it('returns all mainnet chains', () => {
+  // JuiceSwap only supports Citrea Mainnet (Citrea Testnet was sunset), so
+  // getEnabledChains always resolves to Citrea Mainnet regardless of testnet
+  // mode, feature flags, or includeTestnets.
+  const citreaMainnetOnly = {
+    chains: [UniverseChainId.CitreaMainnet],
+    gqlChains: ['CITREA_MAINNET'],
+    defaultChainId: UniverseChainId.CitreaMainnet,
+  }
+
+  it('returns only Citrea Mainnet in mainnet mode', () => {
     expect(getEnabledChains({ isTestnetModeEnabled: false, featureFlaggedChainIds: ALL_CHAIN_IDS })).toEqual({
-      chains: [
-        UniverseChainId.Mainnet,
-        UniverseChainId.Unichain,
-        UniverseChainId.Polygon,
-        UniverseChainId.ArbitrumOne,
-        UniverseChainId.Optimism,
-        UniverseChainId.Base,
-        UniverseChainId.Bnb,
-        UniverseChainId.Blast,
-        UniverseChainId.Avalanche,
-        UniverseChainId.Celo,
-        UniverseChainId.WorldChain,
-        UniverseChainId.Soneium,
-        UniverseChainId.Zora,
-        UniverseChainId.Zksync,
-      ],
-      gqlChains: [
-        Chain.Ethereum,
-        Chain.Unichain,
-        Chain.Polygon,
-        Chain.Arbitrum,
-        Chain.Optimism,
-        Chain.Base,
-        Chain.Bnb,
-        Chain.Blast,
-        Chain.Avalanche,
-        Chain.Celo,
-        Chain.Worldchain,
-        Chain.Soneium,
-        Chain.Zora,
-        Chain.Zksync,
-      ],
-      defaultChainId: UniverseChainId.Mainnet,
+      ...citreaMainnetOnly,
       isTestnetModeEnabled: false,
     })
   })
 
-  it('returns feature flagged chains', () => {
+  it('ignores featureFlaggedChainIds', () => {
     expect(
       getEnabledChains({
         isTestnetModeEnabled: false,
         featureFlaggedChainIds: [UniverseChainId.Mainnet, UniverseChainId.Polygon],
       }),
     ).toEqual({
-      chains: [UniverseChainId.Mainnet, UniverseChainId.Polygon],
-      gqlChains: [Chain.Ethereum, Chain.Polygon],
-      defaultChainId: UniverseChainId.Mainnet,
+      ...citreaMainnetOnly,
       isTestnetModeEnabled: false,
     })
   })
 
-  it('returns testnet chains', () => {
+  it('returns Citrea Mainnet even in testnet mode (Citrea Testnet was sunset)', () => {
     expect(
       getEnabledChains({
         isTestnetModeEnabled: true,
         featureFlaggedChainIds: ALL_CHAIN_IDS,
       }),
     ).toEqual({
-      chains: [UniverseChainId.Sepolia, UniverseChainId.CitreaTestnet],
-      gqlChains: [Chain.EthereumSepolia, Chain.UnknownChain],
-      defaultChainId: UniverseChainId.Sepolia,
+      ...citreaMainnetOnly,
       isTestnetModeEnabled: true,
     })
   })
 
-  it('returns both mainnet and testnet chains when includeTestnets is true', () => {
+  it('ignores includeTestnets', () => {
     expect(
       getEnabledChains({
         includeTestnets: true,
         isTestnetModeEnabled: false,
-        featureFlaggedChainIds: [
-          UniverseChainId.Mainnet,
-          UniverseChainId.Unichain,
-          UniverseChainId.Base,
-          UniverseChainId.Sepolia,
-        ],
+        featureFlaggedChainIds: [UniverseChainId.Mainnet, UniverseChainId.Unichain, UniverseChainId.Base],
       }),
     ).toEqual({
-      chains: [UniverseChainId.Mainnet, UniverseChainId.Unichain, UniverseChainId.Base, UniverseChainId.Sepolia],
-      gqlChains: [Chain.Ethereum, Chain.Unichain, Chain.Base, Chain.EthereumSepolia],
-      defaultChainId: UniverseChainId.Mainnet,
+      ...citreaMainnetOnly,
       isTestnetModeEnabled: false,
     })
   })

--- a/packages/uniswap/src/features/chains/utils.ts
+++ b/packages/uniswap/src/features/chains/utils.ts
@@ -192,8 +192,8 @@ export function filterChainIdsByFeatureFlag(featureFlaggedChainIds: {
   })
 }
 
-// JuiceSwap only supports Citrea chains
-export const ALWAYS_ENABLED_CHAIN_IDS = [UniverseChainId.CitreaMainnet, UniverseChainId.CitreaTestnet]
+// JuiceSwap only supports Citrea Mainnet (Citrea Testnet was sunset)
+export const ALWAYS_ENABLED_CHAIN_IDS = [UniverseChainId.CitreaMainnet]
 
 // Chains that can be switched to for ERC20 cross-chain swaps
 // These are NOT shown in the UI chain selector but CAN be switched to
@@ -231,14 +231,8 @@ export function getEnabledChains({
       return false
     }
 
-    // JuiceSwap only supports Citrea chains:
-    // - Mainnet mode: only CitreaMainnet
-    // - Testnet mode: only CitreaTestnet
-    if (isTestnetModeEnabled) {
-      return chainInfo.id === UniverseChainId.CitreaTestnet
-    } else {
-      return chainInfo.id === UniverseChainId.CitreaMainnet
-    }
+    // JuiceSwap only supports Citrea Mainnet (Citrea Testnet was sunset)
+    return chainInfo.id === UniverseChainId.CitreaMainnet
   })
 
   // Extract chain IDs and GQL chains from filtered results
@@ -257,15 +251,12 @@ export function getEnabledChains({
 
 function getDefaultChainId({
   platform: _platform,
-  isTestnetModeEnabled,
+  isTestnetModeEnabled: _isTestnetModeEnabled,
 }: {
   platform?: Platform
   isTestnetModeEnabled: boolean
 }): UniverseChainId {
-  if (isTestnetModeEnabled) {
-    return UniverseChainId.CitreaTestnet
-  }
-
+  // Citrea Testnet was sunset — JuiceSwap defaults to Citrea Mainnet.
   return UniverseChainId.CitreaMainnet
 }
 


### PR DESCRIPTION
## What

JuiceSwap now supports **Citrea Mainnet (`4114`) only**. Citrea Testnet is removed from every chain-enablement path:

- **`ALWAYS_ENABLED_CHAIN_IDS`** → Citrea Mainnet only (drives Explore, swap input/output validation, and the Citrea URL params)
- **`getEnabledChains` / `getDefaultChainId`** → always resolve to Citrea Mainnet; testnet mode no longer surfaces or defaults to Citrea Testnet
- **`useFeatureFlaggedChainIds`** → Citrea Testnet disabled for quote calculation

## Scope (deliberately minimal — per request)

The `UniverseChainId.CitreaTestnet` enum member, its chain-info, and the ~50 testnet-gated feature branches (including the whole **BApps campaign**) are **left in place as dormant / unreachable code**, and the generic Uniswap testnet-mode scaffolding is untouched. Removing the enum member would cascade into all ~50 files (the `UNIVERSE_CHAIN_INFO` map is exhaustively typed over the enum) — out of scope for this pass.

Net effect: testnet is no longer enabled, default, quotable, explorable, or URL-addressable, without a 50-file refactor.

## Tests

Refreshed the `getEnabledChains` unit tests, which were **already red on `develop`** (they asserted stock-Uniswap chains that the JuiceSwap fork had overridden). They now assert the fork's Citrea-Mainnet-only behavior. ✅

## Checks (run locally)

- `yarn web build:production` ✅ (the PR gate — 10,450 modules, exit 0)
- `getEnabledChains` jest suite ✅ (turned 4 red → green)

Shared `@juiceswapxyz/sdk-core` still defines the `CitreaTestnet` ChainId — left untouched (app-layer only).