### PR TITLE
fix(docker): return plain 404 for doubled /assets/assets/ crawler paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,13 @@ RUN printf 'server {\n\
         try_files $uri $uri/ /index.html;\n\
     }\n\
 \n\
+    # A doubled /assets/assets/ path is never produced by the app - only by a\n\
+    # recurring crawler that mis-resolves relative imports (500-line 404 bursts\n\
+    # in the error log). ^~ wins over the regex location below.\n\
+    location ^~ /assets/assets/ {\n\
+        return 404;\n\
+    }\n\
+\n\
     location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {\n\
         expires 1y;\n\
         add_header Cache-Control "public, immutable";\n\


### PR DESCRIPTION
## Why

A recurring external crawler mis-resolves the app's relative imports and requests every JS chunk under a doubled `/assets/assets/*.js` path — a path the Vite build never produces. Each visit floods the nginx error log with a deterministic burst of ~500 `open() ... failed (2: No such file or directory)` lines. Observed on the dev deployment (`jsw-dapp-40`) on 2026-07-09, 07-13 and 07-15 — identical 509-line bursts, cadence tightening from ~4 days to ~2. The prod containers see the same class from other scanners probing stale chunk names.

## What

One nginx `location` block in the Dockerfile's inline config:

```nginx
location ^~ /assets/assets/ {
    return 404;
}
```

- `return 404` short-circuits before any filesystem lookup, so these requests get their 404 **without writing an error-log line** (requests remain visible in the access log at normal level).
- `^~` is required: without it, the existing `~* \.(js|css|...)$` regex location would win for these paths and the open() attempt would still happen.
- Zero risk to real traffic — the app references all chunks absolutely under `/assets/`, and the entire observed burst history contains no legitimate hit on the doubled path.

## Validation

Rendered the `printf` output exactly as Docker executes it (line-continuations stripped) and verified the resulting `default.conf` — structurally identical to the current one plus the new block.

## Post-deploy check

After this reaches the dev image: the next crawler visit (expected within ~2 days) should produce zero nginx error-log lines for `/assets/assets/` while returning 404s in the access log.