### PR TITLE
fix(web): let stale clients self-heal after deploys instead of 404-looping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,13 @@ RUN printf 'server {\n\
         try_files $uri $uri/ /index.html;\n\
     }\n\
 \n\
+    # Hashed assets are immutable, but index.html must always revalidate:\n\
+    # without this, heuristically cached copies keep clients on a stale build\n\
+    # requesting chunk hashes that no longer exist after a deploy.\n\
+    location = /index.html {\n\
+        add_header Cache-Control "no-cache";\n\
+    }\n\
+\n\
     # A doubled /assets/assets/ path is never produced by the app - only by a\n\
     # recurring crawler that mis-resolves relative imports (500-line 404 bursts\n\
     # in the error log). ^~ wins over the regex location below.\n\

--- a/apps/web/src/utils/lazyWithRetry.ts
+++ b/apps/web/src/utils/lazyWithRetry.ts
@@ -72,7 +72,7 @@ function calculateDelay(attempt: number, options: { baseDelay: number; maxDelay:
 /**
  * Attempts to refresh the page with cooldown protection
  */
-function attemptPageRefresh(): void {
+export function attemptPageRefresh(): void {
   try {
     const lastRefresh = localStorage.getItem(REFRESH_COOLDOWN_KEY)
     const now = Date.now()

--- a/apps/web/src/utils/setupVitePreloadErrorHandler.test.ts
+++ b/apps/web/src/utils/setupVitePreloadErrorHandler.test.ts
@@ -1,0 +1,49 @@
+import { setupVitePreloadErrorHandler } from 'utils/setupVitePreloadErrorHandler'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock window.location.reload
+const mockReload = vi.fn()
+Object.defineProperty(window, 'location', {
+  value: { reload: mockReload },
+  writable: true,
+})
+
+// Mock localStorage
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+}
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+})
+
+describe('setupVitePreloadErrorHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLocalStorage.getItem.mockReturnValue(null)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('prevents the default throw and reloads the page', () => {
+    setupVitePreloadErrorHandler()
+
+    const event = new Event('vite:preloadError', { cancelable: true })
+    window.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(mockReload).toHaveBeenCalled()
+  })
+
+  it('skips the reload while the refresh cooldown is active', () => {
+    mockLocalStorage.getItem.mockReturnValue(Date.now().toString())
+
+    setupVitePreloadErrorHandler()
+    window.dispatchEvent(new Event('vite:preloadError', { cancelable: true }))
+
+    expect(mockReload).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/utils/setupVitePreloadErrorHandler.ts
+++ b/apps/web/src/utils/setupVitePreloadErrorHandler.ts
@@ -1,3 +1,5 @@
+import { attemptPageRefresh } from 'utils/lazyWithRetry'
+
 export function setupVitePreloadErrorHandler(): void {
   window.addEventListener('vite:preloadError', (event: Event) => {
     // Prevent Vite from throwing the error and crashing the app
@@ -6,6 +8,8 @@ export function setupVitePreloadErrorHandler(): void {
     // eslint-disable-next-line no-console
     console.error('Vite preload error: Dynamic import failed to load')
 
-    // TODO(INFRA-546): Add retry logic in the future if needed
+    // A missing preloaded chunk means this client runs a stale build whose
+    // hashed assets are gone; retrying can never succeed, only a reload can.
+    attemptPageRefresh()
   })
 }


### PR DESCRIPTION
## Problem

After every dapp deploy, clients still on the previous build request hashed chunks that no longer exist. Today this produced two bursts (~350 and ~215 nginx `open() ... No such file or directory` error lines within minutes, e.g. `/assets/useBooleanState-bGgpJuUC.js` requested 15+ times in 3 seconds) — same class of noise as the `/assets/assets/` crawler fix (#777).

Two gaps cause it:

1. **`index.html` is served with no `Cache-Control` header** while hashed assets get `immutable, 1y`. Without a header, browsers apply heuristic caching, so even fresh navigations can reuse a stale `index.html` for hours after a deploy — and the recovery reload in `lazyWithRetry` can land right back on the stale build.
2. **The `vite:preloadError` handler swallows the event** (`TODO(INFRA-546)`), so that failure path never recovers at all. Meanwhile a user clicking around re-triggers the 4-attempt retry cycle per interaction (the page-refresh escape hatch is cooldown-gated to once per 5 minutes), producing the sustained bursts.

## Fix

- nginx (Dockerfile): serve `index.html` with `Cache-Control: no-cache` — revalidation is a cheap 304, and every reload is guaranteed to pick up the current build.
- `setupVitePreloadErrorHandler`: reload via the existing cooldown-guarded `attemptPageRefresh()` from `lazyWithRetry` (completes INFRA-546).

A stale tab now produces one short, self-terminating burst instead of recurring storms. Deliberately **no** change to nginx error logging: a genuinely broken deploy (current build referencing a missing chunk) still shows up loud as a sustained, non-self-healing error storm.

## Testing

- New unit tests for the preload-error handler (prevents default, reloads, respects the refresh cooldown); `lazyWithRetry` suite still green (21/21).
- ESLint + Prettier clean on changed files.
- Rendered the nginx conf from the Dockerfile printf and verified structure; the new block mirrors the existing #777 block.