### PR TITLE
10444125 - fix(docker): stop logging missing static files as nginx errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,10 @@ RUN printf 'server {\n\
     location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {\n\
         expires 1y;\n\
         add_header Cache-Control "public, immutable";\n\
+        # Requests for files that do not exist are routine here (vulnerability\n\
+        # scanners probing paths, stale clients asking for old chunk hashes):\n\
+        # keep answering 404 but do not write each miss to the error log.\n\
+        log_not_found off;\n\
     }\n\
 }\n' > /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Why

Vulnerability scanners routinely probe asset paths (e.g. `/assets/<hash>.js/truffle.js`, `…?value=file:///etc/passwd`). Every request for a non-existent static file makes nginx write an error-log line (`open() ... failed (2: No such file or directory)`) — a single sweep produced >1000 such lines within one minute. That floods the error log, drowns real errors and trips log-based alerting. A missing static file is a client-side event (404), not a server error.

## What

Add `log_not_found off;` to the static-asset location block of the embedded nginx config. The 404 response and the access-log entry are unchanged; only the per-miss error-log line is dropped. Complements #777, which special-cased the doubled `/assets/assets/` crawler path.

## Verification

- Extracted the generated `default.conf` from the Dockerfile `printf` and ran `nginx -t` in `nginx:alpine`: syntax ok, test successful.
- Functional check against a container running the generated config: `GET /assets/<missing>.js` → 404 with zero `No such file` error-log lines; existing asset → 200; `/` and SPA-fallback routes → 200 (unchanged).