### PR TITLE
9cfe3211 - chore: default cross-chain swaps off, stop warming its dead backend

### DIFF
--- a/apps/web/src/constants/featureFlags.ts
+++ b/apps/web/src/constants/featureFlags.ts
@@ -15,9 +15,11 @@ export const WebFeatureFlags = {
   CEX_TRANSFER_ENABLED: process.env.REACT_APP_CEX_TRANSFER_ENABLED === 'true', // Default to false unless explicitly enabled
 
   // Enable/disable Cross-Chain Swaps (Bitcoin, Lightning, ERC20 bridges)
-  // Set REACT_APP_CROSS_CHAIN_SWAPS=false in .env to disable
-  // Or use ?cross-chain-swaps=false in URL to disable temporarily
-  CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS !== 'false', // Default to true unless explicitly disabled
+  // The swap backend and claim indexer this feature depends on have been
+  // decommissioned (see JuiceSwapxyz/api#282), so it's off until a
+  // replacement backend is wired up.
+  // Set REACT_APP_CROSS_CHAIN_SWAPS=true in .env to re-enable
+  CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true', // Default to false unless explicitly enabled
 
   // Enable/disable Juice Points program (Points UI, Leaderboard route, NFT PFP)
   // Set REACT_APP_JUICE_POINTS_PROGRAM=true in .env to enable

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -30,9 +30,10 @@ export default function App() {
   const currentPage = getCurrentPageFromLocation(pathname)
 
   useFeatureFlagUrlOverrides()
-  useCrossChainSwapsEnabled() // Handle ?cross-chain-swaps=true/false URL parameter
-  useSyncBridgeSwaps() // Sync bridge swaps with GraphQL data on app init
-  useWarmBridgePairInfo()
+  // Also handles ?cross-chain-swaps=true/false URL parameter as a side effect
+  const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
+  useSyncBridgeSwaps(crossChainSwapsEnabled) // Sync bridge swaps with GraphQL data on app init
+  useWarmBridgePairInfo(crossChainSwapsEnabled)
 
   useEffect(() => {
     initializeScrollWatcher()

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -65,10 +65,10 @@ const useSubmarineBridge = (params?: {
 }
 
 /** Prefetches Boltz/LDS pair config into the React Query cache so bridge limits resolve faster on first open. */
-export function useWarmBridgePairInfo(): void {
-  useChainBridge({ enabled: true })
-  useReverseBridge({ enabled: true })
-  useSubmarineBridge({ enabled: true })
+export function useWarmBridgePairInfo(enabled: boolean): void {
+  useChainBridge({ enabled })
+  useReverseBridge({ enabled })
+  useSubmarineBridge({ enabled })
 }
 
 const isChainBridge = ({ currencyIn, currencyOut }: BridgeLimitsQueryParams): boolean => {


### PR DESCRIPTION
EN:
The swap backend and claim indexer that Cross-Chain Swaps depends on have been decommissioned, so this flips the feature to opt-in instead of opt-out and stops two background calls that were hitting the dead backend for every visitor regardless of the flag.

DE:
Das Swap-Backend und der Claim-Indexer, von denen Cross-Chain Swaps abhängt, wurden stillgelegt, daher wird das Feature auf Opt-in statt Opt-out umgestellt und zwei Hintergrundaufrufe gestoppt, die unabhängig vom Flag für jeden Besucher gegen das tote Backend liefen.

<details>
<summary>Details</summary>

- `WebFeatureFlags.CROSS_CHAIN_SWAPS` now defaults to `false` (was `true`); set `REACT_APP_CROSS_CHAIN_SWAPS=true` to re-enable once a working backend exists. This hides the "Bridge" nav tab, its pair shortcuts, and the "View Bridge Swaps" link.
- `useWarmBridgePairInfo()` in `App.tsx` ran unconditionally on every page load for every visitor, polling the Boltz pair-config endpoints (`chain-bridge`, `reverse-bridge`, `submarine-bridge`) every 10 minutes regardless of the flag. Now gated on `useCrossChainSwapsEnabled()`.
- `useSyncBridgeSwaps()` also ran unconditionally, pushing any local pending-swap state to the backend on mount/focus/reconnect. Same gate applied - it already has an `enabled` param, just wasn't wired up.
- Backend-side companion change: JuiceSwapxyz/api#282 (disables swap creation and status syncing there).
- Not touched: the `/bridge-swaps` route itself and the `?inputCurrency=BTC&outputCurrency=cBTC`-style direct URLs still work if someone has them bookmarked/shared - this only removes discovery via navigation. Also not touched: the actual swap-execution sagas and claim/refund flow, since those need a closer look before changing their error behavior.
- Verified via `tsc --noEmit` and `eslint` on the changed files and their only caller; no pre-existing test coverage for these three files. Could not get a full `turbo typecheck` run clean in this environment, but confirmed (by stashing the diff and re-running) that the failures it hits are pre-existing and unrelated to this change.

</details>