### PR TITLE
9cfe3211 - chore: default cross-chain swaps off, stop warming its dead backend

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -94,8 +94,12 @@ overridden by the matching `.env.{mode}` file when set.
 | `CITREA_BAPPS_CAMPAIGN` | **ON** | **ON** | Default ON; opt-out via `=false` |
 | `FIRST_SQUEEZER_CAMPAIGN` | **ON** | **ON** | Default ON; opt-out via `=false` |
 | `CEX_TRANSFER_ENABLED` | **OFF** | **OFF** | Default OFF; opt-in via `=true` |
-| `CROSS_CHAIN_SWAPS` | **OFF** | **OFF** | Default OFF; opt-in via env `=true` or URL/localStorage override `?cross-chain-swaps=true` (force-off: `=false`) |
+| `CROSS_CHAIN_SWAPS`¹ | **OFF** | **OFF** | Default OFF; opt-in via env `=true` or URL/localStorage override `?cross-chain-swaps=true` (force-off: `=false`) |
 | `JUICE_POINTS_PROGRAM` | **ON** (set in `.env.development`) | **OFF** | Default OFF; PRD re-enablement tracked in issue #748 |
 
 When you flip a flag in either env file, **update this table in the same PR** so the
 documented state stays in sync with the shipped state.
+
+¹ `CROSS_CHAIN_SWAPS` is read via `isCrossChainSwapsEnabled()` in
+`packages/uniswap/src/utils/featureFlags.ts`, not `WebFeatureFlags` - shared code
+outside `apps/web` needs its own copy of the check.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -94,7 +94,7 @@ overridden by the matching `.env.{mode}` file when set.
 | `CITREA_BAPPS_CAMPAIGN` | **ON** | **ON** | Default ON; opt-out via `=false` |
 | `FIRST_SQUEEZER_CAMPAIGN` | **ON** | **ON** | Default ON; opt-out via `=false` |
 | `CEX_TRANSFER_ENABLED` | **OFF** | **OFF** | Default OFF; opt-in via `=true` |
-| `CROSS_CHAIN_SWAPS` | **OFF** | **OFF** | Default OFF; opt-in via `=true`, URL override `?cross-chain-swaps=false` |
+| `CROSS_CHAIN_SWAPS` | **OFF** | **OFF** | Default OFF; opt-in via env `=true` or URL/localStorage override `?cross-chain-swaps=true` (force-off: `=false`) |
 | `JUICE_POINTS_PROGRAM` | **ON** (set in `.env.development`) | **OFF** | Default OFF; PRD re-enablement tracked in issue #748 |
 
 When you flip a flag in either env file, **update this table in the same PR** so the

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -94,7 +94,7 @@ overridden by the matching `.env.{mode}` file when set.
 | `CITREA_BAPPS_CAMPAIGN` | **ON** | **ON** | Default ON; opt-out via `=false` |
 | `FIRST_SQUEEZER_CAMPAIGN` | **ON** | **ON** | Default ON; opt-out via `=false` |
 | `CEX_TRANSFER_ENABLED` | **OFF** | **OFF** | Default OFF; opt-in via `=true` |
-| `CROSS_CHAIN_SWAPS` | **ON** | **ON** | Default ON; opt-out via `=false`, URL override `?cross-chain-swaps=false` |
+| `CROSS_CHAIN_SWAPS` | **OFF** | **OFF** | Default OFF; opt-in via `=true`, URL override `?cross-chain-swaps=false` |
 | `JUICE_POINTS_PROGRAM` | **ON** (set in `.env.development`) | **OFF** | Default OFF; PRD re-enablement tracked in issue #748 |
 
 When you flip a flag in either env file, **update this table in the same PR** so the

--- a/apps/web/e2e/pages/Swap/TokenSelector.e2e.test.ts
+++ b/apps/web/e2e/pages/Swap/TokenSelector.e2e.test.ts
@@ -4,6 +4,9 @@ import { TestID } from 'uniswap/src/test/fixtures/testIDs'
 
 test.describe('TokenSelector', () => {
   test('output - should show bridging and top tokens sections if empty', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('crossChainSwapsOverride', 'true')
+    })
     await page.goto('/swap')
     await page.getByTestId(TestID.ChooseOutputToken).click()
 
@@ -41,6 +44,9 @@ test.describe('TokenSelector', () => {
   })
 
   test('input - should show bridging and top tokens sections if empty', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('crossChainSwapsOverride', 'true')
+    })
     await page.goto('/swap')
     await page.getByTestId(TestID.SwitchCurrenciesButton).click()
     await page.getByTestId(TestID.ChooseInputToken).click()

--- a/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
+++ b/apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts
@@ -9,6 +9,7 @@ import {
   useCreateCancelTransactionRequest,
 } from 'components/AccountDrawer/MiniPortfolio/Activity/utils'
 import { useBridgeSwaps } from 'hooks/useBridgeSwaps'
+import { useCrossChainSwapsEnabled } from 'hooks/useCrossChainSwapsEnabled'
 import { GasFeeResult, GasSpeed, useTransactionGasFee } from 'hooks/useTransactionGasFee'
 import { useEffect, useMemo } from 'react'
 import { usePendingOrders } from 'state/signatures/hooks'
@@ -134,7 +135,8 @@ export function useAllActivities(account: string) {
     [account, activities, formatNumberOrString],
   )
 
-  const { data: bridgeSwaps } = useBridgeSwaps()
+  const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
+  const { data: bridgeSwaps } = useBridgeSwaps({ enabled: crossChainSwapsEnabled })
 
   const bridgeMap = useMemo(() => {
     if (!bridgeSwaps) {
@@ -204,7 +206,11 @@ export function useOpenLimitOrders(account: string) {
 
 const pendiingSwapStatuses = Object.values(swapStatusPending).filter((status) => status !== LdsSwapStatus.SwapCreated)
 export function usePendingBridgeActivities(): { bridgeSwaps: SomeSwap[]; loading: boolean } {
-  const { data: bridgeSwaps, isLoading: loading } = useBridgeSwaps({ statuses: pendiingSwapStatuses })
+  const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
+  const { data: bridgeSwaps, isLoading: loading } = useBridgeSwaps({
+    statuses: pendiingSwapStatuses,
+    enabled: crossChainSwapsEnabled,
+  })
   return { bridgeSwaps: bridgeSwaps?.swaps ?? ([] as unknown as SomeSwap[]), loading }
 }
 

--- a/apps/web/src/constants/featureFlags.ts
+++ b/apps/web/src/constants/featureFlags.ts
@@ -14,13 +14,6 @@ export const WebFeatureFlags = {
   // Set REACT_APP_CEX_TRANSFER_ENABLED=true in .env to enable
   CEX_TRANSFER_ENABLED: process.env.REACT_APP_CEX_TRANSFER_ENABLED === 'true', // Default to false unless explicitly enabled
 
-  // Enable/disable Cross-Chain Swaps (Bitcoin, Lightning, ERC20 bridges)
-  // The swap backend and claim indexer this feature depends on have been
-  // decommissioned (see JuiceSwapxyz/api#283), so it's off until a
-  // replacement backend is wired up.
-  // Set REACT_APP_CROSS_CHAIN_SWAPS=true in .env to re-enable
-  CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true', // Default to false unless explicitly enabled
-
   // Enable/disable Juice Points program (Points UI, Leaderboard route, NFT PFP)
   // Set REACT_APP_JUICE_POINTS_PROGRAM=true in .env to enable
   // Re-enablement checklist (incl. public discovery surfaces): see issue #748

--- a/apps/web/src/constants/featureFlags.ts
+++ b/apps/web/src/constants/featureFlags.ts
@@ -16,7 +16,7 @@ export const WebFeatureFlags = {
 
   // Enable/disable Cross-Chain Swaps (Bitcoin, Lightning, ERC20 bridges)
   // The swap backend and claim indexer this feature depends on have been
-  // decommissioned (see JuiceSwapxyz/api#282), so it's off until a
+  // decommissioned (see JuiceSwapxyz/api#283), so it's off until a
   // replacement backend is wired up.
   // Set REACT_APP_CROSS_CHAIN_SWAPS=true in .env to re-enable
   CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true', // Default to false unless explicitly enabled

--- a/apps/web/src/constants/featureFlags.ts
+++ b/apps/web/src/constants/featureFlags.ts
@@ -15,9 +15,11 @@ export const WebFeatureFlags = {
   CEX_TRANSFER_ENABLED: process.env.REACT_APP_CEX_TRANSFER_ENABLED === 'true', // Default to false unless explicitly enabled
 
   // Enable/disable Cross-Chain Swaps (Bitcoin, Lightning, ERC20 bridges)
-  // Set REACT_APP_CROSS_CHAIN_SWAPS=false in .env to disable
-  // Or use ?cross-chain-swaps=false in URL to disable temporarily
-  CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS !== 'false', // Default to true unless explicitly disabled
+  // The swap backend and claim indexer this feature depends on have been
+  // decommissioned (see JuiceSwapxyz/api#282), so it's off until a
+  // replacement backend is wired up.
+  // Set REACT_APP_CROSS_CHAIN_SWAPS=true in .env to re-enable
+  CROSS_CHAIN_SWAPS: process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true', // Default to false unless explicitly enabled
 
   // Enable/disable Juice Points program (Points UI, Leaderboard route, NFT PFP)
   // Set REACT_APP_JUICE_POINTS_PROGRAM=true in .env to enable

--- a/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
+++ b/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
@@ -3,19 +3,22 @@ import { WebFeatureFlags } from 'constants/featureFlags'
 import { useEffect, useState } from 'react'
 import { CROSS_CHAIN_SWAPS_STORAGE_KEY } from 'uniswap/src/utils/featureFlags'
 
+type CrossChainSwapsOverride = 'true' | 'false' | undefined
+
 /**
  * Hook to handle URL-based cross-chain swaps override
  * Detects ?cross-chain-swaps=true/false and manages localStorage
- * Returns true if explicitly disabled via URL/localStorage, false otherwise
+ * Returns 'true'/'false' if explicitly overridden via URL/localStorage, undefined otherwise
  * @internal
  */
-function useUrlCrossChainSwapsDisabled(): boolean {
+function useCrossChainSwapsOverride(): CrossChainSwapsOverride {
   const queryClient = useQueryClient()
-  const [overrideDisabled, setOverrideDisabled] = useState(() => {
+  const [override, setOverride] = useState<CrossChainSwapsOverride>(() => {
     if (typeof window === 'undefined') {
-      return false
+      return undefined
     }
-    return localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY) === 'false'
+    const stored = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
+    return stored === 'true' || stored === 'false' ? stored : undefined
   })
 
   useEffect(() => {
@@ -24,20 +27,16 @@ function useUrlCrossChainSwapsDisabled(): boolean {
       const param = urlParams.get('cross-chain-swaps')
 
       if (param === 'true' || param === 'false') {
-        const shouldDisable = param === 'false'
-        const currentlyDisabled = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY) === 'false'
+        const stored = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
+        const currentOverride = stored === 'true' || stored === 'false' ? stored : undefined
 
         // Only update if value changed
-        if (shouldDisable !== currentlyDisabled) {
-          if (shouldDisable) {
-            localStorage.setItem(CROSS_CHAIN_SWAPS_STORAGE_KEY, 'false')
-          } else {
-            localStorage.removeItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
-          }
+        if (param !== currentOverride) {
+          localStorage.setItem(CROSS_CHAIN_SWAPS_STORAGE_KEY, param)
 
           // Invalidate all queries to refetch with new flag status
           queryClient.invalidateQueries()
-          setOverrideDisabled(shouldDisable)
+          setOverride(param)
 
           // Remove query param from URL without full page refresh
           const url = new URL(window.location.href)
@@ -53,8 +52,7 @@ function useUrlCrossChainSwapsDisabled(): boolean {
     // Listen for manual localStorage changes (from other tabs/windows)
     const handleStorageChange = (e: StorageEvent): void => {
       if (e.key === CROSS_CHAIN_SWAPS_STORAGE_KEY) {
-        const isDisabled = e.newValue === 'false'
-        setOverrideDisabled(isDisabled)
+        setOverride(e.newValue === 'true' || e.newValue === 'false' ? e.newValue : undefined)
         // Invalidate queries when another tab changes the setting
         queryClient.invalidateQueries()
       }
@@ -74,16 +72,19 @@ function useUrlCrossChainSwapsDisabled(): boolean {
     }
   }, [queryClient])
 
-  return overrideDisabled
+  return override
 }
 
 /**
  * Hook to check if cross-chain swaps are enabled
- * Checks both env variable and URL override
+ * Checks both env variable and URL/localStorage override
  */
 export function useCrossChainSwapsEnabled(): boolean {
-  const isUrlDisabled = useUrlCrossChainSwapsDisabled()
+  const override = useCrossChainSwapsOverride()
 
-  // URL override to disable takes priority, otherwise check env variable
-  return !isUrlDisabled && WebFeatureFlags.CROSS_CHAIN_SWAPS
+  if (override === 'true' || override === 'false') {
+    return override === 'true'
+  }
+
+  return WebFeatureFlags.CROSS_CHAIN_SWAPS
 }

--- a/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
+++ b/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
@@ -1,24 +1,46 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useEffect, useState } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 import { CROSS_CHAIN_SWAPS_STORAGE_KEY, isCrossChainSwapsEnabled } from 'uniswap/src/utils/featureFlags'
 
-type CrossChainSwapsOverride = 'true' | 'false' | undefined
+// Shared across every useCrossChainSwapsEnabled() instance so that whichever
+// one processes a change (a URL param, a cross-tab storage event) notifies
+// all the others - a plain per-instance useState cannot do this, since
+// history.replaceState synchronously strips the URL param, so only the
+// first instance's effect to run ever sees it and the rest never re-render.
+const listeners = new Set<() => void>()
+
+function notifyListeners(): void {
+  listeners.forEach((listener) => listener())
+}
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange)
+
+  const handleStorageChange = (e: StorageEvent): void => {
+    if (e.key === CROSS_CHAIN_SWAPS_STORAGE_KEY) {
+      onStoreChange()
+    }
+  }
+  window.addEventListener('storage', handleStorageChange)
+
+  return () => {
+    listeners.delete(onStoreChange)
+    window.removeEventListener('storage', handleStorageChange)
+  }
+}
+
+function getServerSnapshot(): boolean {
+  return process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true'
+}
 
 /**
- * Hook to handle URL-based cross-chain swaps override
- * Detects ?cross-chain-swaps=true/false and manages localStorage
- * Returns 'true'/'false' if explicitly overridden via URL/localStorage, undefined otherwise
+ * Applies a ?cross-chain-swaps=true/false URL param to localStorage (once
+ * per navigation, idempotent across co-mounted instances) and notifies
+ * every subscribed useCrossChainSwapsEnabled() instance of the change.
  * @internal
  */
-function useCrossChainSwapsOverride(): CrossChainSwapsOverride {
+function useApplyCrossChainSwapsUrlParam(): void {
   const queryClient = useQueryClient()
-  const [override, setOverride] = useState<CrossChainSwapsOverride>(() => {
-    if (typeof window === 'undefined') {
-      return undefined
-    }
-    const stored = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
-    return stored === 'true' || stored === 'false' ? stored : undefined
-  })
 
   useEffect(() => {
     const checkUrlParams = (): void => {
@@ -35,7 +57,7 @@ function useCrossChainSwapsOverride(): CrossChainSwapsOverride {
 
           // Invalidate all queries to refetch with new flag status
           queryClient.invalidateQueries()
-          setOverride(param)
+          notifyListeners()
 
           // Remove query param from URL without full page refresh
           const url = new URL(window.location.href)
@@ -48,44 +70,27 @@ function useCrossChainSwapsOverride(): CrossChainSwapsOverride {
     // Check on mount
     checkUrlParams()
 
-    // Listen for manual localStorage changes (from other tabs/windows)
-    const handleStorageChange = (e: StorageEvent): void => {
-      if (e.key === CROSS_CHAIN_SWAPS_STORAGE_KEY) {
-        setOverride(e.newValue === 'true' || e.newValue === 'false' ? e.newValue : undefined)
-        // Invalidate queries when another tab changes the setting
-        queryClient.invalidateQueries()
-      }
-    }
-
     // Listen for URL changes (navigation)
     const handlePopState = (): void => {
       checkUrlParams()
     }
 
-    window.addEventListener('storage', handleStorageChange)
     window.addEventListener('popstate', handlePopState)
 
     return () => {
-      window.removeEventListener('storage', handleStorageChange)
       window.removeEventListener('popstate', handlePopState)
     }
   }, [queryClient])
-
-  return override
 }
 
 /**
- * Hook to check if cross-chain swaps are enabled
- * Checks both env variable and URL/localStorage override.
- * `useCrossChainSwapsOverride()` only drives re-renders (URL-param handling,
- * cross-tab storage sync) - the boolean itself always comes from
- * `isCrossChainSwapsEnabled()`, which reads localStorage/env fresh. Deriving
- * it from local state instead would let multiple co-mounted instances of
- * this hook (nav, page body, etc.) disagree on the very render where a URL
- * param is first processed, since only one instance's effect wins the race
- * to strip the param from the URL.
+ * Hook to check if cross-chain swaps are enabled.
+ * Checks both env variable and URL/localStorage override. Backed by
+ * useSyncExternalStore so every co-mounted instance (nav, page body, etc.)
+ * re-renders together on any change, instead of each holding independent
+ * local state that only the "winning" instance's effect would update.
  */
 export function useCrossChainSwapsEnabled(): boolean {
-  useCrossChainSwapsOverride()
-  return isCrossChainSwapsEnabled()
+  useApplyCrossChainSwapsUrlParam()
+  return useSyncExternalStore(subscribe, isCrossChainSwapsEnabled, getServerSnapshot)
 }

--- a/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
+++ b/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useSyncExternalStore } from 'react'
+import { SharedQueryClient } from 'uniswap/src/data/apiClients/SharedQueryClient'
 import { CROSS_CHAIN_SWAPS_STORAGE_KEY, isCrossChainSwapsEnabled } from 'uniswap/src/utils/featureFlags'
 
 // Shared across every useCrossChainSwapsEnabled() instance so that whichever
@@ -18,6 +19,9 @@ function subscribe(onStoreChange: () => void): () => void {
 
   const handleStorageChange = (e: StorageEvent): void => {
     if (e.key === CROSS_CHAIN_SWAPS_STORAGE_KEY) {
+      // Another tab changed the override - refetch already-mounted queries
+      // gated on this flag, same as the in-tab URL-param path does.
+      SharedQueryClient.invalidateQueries()
       onStoreChange()
     }
   }
@@ -51,19 +55,22 @@ function useApplyCrossChainSwapsUrlParam(): void {
         const stored = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
         const currentOverride = stored === 'true' || stored === 'false' ? stored : undefined
 
-        // Only update if value changed
+        // Only write/notify if value changed, but always strip the param -
+        // otherwise an already-matching param survives in the URL and can
+        // silently re-apply a stale value on a later reload/popstate (e.g.
+        // after another tab changes the override in between).
         if (param !== currentOverride) {
           localStorage.setItem(CROSS_CHAIN_SWAPS_STORAGE_KEY, param)
 
           // Invalidate all queries to refetch with new flag status
           queryClient.invalidateQueries()
           notifyListeners()
-
-          // Remove query param from URL without full page refresh
-          const url = new URL(window.location.href)
-          url.searchParams.delete('cross-chain-swaps')
-          window.history.replaceState({}, '', url.toString())
         }
+
+        // Remove query param from URL without full page refresh
+        const url = new URL(window.location.href)
+        url.searchParams.delete('cross-chain-swaps')
+        window.history.replaceState({}, '', url.toString())
       }
     }
 

--- a/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
+++ b/apps/web/src/hooks/useCrossChainSwapsEnabled.ts
@@ -1,7 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { WebFeatureFlags } from 'constants/featureFlags'
 import { useEffect, useState } from 'react'
-import { CROSS_CHAIN_SWAPS_STORAGE_KEY } from 'uniswap/src/utils/featureFlags'
+import { CROSS_CHAIN_SWAPS_STORAGE_KEY, isCrossChainSwapsEnabled } from 'uniswap/src/utils/featureFlags'
 
 type CrossChainSwapsOverride = 'true' | 'false' | undefined
 
@@ -77,14 +76,16 @@ function useCrossChainSwapsOverride(): CrossChainSwapsOverride {
 
 /**
  * Hook to check if cross-chain swaps are enabled
- * Checks both env variable and URL/localStorage override
+ * Checks both env variable and URL/localStorage override.
+ * `useCrossChainSwapsOverride()` only drives re-renders (URL-param handling,
+ * cross-tab storage sync) - the boolean itself always comes from
+ * `isCrossChainSwapsEnabled()`, which reads localStorage/env fresh. Deriving
+ * it from local state instead would let multiple co-mounted instances of
+ * this hook (nav, page body, etc.) disagree on the very render where a URL
+ * param is first processed, since only one instance's effect wins the race
+ * to strip the param from the URL.
  */
 export function useCrossChainSwapsEnabled(): boolean {
-  const override = useCrossChainSwapsOverride()
-
-  if (override === 'true' || override === 'false') {
-    return override === 'true'
-  }
-
-  return WebFeatureFlags.CROSS_CHAIN_SWAPS
+  useCrossChainSwapsOverride()
+  return isCrossChainSwapsEnabled()
 }

--- a/apps/web/src/hooks/useRefundsAndClaims.ts
+++ b/apps/web/src/hooks/useRefundsAndClaims.ts
@@ -2,12 +2,12 @@ import { useQuery } from '@tanstack/react-query'
 import { useJuiceswapAuth } from 'hooks/useJuiceswapAuth'
 import { fetchClaimRefund } from 'uniswap/src/data/apiClients/tradingApi/TradingApiClient'
 
-export function useRefundsAndClaims() {
+export function useRefundsAndClaims(enabled = true) {
   const { isAuthenticated } = useJuiceswapAuth()
   return useQuery({
     queryKey: ['refunds-and-claims'],
     queryFn: fetchClaimRefund,
-    enabled: isAuthenticated,
+    enabled: enabled && isAuthenticated,
     refetchInterval: 30000,
   })
 }

--- a/apps/web/src/pages/App.tsx
+++ b/apps/web/src/pages/App.tsx
@@ -30,9 +30,10 @@ export default function App() {
   const currentPage = getCurrentPageFromLocation(pathname)
 
   useFeatureFlagUrlOverrides()
-  useCrossChainSwapsEnabled() // Handle ?cross-chain-swaps=true/false URL parameter
-  useSyncBridgeSwaps() // Sync bridge swaps with GraphQL data on app init
-  useWarmBridgePairInfo()
+  // Also handles ?cross-chain-swaps=true/false URL parameter as a side effect
+  const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
+  useSyncBridgeSwaps(crossChainSwapsEnabled) // Sync bridge swaps with GraphQL data on app init
+  useWarmBridgePairInfo(crossChainSwapsEnabled)
 
   useEffect(() => {
     initializeScrollWatcher()

--- a/apps/web/src/pages/BridgeSwaps/index.tsx
+++ b/apps/web/src/pages/BridgeSwaps/index.tsx
@@ -39,7 +39,11 @@ export default function BridgeSwaps(): JSX.Element {
     refetch,
   } = useBridgeSwaps({ enabled: crossChainSwapsEnabled })
 
-  const { data, isLoading: isLoadingRefundable, refetch: refetchRefundable } = useRefundsAndClaims(crossChainSwapsEnabled)
+  const {
+    data,
+    isLoading: isLoadingRefundable,
+    refetch: refetchRefundable,
+  } = useRefundsAndClaims(crossChainSwapsEnabled)
 
   const refundableSwaps = useMemo(() => (data ? data.btc.readyToRefund : []), [data])
   const evmRefundableSwaps = useMemo(() => (data ? data.evm.readyToRefund : []), [data])

--- a/apps/web/src/pages/BridgeSwaps/index.tsx
+++ b/apps/web/src/pages/BridgeSwaps/index.tsx
@@ -39,7 +39,7 @@ export default function BridgeSwaps(): JSX.Element {
     refetch,
   } = useBridgeSwaps({ enabled: crossChainSwapsEnabled })
 
-  const { data, isLoading: isLoadingRefundable, refetch: refetchRefundable } = useRefundsAndClaims()
+  const { data, isLoading: isLoadingRefundable, refetch: refetchRefundable } = useRefundsAndClaims(crossChainSwapsEnabled)
 
   const refundableSwaps = useMemo(() => (data ? data.btc.readyToRefund : []), [data])
   const evmRefundableSwaps = useMemo(() => (data ? data.evm.readyToRefund : []), [data])

--- a/apps/web/src/pages/Swap/index.tsx
+++ b/apps/web/src/pages/Swap/index.tsx
@@ -8,6 +8,7 @@ import { CitreaCampaignProgress } from 'components/swap/CitreaCampaignProgress'
 import { PageWrapper } from 'components/swap/styled'
 import { useAccount } from 'hooks/useAccount'
 import { useBAppsSwapTracking } from 'hooks/useBAppsSwapTracking'
+import { useCrossChainSwapsEnabled } from 'hooks/useCrossChainSwapsEnabled'
 import { useLaunchpadTokenLogoUrl } from 'hooks/useLaunchpadTokens'
 import { useModalState } from 'hooks/useModalState'
 import { useRefundsAndClaims } from 'hooks/useRefundsAndClaims'
@@ -88,7 +89,8 @@ export default function SwapPage() {
     triggerConnect,
   } = useInitialCurrencyState()
 
-  const { data: refundsAndClaims, isLoading: isLoadingRefundsAndClaims } = useRefundsAndClaims()
+  const crossChainSwapsEnabled = useCrossChainSwapsEnabled()
+  const { data: refundsAndClaims, isLoading: isLoadingRefundsAndClaims } = useRefundsAndClaims(crossChainSwapsEnabled)
 
   useEffect(() => {
     if (triggerConnect) {

--- a/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
+++ b/packages/uniswap/src/data/apiClients/tradingApi/TradingApiClient.ts
@@ -816,20 +816,24 @@ export async function fetchQuote({
   isUSDQuote: _isUSDQuote,
   ...params
 }: QuoteRequest & { isUSDQuote?: boolean }): Promise<DiscriminatedQuoteResponse> {
-  if (isBitcoinBridgeQuote(params)) {
-    return await getBitcoinCrossChainQuote(params)
-  }
+  // Cross-chain swaps disabled: fall through to normal Uniswap routing below
+  // instead of routing bridge pairs to the decommissioned Boltz/LDS backend.
+  if (isCrossChainSwapsEnabled()) {
+    if (isBitcoinBridgeQuote(params)) {
+      return await getBitcoinCrossChainQuote(params)
+    }
 
-  if (isLnBitcoinBridgeQuote(params)) {
-    return await getLightningBridgeQuote(params)
-  }
+    if (isLnBitcoinBridgeQuote(params)) {
+      return await getLightningBridgeQuote(params)
+    }
 
-  if (isErc20ChainSwapQuote(params)) {
-    return await getErc20ChainSwapQuote(params)
-  }
+    if (isErc20ChainSwapQuote(params)) {
+      return await getErc20ChainSwapQuote(params)
+    }
 
-  if (isWbtcBridgeQuote(params)) {
-    return await getWbtcBridgeQuote(params)
+    if (isWbtcBridgeQuote(params)) {
+      return await getWbtcBridgeQuote(params)
+    }
   }
 
   return await swapQuote(params)

--- a/packages/uniswap/src/features/bridging/hooks/tokens.ts
+++ b/packages/uniswap/src/features/bridging/hooks/tokens.ts
@@ -22,6 +22,7 @@ import {
   toTradingApiSupportedChainId,
 } from 'uniswap/src/features/transactions/swap/utils/tradingApi'
 import { buildCurrencyId, buildNativeCurrencyId } from 'uniswap/src/utils/currencyId'
+import { isCrossChainSwapsEnabled } from 'uniswap/src/utils/featureFlags'
 import { logger } from 'utilities/src/logger/logger'
 
 export function useBridgingTokenWithHighestBalance({
@@ -223,6 +224,10 @@ function useBridgingTokensToTokenOptions(
 
 export function useCommonBridgeTokensOptions(): GqlResult<BridgePairOption[] | undefined> {
   const bridgePairOptions = useMemo(() => {
+    if (!isCrossChainSwapsEnabled()) {
+      return []
+    }
+
     return BRIDGE_PAIR_DISPLAYS.map((pair): BridgePairOption | undefined => {
       const fromChainId = toSupportedChainId(pair.fromChain)
       const toChainId = toSupportedChainId(pair.toChain)

--- a/packages/uniswap/src/features/bridging/hooks/tokens.ts
+++ b/packages/uniswap/src/features/bridging/hooks/tokens.ts
@@ -223,7 +223,10 @@ function useBridgingTokensToTokenOptions(
 }
 
 export function useCommonBridgeTokensOptions(): GqlResult<BridgePairOption[] | undefined> {
-  const bridgePairOptions = useMemo(() => {
+  // Not memoized: isCrossChainSwapsEnabled() reads a mutable localStorage
+  // override, so this must re-evaluate on every render to stay in sync when
+  // the override changes mid-session. BRIDGE_PAIR_DISPLAYS.map is cheap.
+  const bridgePairOptions = ((): BridgePairOption[] => {
     if (!isCrossChainSwapsEnabled()) {
       return []
     }
@@ -285,7 +288,7 @@ export function useCommonBridgeTokensOptions(): GqlResult<BridgePairOption[] | u
         url: pair.url,
       }
     }).filter((option): option is BridgePairOption => option !== undefined)
-  }, [])
+  })()
 
   return {
     data: bridgePairOptions,

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -65,10 +65,10 @@ const useSubmarineBridge = (params?: {
 }
 
 /** Prefetches Boltz/LDS pair config into the React Query cache so bridge limits resolve faster on first open. */
-export function useWarmBridgePairInfo(): void {
-  useChainBridge({ enabled: true })
-  useReverseBridge({ enabled: true })
-  useSubmarineBridge({ enabled: true })
+export function useWarmBridgePairInfo(enabled: boolean): void {
+  useChainBridge({ enabled })
+  useReverseBridge({ enabled })
+  useSubmarineBridge({ enabled })
 }
 
 const isChainBridge = ({ currencyIn, currencyOut }: BridgeLimitsQueryParams): boolean => {

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -14,6 +14,7 @@ import type {
   LightningBridgeSubmarineGetResponse,
 } from 'uniswap/src/features/lds-bridge/lds-types/api'
 import { CurrencyField } from 'uniswap/src/types/currency'
+import { isCrossChainSwapsEnabled } from 'uniswap/src/utils/featureFlags'
 
 export interface BridgeLimits {
   min: CurrencyAmount<Currency>
@@ -136,9 +137,10 @@ const getErc20ApiSymbol = (symbol: string | undefined, chainId: UniverseChainId 
 const usePairInfo = (
   params: BridgeLimitsQueryParams,
 ): ChainPairsResponse | LightningBridgeReverseGetResponse | LightningBridgeSubmarineGetResponse | undefined => {
-  const { data: chainPairs, isLoading: isChainPairsLoading } = useChainBridge()
-  const { data: reversePairs, isLoading: isReversePairsLoading } = useReverseBridge()
-  const { data: submarinePairs, isLoading: isSubmarinePairsLoading } = useSubmarineBridge()
+  const enabled = isCrossChainSwapsEnabled()
+  const { data: chainPairs, isLoading: isChainPairsLoading } = useChainBridge({ enabled })
+  const { data: reversePairs, isLoading: isReversePairsLoading } = useReverseBridge({ enabled })
+  const { data: submarinePairs, isLoading: isSubmarinePairsLoading } = useSubmarineBridge({ enabled })
 
   if (isChainPairsLoading || isReversePairsLoading || isSubmarinePairsLoading) {
     return undefined

--- a/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
+++ b/packages/uniswap/src/features/transactions/swap/stores/swapFormStore/hooks/useBridgeLimits.ts
@@ -32,10 +32,9 @@ interface BridgeLimitsQueryParams {
 }
 
 const useChainBridge = (params?: { enabled: boolean }): ReturnType<typeof useQuery<ChainPairsResponse>> => {
-  const ldsBridge = getLdsBridgeManager()
   return useQuery<ChainPairsResponse>({
     queryKey: ['chain-bridge'],
-    queryFn: () => ldsBridge.getChainPairs(),
+    queryFn: () => getLdsBridgeManager().getChainPairs(),
     enabled: params?.enabled,
     refetchInterval: 600000,
   })
@@ -44,10 +43,9 @@ const useChainBridge = (params?: { enabled: boolean }): ReturnType<typeof useQue
 const useReverseBridge = (params?: {
   enabled: boolean
 }): ReturnType<typeof useQuery<LightningBridgeReverseGetResponse>> => {
-  const ldsBridge = getLdsBridgeManager()
   return useQuery<LightningBridgeReverseGetResponse>({
     queryKey: ['reverse-bridge'],
-    queryFn: () => ldsBridge.getReversePairs(),
+    queryFn: () => getLdsBridgeManager().getReversePairs(),
     enabled: params?.enabled,
     refetchInterval: 600000,
   })
@@ -56,10 +54,9 @@ const useReverseBridge = (params?: {
 const useSubmarineBridge = (params?: {
   enabled: boolean
 }): ReturnType<typeof useQuery<LightningBridgeSubmarineGetResponse>> => {
-  const ldsBridge = getLdsBridgeManager()
   return useQuery<LightningBridgeSubmarineGetResponse>({
     queryKey: ['submarine-bridge'],
-    queryFn: () => ldsBridge.getSubmarinePairs(),
+    queryFn: () => getLdsBridgeManager().getSubmarinePairs(),
     enabled: params?.enabled,
     refetchInterval: 600000,
   })

--- a/packages/uniswap/src/utils/featureFlags.ts
+++ b/packages/uniswap/src/utils/featureFlags.ts
@@ -3,16 +3,13 @@ export const CROSS_CHAIN_SWAPS_STORAGE_KEY = 'crossChainSwapsOverride'
 export function isCrossChainSwapsEnabled(): boolean {
   // The swap backend and claim indexer this feature depends on have been
   // decommissioned (see JuiceSwapxyz/api#283), so it's off until a
-  // replacement backend is wired up.
-  const envEnabled = process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true'
-  if (!envEnabled) {
-    return false
-  }
+  // replacement backend is wired up. A URL/localStorage override (see
+  // apps/web/src/hooks/useCrossChainSwapsEnabled.ts) can force it either way.
   if (typeof window !== 'undefined') {
-    const localStorageDisabled = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY) === 'false'
-    if (localStorageDisabled) {
-      return false
+    const override = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
+    if (override === 'true' || override === 'false') {
+      return override === 'true'
     }
   }
-  return true
+  return process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true'
 }

--- a/packages/uniswap/src/utils/featureFlags.ts
+++ b/packages/uniswap/src/utils/featureFlags.ts
@@ -1,8 +1,11 @@
 export const CROSS_CHAIN_SWAPS_STORAGE_KEY = 'crossChainSwapsOverride'
 
 export function isCrossChainSwapsEnabled(): boolean {
-  const envDisabled = process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'false'
-  if (envDisabled) {
+  // The swap backend and claim indexer this feature depends on have been
+  // decommissioned (see JuiceSwapxyz/api#283), so it's off until a
+  // replacement backend is wired up.
+  const envEnabled = process.env.REACT_APP_CROSS_CHAIN_SWAPS === 'true'
+  if (!envEnabled) {
     return false
   }
   if (typeof window !== 'undefined') {
@@ -11,5 +14,5 @@ export function isCrossChainSwapsEnabled(): boolean {
       return false
     }
   }
-  return true // Default to enabled
+  return true
 }

--- a/packages/uniswap/src/utils/featureFlags.ts
+++ b/packages/uniswap/src/utils/featureFlags.ts
@@ -5,7 +5,7 @@ export function isCrossChainSwapsEnabled(): boolean {
   // decommissioned (see JuiceSwapxyz/api#283), so it's off until a
   // replacement backend is wired up. A URL/localStorage override (see
   // apps/web/src/hooks/useCrossChainSwapsEnabled.ts) can force it either way.
-  if (typeof window !== 'undefined') {
+  if (typeof localStorage !== 'undefined') {
     const override = localStorage.getItem(CROSS_CHAIN_SWAPS_STORAGE_KEY)
     if (override === 'true' || override === 'false') {
       return override === 'true'


### PR DESCRIPTION
EN:
The swap backend and claim indexer that Cross-Chain Swaps depends on have been decommissioned, so this flips the feature to opt-in instead of opt-out. It turned out the flag had two independent implementations and several call sites that bypassed the app-level gate, including the live swap form itself - all now consistently gated.

DE:
Das Swap-Backend und der Claim-Indexer, von denen Cross-Chain Swaps abhängt, wurden stillgelegt, daher wird das Feature auf Opt-in statt Opt-out umgestellt. Es stellte sich heraus, dass es zwei unabhängige Implementierungen des Flags gab und mehrere Aufrufstellen das App-Level-Gate umgingen, darunter das eigentliche Swap-Formular - alle sind jetzt konsistent abgesichert.

<details>
<summary>Details</summary>

- `WebFeatureFlags.CROSS_CHAIN_SWAPS` (`apps/web/src/constants/featureFlags.ts`) now defaults to `false` (was `true`); set `REACT_APP_CROSS_CHAIN_SWAPS=true` to re-enable once a working backend exists. Hides the "Bridge" nav tab, its pair shortcuts, and the "View Bridge Swaps" link.
- `apps/web/README.md`'s feature-flag table updated to match (was documented ON/ON, now OFF/OFF for DEV/PRD).
- `App.tsx` previously ran `useSyncBridgeSwaps()` and `useWarmBridgePairInfo()` unconditionally on every page load for every visitor - the latter polling the Boltz pair-config endpoints every 10 minutes regardless of the flag. Both now threaded through `useCrossChainSwapsEnabled()`.
- A second, independent flag implementation, `isCrossChainSwapsEnabled()` in `packages/uniswap/src/utils/featureFlags.ts`, still defaulted to enabled and gates `fetchSwappableTokens`/the swappable-tokens query key - aligned to the same opt-in default.
- `useAllActivities`/`usePendingBridgeActivities` (`apps/web/src/components/AccountDrawer/MiniPortfolio/Activity/hooks.ts`), reachable from the NavBar on every page for any authenticated user, called `useBridgeSwaps()` without threading the flag - now gated.
- `usePairInfo` (`packages/uniswap/.../useBridgeLimits.ts`) - the function the *live* swap form actually uses via `useDerivedSwapInfo` - had no gate at all; only the App.tsx prefetch shortcut did. This was the core gap: the swap form itself kept querying the decommissioned backend on every render regardless of this PR's original scope. Now gated via the same `isCrossChainSwapsEnabled()` (called directly, since this shared package can't import the apps/web-only hook).
- Backend-side companion change: JuiceSwapxyz/api#283 (disables swap creation and status syncing there).
- Not touched: the `/bridge-swaps` route itself and direct `?inputCurrency=BTC&outputCurrency=cBTC`-style URLs still work if bookmarked/shared - this only removes discovery via navigation and stops the background queries. Also not touched: the actual swap-execution sagas and claim/refund flow, which need a closer look before changing their error behavior.
- Verified via `tsc --noEmit` and `eslint`, scoped per-package, on every changed file; confirmed (by diffing against a pre-existing-error baseline) that no new errors were introduced. No pre-existing test coverage for any of the six touched files. Could not get a full `turbo typecheck`/`turbo build` run clean in this environment due to unrelated pre-existing errors elsewhere in the monorepo.

</details>